### PR TITLE
Use hash map for the set of Source instances

### DIFF
--- a/src/CommandHandler.cxx
+++ b/src/CommandHandler.cxx
@@ -79,7 +79,7 @@ void CommandHandler::handle_new(rapidjson::Document &d) {
   }
   for (auto &d : fwt->demuxers()) {
     for (auto &s : d.sources()) {
-      s.teamid = teamid;
+      s.second.teamid = teamid;
     }
   }
 

--- a/src/DemuxTopic.h
+++ b/src/DemuxTopic.h
@@ -5,6 +5,7 @@
 #include "json.h"
 #include <functional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace BrightnESS {
@@ -30,10 +31,12 @@ public:
   ProcessMessageResult process_message(char *msg_data, int msg_size);
   /// Implements TimeDifferenceFromMessage.
   DT time_difference_from_message(char *msg_data, int msg_size);
-  std::vector<Source> &sources();
-  template <typename... Args> Source &add_source(Args &&... args) {
-    _sources.emplace_back(std::forward<Args>(args)...);
-    return _sources.back();
+  std::unordered_map<std::string, Source> &sources();
+  Source &add_source(Source &&source) {
+    using std::move;
+    auto k = source.source();
+    std::pair<std::string, Source> v{k, move(source)};
+    return _sources_map.insert(move(v)).first->second;
   }
   std::string to_str() const;
   rapidjson::Document
@@ -42,7 +45,7 @@ public:
 
 private:
   std::string _topic;
-  std::vector<Source> _sources;
+  std::unordered_map<std::string, Source> _sources_map;
   uint64_t _stop_time;
 };
 

--- a/src/FileWriterTask.cxx
+++ b/src/FileWriterTask.cxx
@@ -61,7 +61,7 @@ int FileWriterTask::hdf_init(rapidjson::Value const &nexus_structure) {
   }
   for (auto &d : demuxers()) {
     for (auto &s : d.sources()) {
-      s.hdf_init(impl->hdf_file);
+      s.second.hdf_init(impl->hdf_file);
     }
   }
   return 0;

--- a/src/helper.h
+++ b/src/helper.h
@@ -1,9 +1,9 @@
 #pragma once
 #include <memory>
+#include <rapidjson/document.h>
 #include <string>
 #include <utility>
 #include <vector>
-#include <rapidjson/document.h>
 
 // note: this implementation does not disable this overload for array types
 template <typename T, typename... TX>


### PR DESCRIPTION
Valgrind/Callgrind showed hot spot if number of streamed sources gets large.
Using a hash map scales better.