### PR TITLE
Do not require type for neutron event data

### DIFF
--- a/src/schemas/ev42/ev42_rw.cxx
+++ b/src/schemas/ev42/ev42_rw.cxx
@@ -93,13 +93,6 @@ HDFWriterModule::init_hdf(hid_t hdf_file, std::string hdf_parent_name,
     return HDFWriterModule::InitResult::ERROR_INCOMPLETE_CONFIGURATION();
   }
   auto sourcename = str.v;
-  str = get_string(&config_stream, "type");
-  if (!str) {
-    return HDFWriterModule::InitResult::ERROR_INCOMPLETE_CONFIGURATION();
-  }
-  auto type = str.v;
-  LOG(7, "ev42::HDFWriterModule::init_hdf  sourcename: {}  type: {}",
-      sourcename, type);
 
   hsize_t chunk_n_elements = 1;
 

--- a/src/schemas/ev42/ev42_rw.cxx
+++ b/src/schemas/ev42/ev42_rw.cxx
@@ -88,11 +88,6 @@ HDFWriterModule::init_hdf(hid_t hdf_file, std::string hdf_parent_name,
                           rapidjson::Value const &config_stream,
                           rapidjson::Value const *config_module) {
   auto hid = H5Gopen2(hdf_file, hdf_parent_name.data(), H5P_DEFAULT);
-  auto str = get_string(&config_stream, "source");
-  if (!str) {
-    return HDFWriterModule::InitResult::ERROR_INCOMPLETE_CONFIGURATION();
-  }
-  auto sourcename = str.v;
 
   hsize_t chunk_n_elements = 1;
 


### PR DESCRIPTION
The NXevent_data already specifies the types so there is no need to require a
type in the filewriter write command.