### PR TITLE
Parse commands given in configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ For example:
 
 ### Send command to kafka-to-nexus
 
-Commands are JSON messages.
-
-Send commands to the broker/topic given by `--broker-command`
+Commands in the form of JSON messages are used to start and stop file writing.
+Commands can be send through Kafka via the broker/topic specified by the
+`--broker-command` option.  Commands can also be given in the configuration
+file specified by `--config-file <file.json>` (see a bit later in this
+section).
 
 In the "streams" section of the command:
 - `topic`: Kafka topic from which the data comes.
@@ -38,6 +40,7 @@ In the "streams" section of the command:
 - `nexus_path`: Location of the written data within the HDF tree.
 
 Command to start writing a file:
+
 ```json
 {
 	"cmd": "FileWriter_new",
@@ -80,8 +83,19 @@ Command to start writing a file:
 ```
 
 Command to exit the file writer:
+
 ```json
 {"cmd": "FileWriter_exit"}
+```
+
+Commands can be given in the configuration file as well:
+
+```json
+{
+  "commands": [
+    { <some command as discussed above> }
+  ]
+}
 ```
 
 

--- a/src/CommandHandler.cxx
+++ b/src/CommandHandler.cxx
@@ -23,7 +23,7 @@ CommandHandler::CommandHandler(Master *master,
   }
 }
 
