### PR TITLE
Get jenkins artifact

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,14 @@
 node('kafka-to-nexus') {
+    stage("Get artifacts") {
+        step([
+            $class: 'CopyArtifact',
+            filter: 'graylog-logger.tar.gz',
+            fingerprintArtifacts: true,
+            projectName: 'ess-dmsc/graylog-logger/master',
+            target: 'artifacts'
+        ])
+    }
+
     dir("code") {
         stage("Checkout") {
             checkout scm

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,6 +38,8 @@ node('kafka-to-nexus') {
         stage("Archive") {
             sh "rm -rf file-writer; mkdir file-writer"
             sh "cp kafka-to-nexus send-command file-writer/"
+            sh "rm -rf file-writer/libs; mkdir file-writer/libs"
+            sh "cp ../artifacts/graylog-logger/usr/local/lib/libgraylog_logger.so file-writer/libs/"
             sh "tar czf file-writer.tar.gz file-writer"
             archiveArtifacts 'file-writer.tar.gz'
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,9 @@ node('kafka-to-nexus') {
             projectName: 'ess-dmsc/graylog-logger/master',
             target: 'artifacts'
         ])
+        dir("artifacts") {
+            sh "tar xzf graylog-logger.tar.gz"
+        }
     }
 
     dir("code") {

--- a/build-script/invoke-cmake-from-jenkinsfile.sh
+++ b/build-script/invoke-cmake-from-jenkinsfile.sh
@@ -1,6 +1,7 @@
 # Factored out from Jenkinsfile because of escape issues
 
 cmake ../code \
+-DCMAKE_PREFIX_PATH=../artifacts/graylog-logger/usr/local \
 -DCMAKE_INCLUDE_PATH=../googletest\;../streaming-data-types\;$DM_ROOT/usr/include\;$DM_ROOT/usr/lib \
 -DCMAKE_LIBRARY_PATH=$DM_ROOT/usr/lib \
 -Dflatc=$DM_ROOT/usr/bin/flatc \


### PR DESCRIPTION
Changes to Jenkins setup to compile against a local copy of graylog-logger, which is then included in the generated job artefact.