### PR TITLE
Write attributes on streams

### DIFF
--- a/src/CommandHandler.cxx
+++ b/src/CommandHandler.cxx
@@ -117,6 +117,7 @@ void CommandHandler::handle_new(rapidjson::Document const &d) {
       LOG(5, "Missing stream specification");
       continue;
     }
+    auto attributes = get_object(*stream.config_stream, "attributes");
     auto &config_stream = *config_stream_value.v;
     LOG(7, "Adding stream: {}", json_to_string(config_stream));
     auto topic = get_string(&config_stream, "topic");
@@ -148,7 +149,7 @@ void CommandHandler::handle_new(rapidjson::Document const &d) {
     }
 
     hdf_writer_module->init_hdf(fwt->hdf_file.h5file, stream.name,
-                                config_stream, nullptr);
+                                config_stream, nullptr, attributes.v);
 
     auto s = Source(source.v, move(hdf_writer_module));
     // Can this be done in a better way?

--- a/src/HDFFile.cxx
+++ b/src/HDFFile.cxx
@@ -152,7 +152,7 @@ void write_attributes(hid_t hdf_this, rapidjson::Value const *jsv) {
 void write_attributes_if_present(hid_t hdf_this, rapidjson::Value const *jsv) {
   auto mem = jsv->FindMember("attributes");
   if (mem != jsv->MemberEnd()) {
-    write_attributes(hdf_this, jsv);
+    write_attributes(hdf_this, &mem->value);
   }
 }
 

--- a/src/HDFFile.cxx
+++ b/src/HDFFile.cxx
@@ -132,24 +132,27 @@ struct SE {
   }
 };
 
-static void write_attributes(hid_t hdf_this, rapidjson::Value const *jsv) {
-  auto mem = jsv->FindMember("attributes");
-  if (mem != jsv->MemberEnd()) {
-    auto &a = mem->value;
-    if (a.IsObject()) {
-      for (auto &at : a.GetObject()) {
-        if (at.value.IsString()) {
-          write_attribute_str(hdf_this, at.name.GetString(),
-                              at.value.GetString());
-        }
-        if (at.value.IsInt64()) {
-          write_attribute(hdf_this, at.name.GetString(), at.value.GetInt64());
-        }
-        if (at.value.IsDouble()) {
-          write_attribute(hdf_this, at.name.GetString(), at.value.GetDouble());
-        }
+void write_attributes(hid_t hdf_this, rapidjson::Value const *jsv) {
+  if (jsv->IsObject()) {
+    for (auto &at : jsv->GetObject()) {
+      if (at.value.IsString()) {
+        write_attribute_str(hdf_this, at.name.GetString(),
+                            at.value.GetString());
+      }
+      if (at.value.IsInt64()) {
+        write_attribute(hdf_this, at.name.GetString(), at.value.GetInt64());
+      }
+      if (at.value.IsDouble()) {
+        write_attribute(hdf_this, at.name.GetString(), at.value.GetDouble());
       }
     }
+  }
+}
+
+void write_attributes_if_present(hid_t hdf_this, rapidjson::Value const *jsv) {
+  auto mem = jsv->FindMember("attributes");
+  if (mem != jsv->MemberEnd()) {
+    write_attributes(hdf_this, jsv);
   }
 }
 
@@ -549,7 +552,7 @@ static void write_dataset(hid_t hdf_parent, rapidjson::Value const *value) {
   // Handle attributes on this dataset
   if (auto x = get_object(*value, "attributes")) {
     auto dsid = H5Dopen2(hdf_parent, name.data(), H5P_DEFAULT);
-    write_attributes(dsid, value);
+    write_attributes(dsid, x.v);
     H5Dclose(dsid);
   }
 }
@@ -592,7 +595,7 @@ static void create_hdf_structures(rapidjson::Value const *value,
   }
 
   if (hdf_this >= 0) {
-    write_attributes(hdf_this, value);
+    write_attributes_if_present(hdf_this, value);
   }
 
   // If the current level in the HDF can act as a parent, then continue the

--- a/src/HDFFile.h
+++ b/src/HDFFile.h
@@ -33,4 +33,7 @@ private:
   friend class CommandHandler;
 };
 
+void write_attributes(hid_t hdf_this, rapidjson::Value const *jsv);
+void write_attributes_if_present(hid_t hdf_this, rapidjson::Value const *jsv);
+
 } // namespace FileWriter

--- a/src/HDFWriterModule.h
+++ b/src/HDFWriterModule.h
@@ -110,7 +110,8 @@ public:
   /// HDFWriterModule.
   virtual InitResult init_hdf(hid_t hdf_file, std::string hdf_parent_name,
                               rapidjson::Value const &config_stream,
-                              rapidjson::Value const *config_module) = 0;
+                              rapidjson::Value const *config_module,
+                              rapidjson::Value const *attributes) = 0;
 
   /// Process the message in some way, for example write to the HDF file.
   virtual WriteResult write(Msg const &msg) = 0;

--- a/src/schemas/ev42/ev42_rw.cxx
+++ b/src/schemas/ev42/ev42_rw.cxx
@@ -4,6 +4,7 @@
 #include "../../HDFWriterModule.h"
 #include "../../h5.h"
 #include "../../helper.h"
+#include "../../json.h"
 #include "schemas/ev42_events_generated.h"
 #include <limits>
 
@@ -61,7 +62,8 @@ public:
   static FileWriter::HDFWriterModule::ptr create();
   InitResult init_hdf(hid_t hdf_file, std::string hdf_parent_name,
                       rapidjson::Value const &config_stream,
-                      rapidjson::Value const *config_module) override;
+                      rapidjson::Value const *config_module,
+                      rapidjson::Value const *attributes) override;
   WriteResult write(Msg const &msg) override;
   int32_t flush() override;
   int32_t close() override;
