### PR TITLE
Publish basic status of file writer `Master`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,24 @@ For example:
 ./kafka-to-nexus --command-uri //kafka-host/filewriter-commands
 ```
 
+
+### Configuration File
+
+The file writer can be configured via `--config-file <json>`
+
+Available options include:
+
+```
+{
+  "command-uri": "//broker[:port]/command-topic",
+  "status-uri": "//broker[:port]/status-topic",
+  "commands": [
+    "a list of commands as discussed below."
+  ]
+}
+```
+
+
 ### Send command to kafka-to-nexus
 
 Commands in the form of JSON messages are used to start and stop file writing.
@@ -94,7 +112,7 @@ Commands can be given in the configuration file as well:
 ```json
 {
   "commands": [
-    { <some command as discussed above> }
+    { "some command": "as discussed above" }
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -16,20 +16,21 @@
 ## Usage
 
 ### Running kafka-to-nexus
+
 ```
 ./kafka-to-nexus -h
 ```
 
 For example:
 ```
-./kafka-to-nexus --broker-command //kafka-host/filewriter-commands
+./kafka-to-nexus --command-uri //kafka-host/filewriter-commands
 ```
 
 ### Send command to kafka-to-nexus
 
 Commands in the form of JSON messages are used to start and stop file writing.
 Commands can be send through Kafka via the broker/topic specified by the
-`--broker-command` option.  Commands can also be given in the configuration
+`--command-uri` option.  Commands can also be given in the configuration
 file specified by `--config-file <file.json>` (see a bit later in this
 section).
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,16 @@ Available options include:
 {
   "command-uri": "//broker[:port]/command-topic",
   "status-uri": "//broker[:port]/status-topic",
+  "status-master-interval": 2000,
   "commands": [
     "a list of commands as discussed below."
   ]
 }
 ```
+
+- `command-uri` Kafka URI where the file writer listens for commands
+- `status-uri` Kafka URI where to publish status updates
+- `status-master-interval` Interval in milliseconds for status updates
 
 
 ### Send command to kafka-to-nexus

--- a/src/CommandHandler.cxx
+++ b/src/CommandHandler.cxx
@@ -127,6 +127,9 @@ void CommandHandler::handle_new(rapidjson::Document const &d) {
       config_kafka_vec.emplace_back(x.first, x.second);
     }
 
+    // TODO
+    // Actually pass master->status_producer to StreamMaster here
+
     auto s = std::unique_ptr<StreamMaster<Streamer, DemuxTopic>>(
         new StreamMaster<Streamer, DemuxTopic>(br, std::move(fwt),
                                                config_kafka_vec));

--- a/src/FileWriterTask.cxx
+++ b/src/FileWriterTask.cxx
@@ -77,11 +77,6 @@ int FileWriterTask::hdf_init(rapidjson::Value const &nexus_structure) {
   return 0;
 }
 
-void FileWriterTask::file_flush() {
-  if (impl)
-    impl->hdf_file.flush();
-}
-
 uint64_t FileWriterTask::id() const { return _id; }
 
 std::string const &FileWriterTask::hdf_filename() const {

--- a/src/FileWriterTask.cxx
+++ b/src/FileWriterTask.cxx
@@ -83,4 +83,19 @@ void FileWriterTask::file_flush() {
 
 uint64_t FileWriterTask::id() const { return _id; }
 
+rapidjson::Value FileWriterTask::stats(
+    rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> &a) {
+  using namespace rapidjson;
+  Value js_topics;
+  js_topics.SetObject();
+  for (auto &d : _demuxers) {
+    js_topics.AddMember(Value(d.topic().c_str(), a), Value(0), a);
+  }
+  Value js_fwt;
+  js_fwt.SetObject();
+  js_fwt.AddMember("filename", Value(impl->hdf_filename.c_str(), a), a);
+  js_fwt.AddMember("topics", js_topics, a);
+  return js_fwt;
+}
+
 } // namespace FileWriter

--- a/src/FileWriterTask.cxx
+++ b/src/FileWriterTask.cxx
@@ -84,7 +84,7 @@ void FileWriterTask::file_flush() {
 uint64_t FileWriterTask::id() const { return _id; }
 
 rapidjson::Value FileWriterTask::stats(
-    rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> &a) {
+    rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> &a) const {
   using namespace rapidjson;
   Value js_topics;
   js_topics.SetObject();

--- a/src/FileWriterTask.cxx
+++ b/src/FileWriterTask.cxx
@@ -79,10 +79,6 @@ int FileWriterTask::hdf_init(rapidjson::Value const &nexus_structure) {
 
 uint64_t FileWriterTask::id() const { return _id; }
 
-std::string const &FileWriterTask::hdf_filename() const {
-  return impl->hdf_filename;
-}
-
 rapidjson::Value FileWriterTask::stats(
     rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> &a) const {
   using namespace rapidjson;

--- a/src/FileWriterTask.cxx
+++ b/src/FileWriterTask.cxx
@@ -34,8 +34,9 @@ std::vector<DemuxTopic> &FileWriterTask::demuxers() { return _demuxers; }
 
 FileWriterTask::FileWriterTask() {
   using namespace std::chrono;
-  _id = duration_cast<nanoseconds>(system_clock::now().time_since_epoch())
-            .count();
+  _id = static_cast<uint64_t>(
+      duration_cast<nanoseconds>(system_clock::now().time_since_epoch())
+          .count());
   _id = (_id & uint64_t(-1) << 16) | (n_FileWriterTask_created & 0xffff);
   ++n_FileWriterTask_created;
   impl.reset(new FileWriterTask_impl);

--- a/src/FileWriterTask.cxx
+++ b/src/FileWriterTask.cxx
@@ -83,6 +83,10 @@ void FileWriterTask::file_flush() {
 
 uint64_t FileWriterTask::id() const { return _id; }
 
+std::string const &FileWriterTask::hdf_filename() const {
+  return impl->hdf_filename;
+}
+
 rapidjson::Value FileWriterTask::stats(
     rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> &a) const {
   using namespace rapidjson;

--- a/src/FileWriterTask.cxx
+++ b/src/FileWriterTask.cxx
@@ -9,7 +9,6 @@ using std::string;
 using std::vector;
 
 class FileWriterTask_impl {
-  std::vector<Source> _sources;
   friend class FileWriterTask;
   friend class ::Test___FileWriterTask___Create01;
   std::string hdf_filename;

--- a/src/FileWriterTask.h
+++ b/src/FileWriterTask.h
@@ -31,6 +31,8 @@ public:
   void file_flush();
   void file_close();
   uint64_t id() const;
+  rapidjson::Value
+  stats(rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> &a);
 
 private:
   std::vector<DemuxTopic> _demuxers;

--- a/src/FileWriterTask.h
+++ b/src/FileWriterTask.h
@@ -29,7 +29,6 @@ public:
   /// Used by Streamer to get the list of demuxers
   std::vector<DemuxTopic> &demuxers();
   uint64_t id() const;
-  std::string const &hdf_filename() const;
   rapidjson::Value
   stats(rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> &a) const;
 

--- a/src/FileWriterTask.h
+++ b/src/FileWriterTask.h
@@ -31,6 +31,7 @@ public:
   void file_flush();
   void file_close();
   uint64_t id() const;
+  std::string const &hdf_filename() const;
   rapidjson::Value
   stats(rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> &a) const;
 

--- a/src/FileWriterTask.h
+++ b/src/FileWriterTask.h
@@ -30,6 +30,7 @@ public:
   std::vector<DemuxTopic> &demuxers();
   void file_flush();
   void file_close();
+  uint64_t id() const;
 
 private:
   std::vector<DemuxTopic> _demuxers;
@@ -37,6 +38,7 @@ private:
   void add_source(Source &&source);
   /// Called by CommandHandler on setup.
   int hdf_init(rapidjson::Value const &nexus_structure);
+  uint64_t _id;
 };
 
 } // namespace FileWriter

--- a/src/FileWriterTask.h
+++ b/src/FileWriterTask.h
@@ -32,7 +32,7 @@ public:
   void file_close();
   uint64_t id() const;
   rapidjson::Value
-  stats(rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> &a);
+  stats(rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> &a) const;
 
 private:
   std::vector<DemuxTopic> _demuxers;

--- a/src/FileWriterTask.h
+++ b/src/FileWriterTask.h
@@ -28,8 +28,6 @@ public:
   FileWriterTask &set_hdf_filename(std::string hdf_filename);
   /// Used by Streamer to get the list of demuxers
   std::vector<DemuxTopic> &demuxers();
-  void file_flush();
-  void file_close();
   uint64_t id() const;
   std::string const &hdf_filename() const;
   rapidjson::Value

--- a/src/KafkaW.cxx
+++ b/src/KafkaW.cxx
@@ -621,7 +621,7 @@ struct Msg_ : public Producer::Msg {
   }
 };
 
-int ProducerTopic::produce(uchar *msg_data, int msg_size, bool print_err) {
+int ProducerTopic::produce(uchar *msg_data, size_t msg_size, bool print_err) {
   auto p = new Msg_;
   std::copy(msg_data, msg_data + msg_size, std::back_inserter(p->v));
   p->finalize();

--- a/src/KafkaW.h
+++ b/src/KafkaW.h
@@ -178,7 +178,7 @@ public:
   ProducerTopic(ProducerTopic &&);
   ProducerTopic(std::shared_ptr<Producer> producer, std::string name);
   ~ProducerTopic();
-  int produce(uchar *msg_data, int msg_size, bool print_err = false);
+  int produce(uchar *msg_data, size_t msg_size, bool print_err = false);
   int produce(std::unique_ptr<Producer::Msg> &msg);
   // Currently it's nice to have access to these for statistics:
   std::shared_ptr<Producer> producer;

--- a/src/MainOpt.cxx
+++ b/src/MainOpt.cxx
@@ -75,7 +75,10 @@ std::pair<int, std::unique_ptr<MainOpt>> parse_opt(int argc, char **argv) {
   static struct option long_options[] = {
       {"help", no_argument, 0, 'h'},
       {"config-file", required_argument, 0, 0},
+      {"command-uri", required_argument, 0, 0},
+      // Legacy alias for 'command-uri'
       {"broker-command", required_argument, 0, 0},
+      {"status-uri", required_argument, 0, 0},
       {"kafka-gelf", required_argument, 0, 0},
       {"graylog-logger-address", required_argument, 0, 0},
       {"use-signal-handler", required_argument, 0, 0},
@@ -112,8 +115,14 @@ std::pair<int, std::unique_ptr<MainOpt>> parse_opt(int argc, char **argv) {
           ret.first = 1;
         }
       }
-      if (std::string("broker-command") == lname) {
+      if (std::string("command-uri") == lname ||
+          std::string("broker-command") == lname) {
         URI uri("//localhost:9092/kafka-to-nexus.command");
+        uri.parse(optarg);
+        opt->command_broker_uri = uri;
+      }
+      if (std::string("status-uri") == lname) {
+        URI uri("//localhost:9092/kafka-to-nexus.status");
         uri.parse(optarg);
         opt->command_broker_uri = uri;
       }

--- a/src/MainOpt.cxx
+++ b/src/MainOpt.cxx
@@ -42,6 +42,9 @@ int MainOpt::parse_config_file(std::string fname) {
     kafka_status_uri = uri;
     do_kafka_status = true;
   }
+  if (auto o = get_int(&d, "status-master-interval")) {
+    status_master_interval = o.v;
+  }
   if (auto o = get_object(d, "kafka")) {
     for (auto &m : o.v->GetObject()) {
       if (m.value.IsString()) {

--- a/src/MainOpt.cxx
+++ b/src/MainOpt.cxx
@@ -26,9 +26,9 @@ int MainOpt::parse_config_file(std::string fname) {
     return -5;
   }
   {
-    auto o = get_string(&d, "broker-command");
+    auto o = get_string(&d, "command-uri");
     if (!o.found()) {
-      o = get_string(&d, "command-uri");
+      o = get_string(&d, "broker-command");
     }
     if (o.found()) {
       URI uri("//localhost:9092/kafka-to-nexus.command");

--- a/src/MainOpt.cxx
+++ b/src/MainOpt.cxx
@@ -76,17 +76,17 @@ std::pair<int, std::unique_ptr<MainOpt>> parse_opt(int argc, char **argv) {
   // For the signal handler
   g_main_opt.store(opt.get());
   static struct option long_options[] = {
-      {"help", no_argument, 0, 'h'},
-      {"config-file", required_argument, 0, 0},
-      {"command-uri", required_argument, 0, 0},
+      {"help", no_argument, nullptr, 'h'},
+      {"config-file", required_argument, nullptr, 0},
+      {"command-uri", required_argument, nullptr, 0},
       // Legacy alias for 'command-uri'
-      {"broker-command", required_argument, 0, 0},
-      {"status-uri", required_argument, 0, 0},
-      {"kafka-gelf", required_argument, 0, 0},
-      {"graylog-logger-address", required_argument, 0, 0},
-      {"use-signal-handler", required_argument, 0, 0},
-      {"teamid", required_argument, 0, 0},
-      {0, 0, 0, 0},
+      {"broker-command", required_argument, nullptr, 0},
+      {"status-uri", required_argument, nullptr, 0},
+      {"kafka-gelf", required_argument, nullptr, 0},
+      {"graylog-logger-address", required_argument, nullptr, 0},
+      {"use-signal-handler", required_argument, nullptr, 0},
+      {"teamid", required_argument, nullptr, 0},
+      {nullptr, 0, nullptr, 0},
   };
   std::string cmd;
   int option_index = 0;

--- a/src/MainOpt.cxx
+++ b/src/MainOpt.cxx
@@ -25,10 +25,22 @@ int MainOpt::parse_config_file(std::string fname) {
     LOG(3, "configuration is not well formed");
     return -5;
   }
-  if (auto o = get_string(&d, "broker-command")) {
-    URI uri("//localhost:9092/kafka-to-nexus.command");
+  {
+    auto o = get_string(&d, "broker-command");
+    if (!o.found()) {
+      o = get_string(&d, "command-uri");
+    }
+    if (o.found()) {
+      URI uri("//localhost:9092/kafka-to-nexus.command");
+      uri.parse(o.v);
+      command_broker_uri = uri;
+    }
+  }
+  if (auto o = get_string(&d, "status-update-uri")) {
+    URI uri("//localhost:9092/kafka-to-nexus.status");
     uri.parse(o.v);
-    command_broker_uri = uri;
+    kafka_status_uri = uri;
+    do_kafka_status = true;
   }
   if (auto o = get_object(d, "kafka")) {
     for (auto &m : o.v->GetObject()) {

--- a/src/MainOpt.cxx
+++ b/src/MainOpt.cxx
@@ -36,7 +36,7 @@ int MainOpt::parse_config_file(std::string fname) {
       command_broker_uri = uri;
     }
   }
-  if (auto o = get_string(&d, "status-update-uri")) {
+  if (auto o = get_string(&d, "status-uri")) {
     URI uri("//localhost:9092/kafka-to-nexus.status");
     uri.parse(o.v);
     kafka_status_uri = uri;

--- a/src/MainOpt.cxx
+++ b/src/MainOpt.cxx
@@ -27,9 +27,6 @@ int MainOpt::parse_config_file(std::string fname) {
   }
   {
     auto o = get_string(&d, "command-uri");
-    if (!o.found()) {
-      o = get_string(&d, "broker-command");
-    }
     if (o.found()) {
       URI uri("//localhost:9092/kafka-to-nexus.command");
       uri.parse(o.v);
@@ -79,8 +76,6 @@ std::pair<int, std::unique_ptr<MainOpt>> parse_opt(int argc, char **argv) {
       {"help", no_argument, nullptr, 'h'},
       {"config-file", required_argument, nullptr, 0},
       {"command-uri", required_argument, nullptr, 0},
-      // Legacy alias for 'command-uri'
-      {"broker-command", required_argument, nullptr, 0},
       {"status-uri", required_argument, nullptr, 0},
       {"kafka-gelf", required_argument, nullptr, 0},
       {"graylog-logger-address", required_argument, nullptr, 0},
@@ -118,8 +113,7 @@ std::pair<int, std::unique_ptr<MainOpt>> parse_opt(int argc, char **argv) {
           ret.first = 1;
         }
       }
-      if (std::string("command-uri") == lname ||
-          std::string("broker-command") == lname) {
+      if (std::string("command-uri") == lname) {
         URI uri("//localhost:9092/kafka-to-nexus.command");
         uri.parse(optarg);
         opt->command_broker_uri = uri;

--- a/src/MainOpt.h
+++ b/src/MainOpt.h
@@ -47,6 +47,9 @@ struct MainOpt {
   bool do_kafka_status = false;
   /// Kafka topic where status updates are to be published
   uri::URI kafka_status_uri{"kafka://localhost:9092/kafka-to-nexus.status"};
+  /// Milliseconds interval to publish status of `Master` (e.g. list of current
+  /// file writings)
+  uint32_t status_master_interval = 2000;
 
   // For testing.
   std::function<void(rd_kafka_topic_partition_list_s *)> on_rebalance_assign;

--- a/src/MainOpt.h
+++ b/src/MainOpt.h
@@ -43,6 +43,11 @@ struct MainOpt {
   /// Kafka broker and topic where file writer commands are published.
   uri::URI command_broker_uri{"kafka://localhost:9092/kafka-to-nexus.command"};
 
+  /// Whether we want to publish status to Kafka
+  bool do_kafka_status = false;
+  /// Kafka topic where status updates are to be published
+  uri::URI kafka_status_uri{"kafka://localhost:9092/kafka-to-nexus.status"};
+
   // For testing.
   std::function<void(rd_kafka_topic_partition_list_s *)> on_rebalance_assign;
   // For testing.

--- a/src/Master.cxx
+++ b/src/Master.cxx
@@ -100,7 +100,10 @@ void Master::statistics() {
   rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(buffer);
   writer.SetIndent(' ', 2);
   js_status.Accept(writer);
-  LOG(3, "status is: {}", buffer.GetString());
+  if (status_producer) {
+    status_producer->produce((KafkaW::uchar *)buffer.GetString(),
+                             buffer.GetSize());
+  }
 }
 
 void Master::stop() { do_run = false; }

--- a/src/Master.cxx
+++ b/src/Master.cxx
@@ -64,7 +64,8 @@ void Master::run() {
       LOG(7, "Handle a command");
       this->handle_command_message(std::move(msg));
     }
-    if (Clock::now() - t_last_statistics > std::chrono::milliseconds(2000)) {
+    if (Clock::now() - t_last_statistics >
+        std::chrono::milliseconds(config.status_master_interval)) {
       t_last_statistics = Clock::now();
       statistics();
     }

--- a/src/Master.cxx
+++ b/src/Master.cxx
@@ -86,8 +86,14 @@ void Master::statistics() {
   for (auto &stream_master : stream_masters) {
     auto fwt_id_str =
         fmt::format("{:016x}", stream_master->file_writer_task().id());
-    js_files.AddMember(Value(fwt_id_str.c_str(), a),
-                       stream_master->file_writer_task().stats(a), a);
+    auto fwt = stream_master->file_writer_task().stats(a);
+    // TODO
+    // Add status when DM-450 lands.
+    fwt.AddMember(
+        "status",
+        StringRef("[to-be-filled-when-StreamMaster-makes-status-available]"),
+        a);
+    js_files.AddMember(Value(fwt_id_str.c_str(), a), fwt, a);
   }
   js_status.AddMember("files", js_files, a);
   rapidjson::StringBuffer buffer;

--- a/src/Master.cxx
+++ b/src/Master.cxx
@@ -26,6 +26,15 @@ void Master::handle_command(rapidjson::Document const &cmd) {
 }
 
 void Master::run() {
+  if (config.do_kafka_status) {
+    LOG(3, "Publishing status to kafka://{}/{}",
+        config.kafka_status_uri.host_port, config.kafka_status_uri.topic);
+    KafkaW::BrokerOpt bopt;
+    bopt.address = config.kafka_status_uri.host_port;
+    auto producer = std::make_shared<KafkaW::Producer>(bopt);
+    status_producer = std::make_shared<KafkaW::ProducerTopic>(
+        producer, config.kafka_status_uri.topic);
+  }
   for (auto const &cmd : config.commands_from_config_file) {
     this->handle_command(cmd);
   }

--- a/src/Master.cxx
+++ b/src/Master.cxx
@@ -77,16 +77,20 @@ void Master::run() {
 }
 
 void Master::statistics() {
+  using namespace rapidjson;
   rapidjson::Document js_status;
   js_status.SetObject();
   auto &a = js_status.GetAllocator();
   for (auto &stream_master : stream_masters) {
-    js_status.AddMember("topics", stream_master->stats(a), a);
+    js_status.AddMember(
+        Value(stream_master->file_writer_task().hdf_filename().c_str(), a),
+        stream_master->file_writer_task().stats(a), a);
   }
-  rapidjson::StringBuffer buf1;
-  rapidjson::PrettyWriter<rapidjson::StringBuffer> wr(buf1);
-  js_status.Accept(wr);
-  LOG(3, "status is: {}", buf1.GetString());
+  rapidjson::StringBuffer buffer;
+  rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(buffer);
+  writer.SetIndent(' ', 2);
+  js_status.Accept(writer);
+  LOG(3, "status is: {}", buffer.GetString());
 }
 
 void Master::stop() { do_run = false; }

--- a/src/Master.cxx
+++ b/src/Master.cxx
@@ -55,6 +55,8 @@ void Master::run() {
     this->handle_command(cmd);
   }
   command_listener.start();
+  using Clock = std::chrono::steady_clock;
+  auto t_last_statistics = Clock::now();
   while (do_run) {
     LOG(7, "Master poll");
     auto p = command_listener.poll();
@@ -62,7 +64,10 @@ void Master::run() {
       LOG(7, "Handle a command");
       this->handle_command_message(std::move(msg));
     }
-    statistics();
+    if (Clock::now() - t_last_statistics > std::chrono::milliseconds(2000)) {
+      t_last_statistics = Clock::now();
+      statistics();
+    }
   }
   LOG(6, "calling stop on all stream_masters");
   for (auto &x : stream_masters) {

--- a/src/Master.cxx
+++ b/src/Master.cxx
@@ -24,6 +24,7 @@ Master::Master(MainOpt &config) : config(config), command_listener(config) {
   if (buffer.back() != 0) {
     // likely an error
     buffer.back() = 0;
+    LOG(4, "Hostname got truncated: {}", buffer.data());
   }
   std::string hostname(buffer.data());
   file_writer_process_id_ =

--- a/src/Master.cxx
+++ b/src/Master.cxx
@@ -65,8 +65,9 @@ void Master::run() {
       LOG(7, "Handle a command");
       this->handle_command_message(std::move(msg));
     }
-    if (Clock::now() - t_last_statistics >
-        std::chrono::milliseconds(config.status_master_interval)) {
+    if (config.do_kafka_status &&
+        Clock::now() - t_last_statistics >
+            std::chrono::milliseconds(config.status_master_interval)) {
       t_last_statistics = Clock::now();
       statistics();
     }

--- a/src/Master.cxx
+++ b/src/Master.cxx
@@ -81,11 +81,15 @@ void Master::statistics() {
   rapidjson::Document js_status;
   js_status.SetObject();
   auto &a = js_status.GetAllocator();
+  Value js_files;
+  js_files.SetObject();
   for (auto &stream_master : stream_masters) {
-    js_status.AddMember(
-        Value(stream_master->file_writer_task().hdf_filename().c_str(), a),
-        stream_master->file_writer_task().stats(a), a);
+    auto fwt_id_str =
+        fmt::format("{:016x}", stream_master->file_writer_task().id());
+    js_files.AddMember(Value(fwt_id_str.c_str(), a),
+                       stream_master->file_writer_task().stats(a), a);
   }
+  js_status.AddMember("files", js_files, a);
   rapidjson::StringBuffer buffer;
   rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(buffer);
   writer.SetIndent(' ', 2);

--- a/src/Master.cxx
+++ b/src/Master.cxx
@@ -2,11 +2,9 @@
 #include "CommandHandler.h"
 #include "FileWriterTask.h"
 #include "Source.h"
+#include "commandproducer.h"
 #include "logger.h"
 #include <chrono>
-// #include "helper.h"
-// #include "utils.h"
-#include "commandproducer.h"
 
 namespace FileWriter {
 

--- a/src/Master.cxx
+++ b/src/Master.cxx
@@ -1,8 +1,5 @@
 #include "Master.h"
 #include "CommandHandler.h"
-#include "FileWriterTask.h"
-#include "Source.h"
-#include "commandproducer.h"
 #include "logger.h"
 #include <chrono>
 #include <rapidjson/document.h>

--- a/src/Master.h
+++ b/src/Master.h
@@ -27,6 +27,9 @@ public:
   std::function<void(void)> cb_on_filewriter_new;
   std::shared_ptr<KafkaW::ProducerTopic> status_producer;
 
+  /// A string which uniquely identifies this file writer on the network
+  std::string file_writer_process_id() const;
+
   MainOpt &config;
 
 private:
@@ -34,6 +37,7 @@ private:
   std::atomic<bool> do_run{true};
   std::vector<std::unique_ptr<StreamMaster<Streamer, DemuxTopic>>>
       stream_masters;
+  std::string file_writer_process_id_;
   friend class CommandHandler;
 };
 

--- a/src/Master.h
+++ b/src/Master.h
@@ -25,6 +25,7 @@ public:
   void handle_command_message(std::unique_ptr<KafkaW::Msg> &&msg);
   void handle_command(rapidjson::Document const &cmd);
   std::function<void(void)> cb_on_filewriter_new;
+  std::shared_ptr<KafkaW::ProducerTopic> status_producer;
 
   MainOpt &config;
 

--- a/src/Master.h
+++ b/src/Master.h
@@ -26,6 +26,7 @@ public:
   void handle_command(rapidjson::Document const &cmd);
   std::function<void(void)> cb_on_filewriter_new;
   std::shared_ptr<KafkaW::ProducerTopic> status_producer;
+  void statistics();
 
   /// A string which uniquely identifies this file writer on the network
   std::string file_writer_process_id() const;

--- a/src/StreamMaster.hpp
+++ b/src/StreamMaster.hpp
@@ -110,6 +110,8 @@ template <typename Streamer, typename Demux> struct StreamMaster {
     return _file_writer_task->stats(a);
   }
 
+  FileWriterTask const &file_writer_task() const { return *_file_writer_task; }
+
 private:
   ErrorCode stop_streamer(const std::string &topic) {
     return streamer[topic].closeStream();

--- a/src/StreamMaster.hpp
+++ b/src/StreamMaster.hpp
@@ -105,6 +105,11 @@ template <typename Streamer, typename Demux> struct StreamMaster {
     return stat;
   }
 
+  rapidjson::Value
+  stats(rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> &a) {
+    return _file_writer_task->stats(a);
+  }
+
 private:
   ErrorCode stop_streamer(const std::string &topic) {
     return streamer[topic].closeStream();

--- a/src/helper.cxx
+++ b/src/helper.cxx
@@ -67,14 +67,18 @@ std::vector<std::string> split(std::string const &input, std::string token) {
   return ret;
 }
 
+bool get_json_ret_string::found() const { return err == 0; }
 get_json_ret_string::operator bool() const { return err == 0; }
 get_json_ret_string::operator std::string() const { return v; }
 
+bool get_json_ret_int::found() const { return err == 0; }
 get_json_ret_int::operator bool() const { return err == 0; }
-
 get_json_ret_int::operator int() const { return v; }
 
+bool get_json_ret_array::found() const { return err == 0; }
 get_json_ret_array::operator bool() const { return err == 0; }
+
+bool get_json_ret_object::found() const { return err == 0; }
 get_json_ret_object::operator bool() const { return err == 0; }
 
 get_json_ret_string get_string(rapidjson::Value const *v, std::string path) {

--- a/src/helper.h
+++ b/src/helper.h
@@ -20,6 +20,7 @@ std::vector<std::string> split(std::string const &input, std::string token);
 struct get_json_ret_string {
   explicit operator bool() const;
   explicit operator std::string() const;
+  bool found() const;
   int err;
   std::string v;
 };
@@ -27,18 +28,21 @@ struct get_json_ret_string {
 struct get_json_ret_int {
   explicit operator bool() const;
   explicit operator int() const;
+  bool found() const;
   int err;
   int v;
 };
 
 struct get_json_ret_array {
   explicit operator bool() const;
+  bool found() const;
   int err = 1;
   rapidjson::Value const *v = nullptr;
 };
 
 struct get_json_ret_object {
   explicit operator bool() const;
+  bool found() const;
   int err = 1;
   rapidjson::Value const *v = nullptr;
 };

--- a/src/kafka-to-nexus.cxx
+++ b/src/kafka-to-nexus.cxx
@@ -20,44 +20,43 @@ int main(int argc, char **argv) {
   auto po = parse_opt(argc, argv);
   auto opt = std::move(po.second);
 
-  printf("kafka-to-nexus-0.0.1 %.7s (ESS, BrightnESS)\n", GIT_COMMIT);
-  printf("  Contact: dominik.werder@psi.ch, michele.brambilla@psi.ch\n\n");
+  fmt::print("kafka-to-nexus {:.7} (ESS, BrightnESS)\n", GIT_COMMIT);
+  fmt::print("  Contact: dominik.werder@psi.ch, michele.brambilla@psi.ch\n\n");
 
   if (opt->help) {
-    printf("Forwards EPICS process variables to Kafka topics.\n"
-           "Controlled via JSON packets sent over the configuration topic.\n"
-           "\n"
-           "\n"
-           "kafka-to-nexus\n"
-           "  --help, -h\n"
-           "\n"
-           "  --config-file               <filename.json>\n"
-           "\n"
-           "  --command-uri               <//host[:port][/topic]>\n"
-           "      Kafka broker/topic to listen for commands.\n"
-           "      Default: //%s/%s\n"
-           "      Legacy alias: --broker-command\n"
-           "\n"
-           "  --status-uri                <//host[:port][/topic]>\n"
-           "      Kafka broker/topic to publish status updates on.\n"
-           "      Default: //%s/%s\n"
-           "\n",
-           opt->command_broker_uri.host_port.c_str(),
-           opt->command_broker_uri.topic.c_str(),
-           opt->kafka_status_uri.host_port.c_str(),
-           opt->kafka_status_uri.topic.c_str());
+    fmt::print(
+        "Forwards EPICS process variables to Kafka topics.\n"
+        "Controlled via JSON packets sent over the configuration topic.\n"
+        "\n"
+        "\n"
+        "kafka-to-nexus\n"
+        "  --help, -h\n"
+        "\n"
+        "  --config-file               <filename.json>\n"
+        "\n"
+        "  --command-uri               <//host[:port][/topic]>\n"
+        "      Kafka broker/topic to listen for commands.\n"
+        "      Default: //{}/{}\n"
+        "      Legacy alias: --broker-command\n"
+        "\n"
+        "  --status-uri                <//host[:port][/topic]>\n"
+        "      Kafka broker/topic to publish status updates on.\n"
+        "      Default: //{}/{}\n"
+        "\n",
+        opt->command_broker_uri.host_port, opt->command_broker_uri.topic,
+        opt->kafka_status_uri.host_port, opt->kafka_status_uri.topic);
 
-    printf("  --kafka-gelf                <//host[:port]/topic>\n"
-           "      Log to Graylog via Kafka GELF adapter.\n"
-           "\n");
+    fmt::print("  --kafka-gelf                <//host[:port]/topic>\n"
+               "      Log to Graylog via Kafka GELF adapter.\n"
+               "\n");
 
-    printf("  --graylog-logger-address    <host:port>\n"
-           "      Log to Graylog via graylog_logger library.\n"
-           "\n");
+    fmt::print("  --graylog-logger-address    <host:port>\n"
+               "      Log to Graylog via graylog_logger library.\n"
+               "\n");
 
-    printf("  -v\n"
-           "      Increase verbosity\n"
-           "\n");
+    fmt::print("  -v\n"
+               "      Increase verbosity\n"
+               "\n");
     return 1;
   }
 

--- a/src/kafka-to-nexus.cxx
+++ b/src/kafka-to-nexus.cxx
@@ -33,12 +33,19 @@ int main(int argc, char **argv) {
            "\n"
            "  --config-file               <filename.json>\n"
            "\n"
-           "  --broker-command            <//host[:port][/topic]>\n"
-           "      Kafka brokers to connect with for configuration updates.\n"
+           "  --command-uri               <//host[:port][/topic]>\n"
+           "      Kafka broker/topic to listen for commands.\n"
+           "      Default: //%s/%s\n"
+           "      Legacy alias: --broker-command\n"
+           "\n"
+           "  --status-uri                <//host[:port][/topic]>\n"
+           "      Kafka broker/topic to publish status updates on.\n"
            "      Default: //%s/%s\n"
            "\n",
            opt->command_broker_uri.host_port.c_str(),
-           opt->command_broker_uri.topic.c_str());
+           opt->command_broker_uri.topic.c_str(),
+           opt->kafka_status_uri.host_port.c_str(),
+           opt->kafka_status_uri.topic.c_str());
 
     printf("  --kafka-gelf                <//host[:port]/topic>\n"
            "      Log to Graylog via Kafka GELF adapter.\n"


### PR DESCRIPTION
- Let the user define a `status-uri` either via the command line or the configuration file to specify on which Kafka topic the file writer should publish the status
- Publish the basic list of files which are currently being written
- Prepared to pass the shared status producer to `StreamMaster` which in turn will publish more details about each file being written
- The overall status of each file being written will be contained in the published json after DM-450 lands