### PR TITLE
Fix FindFmt

### DIFF
--- a/cmake/FindFmt.cmake
+++ b/cmake/FindFmt.cmake
@@ -1,7 +1,7 @@
-# fmt not in the EPEL pinned by the dev-env crew.
+# fmt is not in the EPEL pinned by the dev-env crew.
 # So use the source version:
-find_path(FMT_INCLUDE_DIR NAMES fmt/format.cc)
-find_file(FMT_SRC /fmt/format.cc)
+find_path(FMT_INCLUDE_DIR NAMES fmt/format.h)
+find_file(FMT_SRC fmt/format.cc)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(FMT DEFAULT_MSG


### PR DESCRIPTION
It should be enough to pass the path to fmt in CMAKE_INCLUDE_DIR, if not,
please create a issue.

Thanks @matthew-d-jones for reporting.