@@ -86,7 +88,8 @@ FileWriter::HDFWriterModule::ptr HDFWriterModule::create() {
 HDFWriterModule::InitResult
 HDFWriterModule::init_hdf(hid_t hdf_file, std::string hdf_parent_name,
                           rapidjson::Value const &config_stream,
-                          rapidjson::Value const *config_module) {
+                          rapidjson::Value const *config_module,
+                          rapidjson::Value const *attributes) {
   auto hid = H5Gopen2(hdf_file, hdf_parent_name.data(), H5P_DEFAULT);
 
   hsize_t chunk_n_elements = 1;
@@ -124,6 +127,9 @@ HDFWriterModule::init_hdf(hid_t hdf_file, std::string hdf_parent_name,
     ds_event_index.reset();
     ds_cue_index.reset();
     ds_cue_timestamp_zero.reset();
+  }
+  if (attributes) {
+    write_attributes(hid, attributes);
   }
   H5Gclose(hid);
   return HDFWriterModule::InitResult::OK();

--- a/src/tests/HDFFile.cxx
+++ b/src/tests/HDFFile.cxx
@@ -340,6 +340,29 @@ public:
     return 0;
   }
 
+  /// Used by `data_ev42` test to verify attributes attached to the group.
+  static void verify_attribute_data_ev42(bool &attribute_verified, hid_t oid,
+                                         string const &group_path) {
+    herr_t err;
+    auto a1 = H5Aopen_by_name(oid, group_path.data(), "this_will_be_a_double",
+                              H5P_DEFAULT, H5P_DEFAULT);
+    ASSERT_GE(a1, 0);
+    {
+      auto dt = H5Aget_type(a1);
+      ASSERT_EQ(H5Tget_class(dt), H5T_FLOAT);
+      ASSERT_EQ(H5Tget_size(dt), H5Tget_size(H5T_NATIVE_DOUBLE));
+      err = H5Tclose(dt);
+      ASSERT_GE(err, 0);
+    }
+    double v;
+    err = H5Aread(a1, H5T_NATIVE_DOUBLE, &v);
+    if (v == 0.125) {
+      attribute_verified = true;
+    }
+    err = H5Aclose(a1);
+    ASSERT_GE(err, 0);
+  }
+
   static void data_ev42() {
     using namespace FileWriter;
     using std::array;
@@ -454,16 +477,17 @@ public:
         ch.SetArray();
         {
           auto &children = ch;
-          Value ds1;
+          Document ds1(&a);
           ds1.SetObject();
-          ds1.AddMember("type", "stream", a);
-          Value attr;
-          attr.SetObject();
-          attr.AddMember("this_will_be_a_double", Value(0.123), a);
-          attr.AddMember("this_will_be_a_int64", Value(123), a);
-          ds1.AddMember("attributes", attr, a);
-          Document cfg_nexus;
-          cfg_nexus.Parse(R""(
+          ds1.Parse(R""({
+            "type": "stream",
+            "attributes": {
+              "this_will_be_a_double": 0.125,
+              "this_will_be_a_int64": 123
+            }
+          })"");
+          Document stream(&a);
+          stream.Parse(R""(
             {
               "nexus": {
                 "indices": {
@@ -475,8 +499,6 @@ public:
               }
             }
           )"");
-          Value stream;
-          stream.CopyFrom(cfg_nexus, a);
           stream.AddMember("topic", Value(topic.c_str(), a), a);
           stream.AddMember("source", Value(source.c_str(), a), a);
           stream.AddMember("module", Value(module.c_str(), a), a);
@@ -690,6 +712,12 @@ public:
 
       H5Tclose(dt);
       H5Dclose(ds);
+
+      {
+        bool attribute_verified = false;
+        verify_attribute_data_ev42(attribute_verified, fid, group_path);
+        ASSERT_EQ(attribute_verified, true);
+      }
     }
 
     H5Fclose(fid);

--- a/src/tests/HDFFile.cxx
+++ b/src/tests/HDFFile.cxx
@@ -341,7 +341,7 @@ public:
   }
 
   /// Used by `data_ev42` test to verify attributes attached to the group.
-  static void verify_attribute_data_ev42(bool &attribute_verified, hid_t oid,
+  static void verify_attribute_data_ev42(hid_t oid,
                                          string const &group_path) {
     herr_t err;
     auto a1 = H5Aopen_by_name(oid, group_path.data(), "this_will_be_a_double",
@@ -356,9 +356,7 @@ public:
     }
     double v;
     err = H5Aread(a1, H5T_NATIVE_DOUBLE, &v);
-    if (v == 0.125) {
-      attribute_verified = true;
-    }
+    ASSERT_EQ(v, 0.125);
     err = H5Aclose(a1);
     ASSERT_GE(err, 0);
   }
@@ -713,11 +711,7 @@ public:
       H5Tclose(dt);
       H5Dclose(ds);
 
-      {
-        bool attribute_verified = false;
-        verify_attribute_data_ev42(attribute_verified, fid, group_path);
-        ASSERT_EQ(attribute_verified, true);
-      }
+      verify_attribute_data_ev42(fid, group_path);
     }
 
     H5Fclose(fid);

--- a/src/tests/msg-cmd-new-03.json
+++ b/src/tests/msg-cmd-new-03.json
@@ -1,29 +1,30 @@
 {
-    "file_attributes": {
-	"file_name": "a-dummy-name-02.h5"
-    },
-    "cmd": "FileWriter_new",
-    "nexus_structure": {
-	"children": [
-	    {
-		"type": "group",
-		"name": "for_example_motor_0000",
-		"attributes": {
-		    "NX_class": "NXinstrument"
-		},
-		"children": [
-		    {
-			"type": "stream",
-			"stream": {
-			    "topic": "topic.with.multiple.sources",
-			    "source": "for_example_motor",
-			    "module": "f142",
-			    "type": "float",
-			    "array_size": 4
-			}
-		    }
-		]
-	    }
-	]
-    }
+  "file_attributes": {
+    "file_name": "a-dummy-name-02.h5"
+  },
+  "cmd": "FileWriter_new",
+  "nexus_structure": {
+    "children": [
+      {
+        "type": "group",
+        "name": "for_example_motor_0000",
+        "attributes": {
+          "NX_class": "NXinstrument"
+        },
+        "children": [
+          {
+            "type": "stream",
+            "stream": {
+              "topic": "topic.with.multiple.sources",
+              "source": "for_example_motor",
+              "module": "f142",
+              "type": "float",
+              "array_size": 4
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "job_id": "39gershiudsgf"
 }


### PR DESCRIPTION
Closes #77.
File writer modules can use `write_attributes_if_present` to attach the attributes given in the JSON stream specification to an HDF object associated with the stream, e.g. the containing group.
New test verifies that the attribute is written.