-void CommandHandler::handle_new(rapidjson::Document &d) {
+void CommandHandler::handle_new(rapidjson::Document const &d) {
   // if (g_N_HANDLED > 0) return;
   using namespace rapidjson;
   using std::move;
@@ -83,7 +83,7 @@ void CommandHandler::handle_new(rapidjson::Document &d) {
   }
 
   {
-    Value &nexus_structure = d.FindMember("nexus_structure")->value;
+    Value const & nexus_structure = d.FindMember("nexus_structure")->value;
     auto x = fwt->hdf_init(nexus_structure);
     if (x) {
       LOG(7, "ERROR hdf init failed, cancel this write command");
@@ -138,12 +138,12 @@ void CommandHandler::handle_new(rapidjson::Document &d) {
   g_N_HANDLED += 1;
 }
 
-void CommandHandler::handle_exit(rapidjson::Document &d) {
+void CommandHandler::handle_exit(rapidjson::Document const &d) {
   if (master)
     master->stop();
 }
 
-void CommandHandler::handle(rapidjson::Document &d) {
+void CommandHandler::handle(rapidjson::Document const &d) {
   using std::string;
   using namespace rapidjson;
   uint64_t teamid = 0;

--- a/src/CommandHandler.h
+++ b/src/CommandHandler.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <rapidjson/document.h>
 #include <rapidjson/error/en.h>
+#include <rapidjson/prettywriter.h>
 #include <rapidjson/schema.h>
 #include <rapidjson/stringbuffer.h>
 
@@ -18,6 +19,7 @@ public:
   void handle_new(rapidjson::Document &d);
   void handle_exit(rapidjson::Document &d);
   void handle(Msg const &msg);
+  void handle(rapidjson::Document &cmd);
 
 private:
   std::unique_ptr<rapidjson::SchemaDocument> schema_command;

--- a/src/CommandHandler.h
+++ b/src/CommandHandler.h
@@ -16,10 +16,10 @@ namespace FileWriter {
 class CommandHandler : public FileWriterCommandHandler {
 public:
   CommandHandler(Master *master, rapidjson::Value const *config_file);
-  void handle_new(rapidjson::Document &d);
-  void handle_exit(rapidjson::Document &d);
+  void handle_new(rapidjson::Document const &d);
+  void handle_exit(rapidjson::Document const &d);
   void handle(Msg const &msg);
-  void handle(rapidjson::Document &cmd);
+  void handle(rapidjson::Document const &cmd);
 
 private:
   std::unique_ptr<rapidjson::SchemaDocument> schema_command;

--- a/src/MainOpt.cxx
+++ b/src/MainOpt.cxx
@@ -11,6 +11,7 @@ using uri::URI;
 
 int MainOpt::parse_config_file(std::string fname) {
   using namespace rapidjson;
+  using std::move;
   if (fname == "") {
     LOG(3, "given config filename is empty");
     return -1;
@@ -42,6 +43,13 @@ int MainOpt::parse_config_file(std::string fname) {
         master_config.kafka.emplace_back(m.name.GetString(),
                                          fmt::format("{}", m.value.GetInt()));
       }
+    }
+  }
+  if (auto a = get_array(d, "commands")) {
+    for (auto &e : a.v->GetArray()) {
+      Document js_command;
+      js_command.CopyFrom(e, js_command.GetAllocator());
+      master_config.commands_from_config_file.push_back(move(js_command));
     }
   }
   return 0;

--- a/src/MainOpt.cxx
+++ b/src/MainOpt.cxx
@@ -12,7 +12,7 @@ using uri::URI;
 int MainOpt::parse_config_file(std::string fname) {
   using namespace rapidjson;
   using std::move;
-  if (fname == "") {
+  if (fname.empty()) {
     LOG(3, "given config filename is empty");
     return -1;
   }

--- a/src/MainOpt.cxx
+++ b/src/MainOpt.cxx
@@ -11,7 +11,6 @@ using uri::URI;
 
 int MainOpt::parse_config_file(std::string fname) {
   using namespace rapidjson;
-  using std::move;
   if (fname.empty()) {
     LOG(3, "given config filename is empty");
     return -1;
@@ -49,7 +48,7 @@ int MainOpt::parse_config_file(std::string fname) {
     for (auto &e : a.v->GetArray()) {
       Document js_command;
       js_command.CopyFrom(e, js_command.GetAllocator());
-      master_config.commands_from_config_file.push_back(move(js_command));
+      master_config.commands_from_config_file.push_back(std::move(js_command));
     }
   }
   return 0;

--- a/src/Master.cxx
+++ b/src/Master.cxx
@@ -33,8 +33,6 @@ void Master::run() {
     this->handle_command(cmd);
   }
   command_listener.start();
-  if (_cb_on_connected)
-    (*_cb_on_connected)();
   while (do_run) {
     LOG(7, "Master poll");
     auto p = command_listener.poll();
@@ -51,9 +49,5 @@ void Master::run() {
 }
 
 void Master::stop() { do_run = false; }
-
-void Master::on_consumer_connected(std::function<void(void)> *cb_on_connected) {
-  _cb_on_connected = cb_on_connected;
-}
 
 } // namespace FileWriter

--- a/src/Master.cxx
+++ b/src/Master.cxx
@@ -23,7 +23,15 @@ void Master::handle_command_message(std::unique_ptr<KafkaW::Msg> &&msg) {
   command_handler.handle({(char *)msg->data(), (int32_t)msg->size()});
 }
 
+void Master::handle_command(rapidjson::Document &cmd) {
+  CommandHandler command_handler(this, config.config_file);
+  command_handler.handle(cmd);
+}
+
 void Master::run() {
+  for (auto &cmd : config.commands_from_config_file) {
+    this->handle_command(cmd);
+  }
   command_listener.start();
   if (_cb_on_connected)
     (*_cb_on_connected)();

--- a/src/Master.cxx
+++ b/src/Master.cxx
@@ -23,13 +23,13 @@ void Master::handle_command_message(std::unique_ptr<KafkaW::Msg> &&msg) {
   command_handler.handle({(char *)msg->data(), (int32_t)msg->size()});
 }
 
-void Master::handle_command(rapidjson::Document &cmd) {
+void Master::handle_command(rapidjson::Document const &cmd) {
   CommandHandler command_handler(this, config.config_file);
   command_handler.handle(cmd);
 }
 
 void Master::run() {
-  for (auto &cmd : config.commands_from_config_file) {
+  for (auto const &cmd : config.commands_from_config_file) {
     this->handle_command(cmd);
   }
   command_listener.start();

--- a/src/Master.h
+++ b/src/Master.h
@@ -31,7 +31,6 @@ public:
   void stop();
   void handle_command_message(std::unique_ptr<KafkaW::Msg> &&msg);
   void handle_command(rapidjson::Document const &cmd);
-  void on_consumer_connected(std::function<void(void)> *cb_on_connected);
   std::function<void(void)> cb_on_filewriter_new;
 
   MasterConfig &config;
@@ -39,7 +38,6 @@ public:
 private:
   CommandListener command_listener;
   std::atomic<bool> do_run{true};
-  std::function<void(void)> *_cb_on_connected = nullptr;
   std::vector<std::unique_ptr<StreamMaster<Streamer, DemuxTopic>>>
       stream_masters;
   friend class CommandHandler;

--- a/src/Master.h
+++ b/src/Master.h
@@ -30,6 +30,7 @@ public:
   void run();
   void stop();
   void handle_command_message(std::unique_ptr<KafkaW::Msg> &&msg);
+  void handle_command(rapidjson::Document &cmd);
   void on_consumer_connected(std::function<void(void)> *cb_on_connected);
   std::function<void(void)> cb_on_filewriter_new;
 

--- a/src/Master.h
+++ b/src/Master.h
@@ -18,6 +18,7 @@ struct MasterConfig {
   std::string dir_assets = ".";
   rapidjson::Value const *config_file = nullptr;
   std::vector<std::pair<std::string, std::string>> kafka;
+  std::vector<rapidjson::Document> commands_from_config_file;
 };
 
 /// Listens to the Kafka configuration topic.

--- a/src/Master.h
+++ b/src/Master.h
@@ -30,7 +30,7 @@ public:
   void run();
   void stop();
   void handle_command_message(std::unique_ptr<KafkaW::Msg> &&msg);
-  void handle_command(rapidjson::Document &cmd);
+  void handle_command(rapidjson::Document const &cmd);
   void on_consumer_connected(std::function<void(void)> *cb_on_connected);
   std::function<void(void)> cb_on_filewriter_new;
 

--- a/src/helper.cxx
+++ b/src/helper.cxx
@@ -74,6 +74,7 @@ get_json_ret_int::operator bool() const { return err == 0; }
 
 get_json_ret_int::operator int() const { return v; }
 
+get_json_ret_array::operator bool() const { return err == 0; }
 get_json_ret_object::operator bool() const { return err == 0; }
 
 get_json_ret_string get_string(rapidjson::Value const *v, std::string path) {
@@ -145,6 +146,34 @@ get_json_ret_int get_int(rapidjson::Value const *v, std::string path) {
     ++i1;
   }
   return {1, 0};
+}
+
+get_json_ret_array get_array(rapidjson::Value const &v_, std::string path) {
+  auto v = &v_;
+  get_json_ret_array ret;
+  ret.err = 1;
+  auto a = split(path, ".");
+  uint32_t i1 = 0;
+  for (auto &x : a) {
+    if (!v->IsObject()) {
+      return ret;
+    }
+    auto it = v->FindMember(x.c_str());
+    if (it == v->MemberEnd()) {
+      return ret;
+    }
+    if (i1 == a.size() - 1) {
+      if (it->value.IsArray()) {
+        ret.err = 0;
+        ret.v = &it->value;
+        return ret;
+      }
+    } else {
+      v = &it->value;
+    }
+    ++i1;
+  }
+  return ret;
 }
 
 get_json_ret_object get_object(rapidjson::Value const &v_, std::string path) {

--- a/src/helper.cxx
+++ b/src/helper.cxx
@@ -20,7 +20,7 @@ std::vector<char> gulp(std::string fname) {
   return ret;
 }
 
-std::vector<char> binary_to_hex(char const *data, int len) {
+std::vector<char> binary_to_hex(char const *data, uint32_t len) {
   std::vector<char> ret;
   ret.reserve(len * (64 + 5) / 32 + 32);
   for (uint32_t i1 = 0; i1 < len; ++i1) {

--- a/src/helper.cxx
+++ b/src/helper.cxx
@@ -204,6 +204,8 @@ get_json_ret_object get_object(rapidjson::Value const &v_, std::string path) {
   return ret;
 }
 
+/// During development, I find it sometimes useful to be able to quickly pretty
+/// print some json object.
 std::string pretty_print(rapidjson::Document const *v) {
   rapidjson::StringBuffer buf1;
   rapidjson::PrettyWriter<rapidjson::StringBuffer> wr(buf1);

--- a/src/helper.h
+++ b/src/helper.h
@@ -18,27 +18,27 @@ std::vector<char> binary_to_hex(char const *data, int len);
 std::vector<std::string> split(std::string const &input, std::string token);
 
 struct get_json_ret_string {
-  operator bool() const;
-  operator std::string() const;
+  explicit operator bool() const;
+  explicit operator std::string() const;
   int err;
   std::string v;
 };
 
 struct get_json_ret_int {
-  operator bool() const;
-  operator int() const;
+  explicit operator bool() const;
+  explicit operator int() const;
   int err;
   int v;
 };
 
 struct get_json_ret_array {
-  operator bool() const;
+  explicit operator bool() const;
   int err = 1;
   rapidjson::Value const *v = nullptr;
 };
 
 struct get_json_ret_object {
-  operator bool() const;
+  explicit operator bool() const;
   int err = 1;
   rapidjson::Value const *v = nullptr;
 };

--- a/src/helper.h
+++ b/src/helper.h
@@ -31,6 +31,12 @@ struct get_json_ret_int {
   int v;
 };
 
+struct get_json_ret_array {
+  operator bool() const;
+  int err = 1;
+  rapidjson::Value const *v = nullptr;
+};
+
 struct get_json_ret_object {
   operator bool() const;
   int err = 1;
@@ -39,6 +45,7 @@ struct get_json_ret_object {
 
 get_json_ret_string get_string(rapidjson::Value const *v, std::string path);
 get_json_ret_int get_int(rapidjson::Value const *v, std::string path);
+get_json_ret_array get_array(rapidjson::Value const &v, std::string path);
 get_json_ret_object get_object(rapidjson::Value const &v, std::string path);
 std::string pretty_print(rapidjson::Document const *v);
 

--- a/src/helper.h
+++ b/src/helper.h
@@ -13,7 +13,7 @@ std::unique_ptr<T> make_unique(TX &&... tx) {
 
 std::vector<char> gulp(std::string fname);
 
-std::vector<char> binary_to_hex(char const *data, int len);
+std::vector<char> binary_to_hex(char const *data, uint32_t len);
 
 std::vector<std::string> split(std::string const &input, std::string token);
 

--- a/src/helper.h
+++ b/src/helper.h
@@ -47,6 +47,7 @@ get_json_ret_string get_string(rapidjson::Value const *v, std::string path);
 get_json_ret_int get_int(rapidjson::Value const *v, std::string path);
 get_json_ret_array get_array(rapidjson::Value const &v, std::string path);
 get_json_ret_object get_object(rapidjson::Value const &v, std::string path);
+
 std::string pretty_print(rapidjson::Document const *v);
 
 template <typename T>

--- a/src/tests/HDFFile.cxx
+++ b/src/tests/HDFFile.cxx
@@ -248,7 +248,7 @@ public:
       ASSERT_EQ(err, 0);
       H5Dclose(ds_cue_index);
 
-      ASSERT_GT(cue_timestamp_zero.size(), 10);
+      ASSERT_GT(cue_timestamp_zero.size(), 10u);
       ASSERT_EQ(cue_timestamp_zero.size(), cue_index.size());
 
       auto ds_event_time_zero =
@@ -272,10 +272,10 @@ public:
       ASSERT_EQ(err, 0);
       H5Dclose(ds_event_index);
 
-      ASSERT_GT(event_time_zero.size(), 0);
+      ASSERT_GT(event_time_zero.size(), 0u);
       ASSERT_EQ(event_time_zero.size(), event_index.size());
 
-      for (int i1 = 0; i1 < cue_timestamp_zero.size(); ++i1) {
+      for (hsize_t i1 = 0; i1 < cue_timestamp_zero.size(); ++i1) {
         auto ok = check_cue(event_time_zero, event_index,
                             cue_timestamp_zero[i1], cue_index[i1]);
         ASSERT_TRUE(ok);

--- a/src/tests/HDFFile.cxx
+++ b/src/tests/HDFFile.cxx
@@ -151,7 +151,7 @@ public:
     auto &reg = FileWriter::Schemas::SchemaRegistry::items();
     std::array<char, 4> fbid{{'e', 'v', '4', '2'}};
     auto writer = reg.at(fbid)->create_reader()->create_writer();
-    FlatBufs::ev42::synth synth(source_name, seed);
+    FlatBufs::ev42::synth synth(string(source_name), seed);
     LOG(7, "generating...");
     for (int i1 = 0; i1 < SP; ++i1) {
       fbs.push_back(synth.next(rnd_nn() >> 24));
@@ -213,7 +213,7 @@ public:
     {
       rnd_nn.seed(0);
       size_t n1 = 0;
-      FlatBufs::ev42::synth synth(source_name, seed);
+      FlatBufs::ev42::synth synth(string(source_name), seed);
       for (int i1 = 0; i1 < SP; ++i1) {
         auto fb_ = synth.next(rnd_nn() >> 24);
         auto fb = fb_.root();

--- a/src/tests/helper.cxx
+++ b/src/tests/helper.cxx
@@ -62,7 +62,7 @@ static Document make_test_doc() {
 }
 
 TEST(helper, make_test_doc) {
-  ASSERT_EQ(false, make_test_doc().HasParseError());
+  ASSERT_FALSE(make_test_doc().HasParseError());
 }
 
 TEST(helper, get_string_01) {


### PR DESCRIPTION
Add the possibility to issue file writer commands from the configuration file. Those commands are processed before any command is taken from the Kafka command topic.