### PR TITLE
Define the helper `nat_type` only once in h5.h, h5.cxx

### DIFF
--- a/src/HDFFile.cxx
+++ b/src/HDFFile.cxx
@@ -1,3 +1,4 @@
+#include "h5.h"
 #include "HDFFile.h"
 #include "HDFFile_h5.h"
 #include "HDFFile_impl.h"
@@ -42,18 +43,6 @@ HDFFile::~HDFFile() {
     H5Fclose(h5file);
   }
 }
-
-template <typename T> hid_t nat_type();
-template <> hid_t nat_type<float>() { return H5T_NATIVE_FLOAT; }
-template <> hid_t nat_type<double>() { return H5T_NATIVE_DOUBLE; }
-template <> hid_t nat_type<int8_t>() { return H5T_NATIVE_INT8; }
-template <> hid_t nat_type<int16_t>() { return H5T_NATIVE_INT16; }
-template <> hid_t nat_type<int32_t>() { return H5T_NATIVE_INT32; }
-template <> hid_t nat_type<int64_t>() { return H5T_NATIVE_INT64; }
-template <> hid_t nat_type<uint8_t>() { return H5T_NATIVE_UINT8; }
-template <> hid_t nat_type<uint16_t>() { return H5T_NATIVE_UINT16; }
-template <> hid_t nat_type<uint32_t>() { return H5T_NATIVE_UINT32; }
-template <> hid_t nat_type<uint64_t>() { return H5T_NATIVE_UINT64; }
 
 static void write_hdf_ds_scalar_string(hid_t loc, std::string name,
                                        std::string s1) {
@@ -102,8 +91,8 @@ static void write_attribute(hid_t loc, std::string name, T value) {
   H5Pset_char_encoding(acpl, H5T_CSET_UTF8);
   auto dsp_sc = H5Screate(H5S_SCALAR);
   auto at =
-      H5Acreate2(loc, name.c_str(), nat_type<T>(), dsp_sc, acpl, H5P_DEFAULT);
-  H5Awrite(at, nat_type<T>(), &value);
+      H5Acreate2(loc, name.c_str(), h5::nat_type<T>(), dsp_sc, acpl, H5P_DEFAULT);
+  H5Awrite(at, h5::nat_type<T>(), &value);
   H5Aclose(at);
   H5Sclose(dsp_sc);
   H5Pclose(acpl);
@@ -315,7 +304,7 @@ write_ds_numeric(hid_t hdf_parent, std::string name, std::vector<hsize_t> sizes,
     return;
   }
 
-  auto dt = nat_type<DT>();
+  auto dt = h5::nat_type<DT>();
   auto ds = H5Dcreate2(hdf_parent, name.data(), dt, dsp, H5P_DEFAULT, dcpl,
                        H5P_DEFAULT);
   auto err = H5Dwrite(ds, dt, H5S_ALL, H5S_ALL, H5P_DEFAULT, blob.data());

--- a/src/h5.cxx
+++ b/src/h5.cxx
@@ -3,7 +3,6 @@
 
 namespace h5 {
 
-template <typename T> hid_t nat_type();
 template <> hid_t nat_type<float>() { return H5T_NATIVE_FLOAT; }
 template <> hid_t nat_type<double>() { return H5T_NATIVE_DOUBLE; }
 template <> hid_t nat_type<int8_t>() { return H5T_NATIVE_INT8; }

--- a/src/h5.h
+++ b/src/h5.h
@@ -13,6 +13,8 @@ using std::array;
 using std::vector;
 using std::string;
 
+template <typename T> hid_t nat_type();
+
 void swap(hsize_t &, hsize_t &);
 
 namespace h5p {

--- a/src/tests/HDFFile.cxx
+++ b/src/tests/HDFFile.cxx
@@ -4,6 +4,7 @@
 #include "../KafkaW.h"
 #include "../MainOpt.h"
 #include "../helper.h"
+#include "../h5.h"
 #include "../schemas/ev42/ev42_synth.h"
 #include "../schemas/f142/f142_synth.h"
 #include <array>
@@ -21,18 +22,6 @@ using std::array;
 using std::chrono::steady_clock;
 using std::chrono::milliseconds;
 using std::chrono::duration_cast;
-
-template <typename T> hid_t nat_type();
-template <> hid_t nat_type<float>() { return H5T_NATIVE_FLOAT; }
-template <> hid_t nat_type<double>() { return H5T_NATIVE_DOUBLE; }
-template <> hid_t nat_type<int8_t>() { return H5T_NATIVE_INT8; }
-template <> hid_t nat_type<int16_t>() { return H5T_NATIVE_INT16; }
-template <> hid_t nat_type<int32_t>() { return H5T_NATIVE_INT32; }
-template <> hid_t nat_type<int64_t>() { return H5T_NATIVE_INT64; }
-template <> hid_t nat_type<uint8_t>() { return H5T_NATIVE_UINT8; }
-template <> hid_t nat_type<uint16_t>() { return H5T_NATIVE_UINT16; }
-template <> hid_t nat_type<uint32_t>() { return H5T_NATIVE_UINT32; }
-template <> hid_t nat_type<uint64_t>() { return H5T_NATIVE_UINT64; }
 
 // Verify
 TEST(HDFFile, create) {
@@ -619,7 +608,7 @@ public:
         err = H5Sselect_hyperslab(dsp, H5S_SELECT_SET, start.data(), nullptr,
                                   count.data(), nullptr);
         ASSERT_GE(err, 0);
-        err = H5Dread(ds, nat_type<DT>(), mem, dsp, H5P_DEFAULT, data.data());
+        err = H5Dread(ds, h5::nat_type<DT>(), mem, dsp, H5P_DEFAULT, data.data());
         ASSERT_GE(err, 0);
         auto fbd = fb.root()->detector_id();
         for (int i1 = 0; i1 < n_events_per_message; ++i1) {


### PR DESCRIPTION
Closes #80 