### PR TITLE
Reduction in log message severity level ambiguity

### DIFF
--- a/src/CommandHandler.cxx
+++ b/src/CommandHandler.cxx
@@ -60,7 +60,7 @@ CommandHandler::CommandHandler(MainOpt &config, Master *master)
     auto doc = make_unique<rapidjson::Document>();
     ParseResult err = doc->Parse(buf1.data(), buf1.size());
     if (err.Code() != ParseErrorCode::kParseErrorNone) {
-      LOG(Sev::Err, "ERROR can not parse schema_command");
+      LOG(Sev::Error, "ERROR can not parse schema_command");
       throw std::runtime_error("ERROR can not parse schema_command");
     }
     schema_command.reset(new SchemaDocument(*doc));
@@ -78,7 +78,7 @@ void CommandHandler::handle_new(rapidjson::Document const &d) {
       StringBuffer sb1, sb2;
       vali.GetInvalidSchemaPointer().StringifyUriFragment(sb1);
       vali.GetInvalidDocumentPointer().StringifyUriFragment(sb2);
-      LOG(Sev::Warn, "ERROR command message schema validation:  Invalid schema: {}  "
+      LOG(Sev::Warning, "ERROR command message schema validation:  Invalid schema: {}  "
              "keyword: {}",
           sb1.GetString(), vali.GetInvalidSchemaKeyword());
       return;
@@ -91,7 +91,7 @@ void CommandHandler::handle_new(rapidjson::Document const &d) {
   if (!job_id.empty()) {
     fwt->job_id_init(job_id);
   } else {
-    LOG(Sev::Warn, "Command not accepted: missing job_id");
+    LOG(Sev::Warning, "Command not accepted: missing job_id");
     return;
   }
 
@@ -105,7 +105,7 @@ void CommandHandler::handle_new(rapidjson::Document const &d) {
     auto &nexus_structure = d.FindMember("nexus_structure")->value;
     auto x = fwt->hdf_init(nexus_structure, stream_hdf_info);
     if (x) {
-      LOG(Sev::Err, "ERROR hdf init failed, cancel this write command");
+      LOG(Sev::Error, "ERROR hdf init failed, cancel this write command");
       return;
     }
   }
@@ -114,42 +114,42 @@ void CommandHandler::handle_new(rapidjson::Document const &d) {
   for (auto &stream : stream_hdf_info) {
     auto config_stream_value = get_object(*stream.config_stream, "stream");
     if (!config_stream_value) {
-      LOG(Sev::Note, "Missing stream specification");
+      LOG(Sev::Notice, "Missing stream specification");
       continue;
     }
     auto &config_stream = *config_stream_value.v;
     LOG(Sev::Info, "Adding stream: {}", json_to_string(config_stream));
     auto topic = get_string(&config_stream, "topic");
     if (!topic) {
-      LOG(Sev::Note, "Missing topic on stream specification");
+      LOG(Sev::Notice, "Missing topic on stream specification");
       continue;
     }
     auto source = get_string(&config_stream, "source");
     if (!source) {
-      LOG(Sev::Note, "Missing source on stream specification");
+      LOG(Sev::Notice, "Missing source on stream specification");
       continue;
     }
     auto module = get_string(&config_stream, "writer_module");
     if (!module) {
       module = get_string(&config_stream, "module");
       if (module) {
-        LOG(Sev::Note, "The key \"stream.module\" is deprecated, please use "
+        LOG(Sev::Notice, "The key \"stream.module\" is deprecated, please use "
                "\"stream.writer_module\" instead.");
       } else {
-        LOG(Sev::Note, "Missing key `writer_module` on stream specification");
+        LOG(Sev::Notice, "Missing key `writer_module` on stream specification");
         continue;
       }
     }
 
     auto module_factory = HDFWriterModuleRegistry::find(module.v);
     if (!module_factory) {
-      LOG(Sev::Warn, "Module '{}' is not available", module.v);
+      LOG(Sev::Warning, "Module '{}' is not available", module.v);
       continue;
     }
 
     auto hdf_writer_module = module_factory();
     if (!hdf_writer_module) {
-      LOG(Sev::Warn, "Can not create a HDFWriterModule for '{}'", module.v);
+      LOG(Sev::Warning, "Can not create a HDFWriterModule for '{}'", module.v);
       continue;
     }
 
@@ -234,9 +234,9 @@ void CommandHandler::handle_stream_master_stop(rapidjson::Document const &d) {
     }
 
     if (counter == 0) {
-      LOG(Sev::Warn, "no file with id : {}", job_id);
+      LOG(Sev::Warning, "no file with id : {}", job_id);
     } else if (counter > 1) {
-      LOG(Sev::Warn, "error: multiple files with id : {}", job_id);
+      LOG(Sev::Warning, "error: multiple files with id : {}", job_id);
     }
   }
 }
@@ -291,7 +291,7 @@ void CommandHandler::handle(rapidjson::Document const &d) {
   StringBuffer buffer;
   PrettyWriter<StringBuffer> writer(buffer);
   d.Accept(writer);
-  LOG(Sev::Warn, "ERROR could not figure out this command: {}", buffer.GetString());
+  LOG(Sev::Warning, "ERROR could not figure out this command: {}", buffer.GetString());
 }
 
 void CommandHandler::handle(Msg const &msg) {
@@ -300,7 +300,7 @@ void CommandHandler::handle(Msg const &msg) {
   auto doc = make_unique<Document>();
   ParseResult err = doc->Parse((char *)msg.data, msg.size);
   if (doc->HasParseError()) {
-    LOG(Sev::Warn, "ERROR json parse: {} {}", err.Code(), GetParseError_En(err.Code()));
+    LOG(Sev::Warning, "ERROR json parse: {} {}", err.Code(), GetParseError_En(err.Code()));
     return;
   }
   handle(*doc);

--- a/src/CommandHandler.cxx
+++ b/src/CommandHandler.cxx
@@ -60,7 +60,7 @@ CommandHandler::CommandHandler(MainOpt &config, Master *master)
     auto doc = make_unique<rapidjson::Document>();
     ParseResult err = doc->Parse(buf1.data(), buf1.size());
     if (err.Code() != ParseErrorCode::kParseErrorNone) {
-      LOG(7, "ERROR can not parse schema_command");
+      LOG(Sev::Err, "ERROR can not parse schema_command");
       throw std::runtime_error("ERROR can not parse schema_command");
     }
     schema_command.reset(new SchemaDocument(*doc));
@@ -78,7 +78,7 @@ void CommandHandler::handle_new(rapidjson::Document const &d) {
       StringBuffer sb1, sb2;
       vali.GetInvalidSchemaPointer().StringifyUriFragment(sb1);
       vali.GetInvalidDocumentPointer().StringifyUriFragment(sb2);
-      LOG(6, "ERROR command message schema validation:  Invalid schema: {}  "
+      LOG(Sev::Warn, "ERROR command message schema validation:  Invalid schema: {}  "
              "keyword: {}",
           sb1.GetString(), vali.GetInvalidSchemaKeyword());
       return;
@@ -91,7 +91,7 @@ void CommandHandler::handle_new(rapidjson::Document const &d) {
   if (!job_id.empty()) {
     fwt->job_id_init(job_id);
   } else {
-    LOG(2, "Command not accepted: missing job_id");
+    LOG(Sev::Warn, "Command not accepted: missing job_id");
     return;
   }
 
@@ -105,51 +105,51 @@ void CommandHandler::handle_new(rapidjson::Document const &d) {
     auto &nexus_structure = d.FindMember("nexus_structure")->value;
     auto x = fwt->hdf_init(nexus_structure, stream_hdf_info);
     if (x) {
-      LOG(7, "ERROR hdf init failed, cancel this write command");
+      LOG(Sev::Err, "ERROR hdf init failed, cancel this write command");
       return;
     }
   }
 
-  LOG(6, "Command contains {} streams", stream_hdf_info.size());
+  LOG(Sev::Info, "Command contains {} streams", stream_hdf_info.size());
   for (auto &stream : stream_hdf_info) {
     auto config_stream_value = get_object(*stream.config_stream, "stream");
     if (!config_stream_value) {
-      LOG(5, "Missing stream specification");
+      LOG(Sev::Note, "Missing stream specification");
       continue;
     }
     auto &config_stream = *config_stream_value.v;
-    LOG(7, "Adding stream: {}", json_to_string(config_stream));
+    LOG(Sev::Info, "Adding stream: {}", json_to_string(config_stream));
     auto topic = get_string(&config_stream, "topic");
     if (!topic) {
-      LOG(5, "Missing topic on stream specification");
+      LOG(Sev::Note, "Missing topic on stream specification");
       continue;
     }
     auto source = get_string(&config_stream, "source");
     if (!source) {
-      LOG(5, "Missing source on stream specification");
+      LOG(Sev::Note, "Missing source on stream specification");
       continue;
     }
     auto module = get_string(&config_stream, "writer_module");
     if (!module) {
       module = get_string(&config_stream, "module");
       if (module) {
-        LOG(4, "The key \"stream.module\" is deprecated, please use "
+        LOG(Sev::Note, "The key \"stream.module\" is deprecated, please use "
                "\"stream.writer_module\" instead.");
       } else {
-        LOG(5, "Missing key `writer_module` on stream specification");
+        LOG(Sev::Note, "Missing key `writer_module` on stream specification");
         continue;
       }
     }
 
     auto module_factory = HDFWriterModuleRegistry::find(module.v);
     if (!module_factory) {
-      LOG(5, "Module '{}' is not available", module.v);
+      LOG(Sev::Warn, "Module '{}' is not available", module.v);
       continue;
     }
 
     auto hdf_writer_module = module_factory();
     if (!hdf_writer_module) {
-      LOG(5, "Can not create a HDFWriterModule for '{}'", module.v);
+      LOG(Sev::Warn, "Can not create a HDFWriterModule for '{}'", module.v);
       continue;
     }
 
@@ -177,12 +177,12 @@ void CommandHandler::handle_new(rapidjson::Document const &d) {
     }
     auto start_time = find_time(d, "start_time");
     if (start_time.count()) {
-      LOG(6, "start time :\t{}", start_time.count());
+      LOG(Sev::Info, "start time :\t{}", start_time.count());
       s->start_time(start_time);
     }
     auto stop_time = find_time(d, "stop_time");
     if (stop_time.count()) {
-      LOG(6, "stop time :\t{}", stop_time.count());
+      LOG(Sev::Info, "stop time :\t{}", stop_time.count());
       s->stop_time(stop_time);
     }
     s->start();
@@ -228,15 +228,15 @@ void CommandHandler::handle_stream_master_stop(rapidjson::Document const &d) {
         } else {
           x->stop();
         }
-        LOG(5, "gracefully stop file with id : {}", job_id);
+        LOG(Sev::Info, "gracefully stop file with id : {}", job_id);
         ++counter;
       }
     }
 
     if (counter == 0) {
-      LOG(3, "no file with id : {}", job_id);
+      LOG(Sev::Warn, "no file with id : {}", job_id);
     } else if (counter > 1) {
-      LOG(3, "error: multiple files with id : {}", job_id);
+      LOG(Sev::Warn, "error: multiple files with id : {}", job_id);
     }
   }
 }
@@ -253,7 +253,7 @@ void CommandHandler::handle(rapidjson::Document const &d) {
     cmd_teamid = int64_t(i);
   }
   if (cmd_teamid != teamid) {
-    LOG(1, "INFO command is for teamid {:016x}, we are {:016x}", cmd_teamid,
+    LOG(Sev::Info, "INFO command is for teamid {:016x}, we are {:016x}", cmd_teamid,
         teamid);
     return;
   }
@@ -291,7 +291,7 @@ void CommandHandler::handle(rapidjson::Document const &d) {
   StringBuffer buffer;
   PrettyWriter<StringBuffer> writer(buffer);
   d.Accept(writer);
-  LOG(3, "ERROR could not figure out this command: {}", buffer.GetString());
+  LOG(Sev::Warn, "ERROR could not figure out this command: {}", buffer.GetString());
 }
 
 void CommandHandler::handle(Msg const &msg) {
@@ -300,7 +300,7 @@ void CommandHandler::handle(Msg const &msg) {
   auto doc = make_unique<Document>();
   ParseResult err = doc->Parse((char *)msg.data, msg.size);
   if (doc->HasParseError()) {
-    LOG(2, "ERROR json parse: {} {}", err.Code(), GetParseError_En(err.Code()));
+    LOG(Sev::Warn, "ERROR json parse: {} {}", err.Code(), GetParseError_En(err.Code()));
     return;
   }
   handle(*doc);

--- a/src/DemuxTopic.cxx
+++ b/src/DemuxTopic.cxx
@@ -41,7 +41,7 @@ DemuxTopic::DT DemuxTopic::time_difference_from_message(char *msg_data,
   Msg msg{msg_data, size_t(msg_size)};
   auto &reader = FlatbufferReaderRegistry::find(msg);
   if (!reader) {
-    LOG(4, "ERROR unknown schema id?");
+    LOG(Sev::Err, "ERROR unknown schema id?");
     return DT::ERR();
   }
   auto srcn = reader->source_name(msg);
@@ -57,12 +57,12 @@ ProcessMessageResult DemuxTopic::process_message(char *msg_data, int msg_size) {
     return ProcessMessageResult::ERR();
   }
   if (reader->timestamp(msg) > _stop_time.count()) {
-    LOG(8, "reader->timestamp(msg) {} > _stop_time {}", reader->timestamp(msg),
+    LOG(Sev::Dbg, "reader->timestamp(msg) {} > _stop_time {}", reader->timestamp(msg),
         _stop_time.count());
     return ProcessMessageResult::STOP();
   }
   auto srcn = reader->source_name(msg);
-  LOG(9, "Msg is for source_name: {}", srcn);
+  LOG(Sev::Dbg, "Msg is for source_name: {}", srcn);
   try {
     auto &s = _sources_map.at(srcn);
     auto ret = s.process_message(msg);

--- a/src/DemuxTopic.cxx
+++ b/src/DemuxTopic.cxx
@@ -41,7 +41,7 @@ DemuxTopic::DT DemuxTopic::time_difference_from_message(char *msg_data,
   Msg msg{msg_data, size_t(msg_size)};
   auto &reader = FlatbufferReaderRegistry::find(msg);
   if (!reader) {
-    LOG(Sev::Err, "ERROR unknown schema id?");
+    LOG(Sev::Error, "ERROR unknown schema id?");
     return DT::ERR();
   }
   auto srcn = reader->source_name(msg);
@@ -57,12 +57,12 @@ ProcessMessageResult DemuxTopic::process_message(char *msg_data, int msg_size) {
     return ProcessMessageResult::ERR();
   }
   if (reader->timestamp(msg) > _stop_time.count()) {
-    LOG(Sev::Dbg, "reader->timestamp(msg) {} > _stop_time {}", reader->timestamp(msg),
+    LOG(Sev::Debug, "reader->timestamp(msg) {} > _stop_time {}", reader->timestamp(msg),
         _stop_time.count());
     return ProcessMessageResult::STOP();
   }
   auto srcn = reader->source_name(msg);
-  LOG(Sev::Dbg, "Msg is for source_name: {}", srcn);
+  LOG(Sev::Debug, "Msg is for source_name: {}", srcn);
   try {
     auto &s = _sources_map.at(srcn);
     auto ret = s.process_message(msg);

--- a/src/FileWriterTask.cxx
+++ b/src/FileWriterTask.cxx
@@ -23,7 +23,7 @@ FileWriterTask::FileWriterTask() {
   ++n_FileWriterTask_created;
 }
 
-FileWriterTask::~FileWriterTask() { LOG(6, "~FileWriterTask"); }
+FileWriterTask::~FileWriterTask() { LOG(Sev::Dbg, "~FileWriterTask"); }
 
 FileWriterTask &FileWriterTask::set_hdf_filename(std::string hdf_filename) {
   this->hdf_filename = hdf_filename;
@@ -49,7 +49,7 @@ int FileWriterTask::hdf_init(rapidjson::Value const &nexus_structure,
                              std::vector<StreamHDFInfo> &stream_hdf_info) {
   auto x = hdf_file.init(hdf_filename, nexus_structure, stream_hdf_info);
   if (x) {
-    LOG(3, "can not initialize hdf file  filename: {}", hdf_filename);
+    LOG(Sev::Warn, "can not initialize hdf file  filename: {}", hdf_filename);
     return x;
   }
   return 0;

--- a/src/FileWriterTask.cxx
+++ b/src/FileWriterTask.cxx
@@ -23,7 +23,7 @@ FileWriterTask::FileWriterTask() {
   ++n_FileWriterTask_created;
 }
 
-FileWriterTask::~FileWriterTask() { LOG(Sev::Dbg, "~FileWriterTask"); }
+FileWriterTask::~FileWriterTask() { LOG(Sev::Debug, "~FileWriterTask"); }
 
 FileWriterTask &FileWriterTask::set_hdf_filename(std::string hdf_filename) {
   this->hdf_filename = hdf_filename;
@@ -49,7 +49,7 @@ int FileWriterTask::hdf_init(rapidjson::Value const &nexus_structure,
                              std::vector<StreamHDFInfo> &stream_hdf_info) {
   auto x = hdf_file.init(hdf_filename, nexus_structure, stream_hdf_info);
   if (x) {
-    LOG(Sev::Warn, "can not initialize hdf file  filename: {}", hdf_filename);
+    LOG(Sev::Warning, "can not initialize hdf file  filename: {}", hdf_filename);
     return x;
   }
   return 0;

--- a/src/FlatbufferReader.cxx
+++ b/src/FlatbufferReader.cxx
@@ -35,7 +35,7 @@ find(FlatbufferReaderRegistry::Key const &key) {
 FlatbufferReader::ptr &find(Msg const &msg) {
   static_assert(FLATBUFFERS_LITTLEENDIAN, "Requires currently little endian");
   if (msg.size < 8) {
-    LOG(4, "flatbuffer message is too small: {} expect at least 8", msg.size);
+    LOG(Sev::Warn, "flatbuffer message is too small: {} expect at least 8", msg.size);
     static FlatbufferReader::ptr empty;
     return empty;
   }

--- a/src/FlatbufferReader.cxx
+++ b/src/FlatbufferReader.cxx
@@ -35,7 +35,7 @@ find(FlatbufferReaderRegistry::Key const &key) {
 FlatbufferReader::ptr &find(Msg const &msg) {
   static_assert(FLATBUFFERS_LITTLEENDIAN, "Requires currently little endian");
   if (msg.size < 8) {
-    LOG(Sev::Warn, "flatbuffer message is too small: {} expect at least 8", msg.size);
+    LOG(Sev::Warning, "flatbuffer message is too small: {} expect at least 8", msg.size);
     static FlatbufferReader::ptr empty;
     return empty;
   }

--- a/src/HDFFile.cxx
+++ b/src/HDFFile.cxx
@@ -37,9 +37,9 @@ HDFFile::~HDFFile() {
   if (h5file >= 0) {
     std::array<char, 512> fname;
     H5Fget_name(h5file, fname.data(), fname.size());
-    LOG(Sev::Dbg, "flush file {}", fname.data());
+    LOG(Sev::Debug, "flush file {}", fname.data());
     H5Fflush(h5file, H5F_SCOPE_LOCAL);
-    LOG(Sev::Dbg, "close file {}", fname.data());
+    LOG(Sev::Debug, "close file {}", fname.data());
     H5Fclose(h5file);
   }
 }
@@ -76,7 +76,7 @@ static void write_hdf_iso8601_now(hid_t location, const std::string &name) {
   try {
     current_time_zone = current_zone();
   } catch(std::runtime_error &) {
-    LOG(Sev::Warn, "ERROR failed to detect time zone for use in ISO8601 timestamp in HDF file")
+    LOG(Sev::Warning, "ERROR failed to detect time zone for use in ISO8601 timestamp in HDF file")
     return;
   }
   auto now =
@@ -311,7 +311,7 @@ write_ds_numeric(hid_t hdf_parent, std::string name, std::vector<hsize_t> sizes,
   populate_blob(blob, vals);
 
   if (blob.size() != total_n) {
-    LOG(Sev::Err,
+    LOG(Sev::Error,
         "unexpected number of values for dataset {}  expected: {}  actual: {}",
         name, total_n, blob.size());
     H5Sclose(dsp);
@@ -324,7 +324,7 @@ write_ds_numeric(hid_t hdf_parent, std::string name, std::vector<hsize_t> sizes,
                        H5P_DEFAULT);
   auto err = H5Dwrite(ds, dt, H5S_ALL, H5S_ALL, H5P_DEFAULT, blob.data());
   if (err < 0) {
-    LOG(Sev::Err, "error while writing dataset {}", name);
+    LOG(Sev::Error, "error while writing dataset {}", name);
   }
   H5Dclose(ds);
   H5Sclose(dsp);
@@ -355,7 +355,7 @@ static void write_ds_string(hid_t hdf_parent, std::string name,
   populate_string_pointers(blob, vals);
 
   if (blob.size() != total_n) {
-    LOG(Sev::Err,
+    LOG(Sev::Error,
         "unexpected number of values for dataset {}  expected: {}  actual: {}",
         name, total_n, blob.size());
     H5Sclose(dsp);
@@ -371,7 +371,7 @@ static void write_ds_string(hid_t hdf_parent, std::string name,
                        H5P_DEFAULT);
   auto err = H5Dwrite(ds, dt, H5S_ALL, H5S_ALL, H5P_DEFAULT, blob.data());
   if (err < 0) {
-    LOG(Sev::Err, "error while writing dataset {}", name);
+    LOG(Sev::Error, "error while writing dataset {}", name);
   }
   H5Dclose(ds);
   H5Sclose(dsp);
@@ -408,7 +408,7 @@ static void write_ds_string_fixed_size(hid_t hdf_parent, std::string name,
   populate_string_fixed_size(blob, element_size, vals);
 
   if (blob.size() != total_n * element_size) {
-    LOG(Sev::Err, "error in sizes");
+    LOG(Sev::Error, "error in sizes");
     H5Sclose(dsp);
     H5Pclose(dcpl);
     return;
@@ -422,7 +422,7 @@ static void write_ds_string_fixed_size(hid_t hdf_parent, std::string name,
                        H5P_DEFAULT);
   auto err = H5Dwrite(ds, dt, H5S_ALL, H5S_ALL, H5P_DEFAULT, blob.data());
   if (err < 0) {
-    LOG(Sev::Err, "error while writing dataset");
+    LOG(Sev::Error, "error while writing dataset");
   }
   H5Dclose(ds);
   H5Sclose(dsp);
@@ -494,7 +494,7 @@ static void write_dataset(hid_t hdf_parent, rapidjson::Value const *value) {
     auto ds_space = get_string(ds.v, "space");
     if (ds_space) {
       if (ds_space.v != "simple") {
-        LOG(Sev::Warn, "sorry, can only handle simple data spaces");
+        LOG(Sev::Warning, "sorry, can only handle simple data spaces");
         return;
       }
     }
@@ -627,7 +627,7 @@ int HDFFile::init(std::string filename, rapidjson::Value const &nexus_structure,
   if (x < 0) {
     std::array<char, 256> cwd;
     getcwd(cwd.data(), cwd.size());
-    LOG(Sev::Err, "ERROR could not create the HDF file: {}  cwd: {}", filename,
+    LOG(Sev::Error, "ERROR could not create the HDF file: {}  cwd: {}", filename,
         cwd.data());
     return -1;
   }

--- a/src/HDFFile.cxx
+++ b/src/HDFFile.cxx
@@ -37,9 +37,9 @@ HDFFile::~HDFFile() {
   if (h5file >= 0) {
     std::array<char, 512> fname;
     H5Fget_name(h5file, fname.data(), fname.size());
-    LOG(6, "flush file {}", fname.data());
+    LOG(Sev::Dbg, "flush file {}", fname.data());
     H5Fflush(h5file, H5F_SCOPE_LOCAL);
-    LOG(6, "close file {}", fname.data());
+    LOG(Sev::Dbg, "close file {}", fname.data());
     H5Fclose(h5file);
   }
 }
@@ -76,7 +76,7 @@ static void write_hdf_iso8601_now(hid_t location, const std::string &name) {
   try {
     current_time_zone = current_zone();
   } catch(std::runtime_error &) {
-    LOG(2, "ERROR failed to detect time zone for use in ISO8601 timestamp in HDF file")
+    LOG(Sev::Warn, "ERROR failed to detect time zone for use in ISO8601 timestamp in HDF file")
     return;
   }
   auto now =
@@ -311,7 +311,7 @@ write_ds_numeric(hid_t hdf_parent, std::string name, std::vector<hsize_t> sizes,
   populate_blob(blob, vals);
 
   if (blob.size() != total_n) {
-    LOG(3,
+    LOG(Sev::Err,
         "unexpected number of values for dataset {}  expected: {}  actual: {}",
         name, total_n, blob.size());
     H5Sclose(dsp);
@@ -324,7 +324,7 @@ write_ds_numeric(hid_t hdf_parent, std::string name, std::vector<hsize_t> sizes,
                        H5P_DEFAULT);
   auto err = H5Dwrite(ds, dt, H5S_ALL, H5S_ALL, H5P_DEFAULT, blob.data());
   if (err < 0) {
-    LOG(3, "error while writing dataset {}", name);
+    LOG(Sev::Err, "error while writing dataset {}", name);
   }
   H5Dclose(ds);
   H5Sclose(dsp);
@@ -355,7 +355,7 @@ static void write_ds_string(hid_t hdf_parent, std::string name,
   populate_string_pointers(blob, vals);
 
   if (blob.size() != total_n) {
-    LOG(3,
+    LOG(Sev::Err,
         "unexpected number of values for dataset {}  expected: {}  actual: {}",
         name, total_n, blob.size());
     H5Sclose(dsp);
@@ -371,7 +371,7 @@ static void write_ds_string(hid_t hdf_parent, std::string name,
                        H5P_DEFAULT);
   auto err = H5Dwrite(ds, dt, H5S_ALL, H5S_ALL, H5P_DEFAULT, blob.data());
   if (err < 0) {
-    LOG(3, "error while writing dataset {}", name);
+    LOG(Sev::Err, "error while writing dataset {}", name);
   }
   H5Dclose(ds);
   H5Sclose(dsp);
@@ -408,7 +408,7 @@ static void write_ds_string_fixed_size(hid_t hdf_parent, std::string name,
   populate_string_fixed_size(blob, element_size, vals);
 
   if (blob.size() != total_n * element_size) {
-    LOG(3, "error in sizes");
+    LOG(Sev::Err, "error in sizes");
     H5Sclose(dsp);
     H5Pclose(dcpl);
     return;
@@ -422,7 +422,7 @@ static void write_ds_string_fixed_size(hid_t hdf_parent, std::string name,
                        H5P_DEFAULT);
   auto err = H5Dwrite(ds, dt, H5S_ALL, H5S_ALL, H5P_DEFAULT, blob.data());
   if (err < 0) {
-    LOG(3, "error while writing dataset");
+    LOG(Sev::Err, "error while writing dataset");
   }
   H5Dclose(ds);
   H5Sclose(dsp);
@@ -494,7 +494,7 @@ static void write_dataset(hid_t hdf_parent, rapidjson::Value const *value) {
     auto ds_space = get_string(ds.v, "space");
     if (ds_space) {
       if (ds_space.v != "simple") {
-        LOG(3, "sorry, can only handle simple data spaces");
+        LOG(Sev::Warn, "sorry, can only handle simple data spaces");
         return;
       }
     }
@@ -627,7 +627,7 @@ int HDFFile::init(std::string filename, rapidjson::Value const &nexus_structure,
   if (x < 0) {
     std::array<char, 256> cwd;
     getcwd(cwd.data(), cwd.size());
-    LOG(0, "ERROR could not create the HDF file: {}  cwd: {}", filename,
+    LOG(Sev::Err, "ERROR could not create the HDF file: {}  cwd: {}", filename,
         cwd.data());
     return -1;
   }

--- a/src/KafkaW.cxx
+++ b/src/KafkaW.cxx
@@ -1,5 +1,4 @@
 #include "KafkaW.h"
-#include "logger.h"
 #include <atomic>
 #include <cerrno>
 
@@ -19,7 +18,7 @@ using std::move;
 
 #define KERR(rk, err)                                                          \
   if (err != 0) {                                                              \
-    LOG(4, "Kafka {}  error: {}, {}, {}", rd_kafka_name(rk), err,              \
+LOG(Sev::Err, "Kafka {}  error: {}, {}, {}", rd_kafka_name(rk), err,              \
         rd_kafka_err2name((rd_kafka_resp_err_t)err),                           \
         rd_kafka_err2str((rd_kafka_resp_err_t)err));                           \
   }
@@ -50,18 +49,18 @@ void BrokerOpt::apply(rd_kafka_conf_t *conf) {
   std::vector<char> errstr(256);
   for (auto &c : conf_ints) {
     auto s1 = fmt::format("{:d}", c.second);
-    LOG(5, "set config: {} = {}", c.first, s1);
+    LOG(Sev::Dbg, "set config: {} = {}", c.first, s1);
     if (RD_KAFKA_CONF_OK != rd_kafka_conf_set(conf, c.first.c_str(), s1.c_str(),
                                               errstr.data(), errstr.size())) {
-      LOG(2, "error setting config: {} = {}", c.first, s1);
+      LOG(Sev::Warn, "error setting config: {} = {}", c.first, s1);
     }
   }
   for (auto &c : conf_strings) {
-    LOG(5, "set config: {} = {}", c.first, c.second);
+    LOG(Sev::Dbg, "set config: {} = {}", c.first, c.second);
     if (RD_KAFKA_CONF_OK != rd_kafka_conf_set(conf, c.first.c_str(),
                                               c.second.c_str(), errstr.data(),
                                               errstr.size())) {
-      LOG(2, "error setting config: {} = {}", c.first, c.second);
+      LOG(Sev::Warn, "error setting config: {} = {}", c.first, c.second);
     }
   }
 }
@@ -72,19 +71,19 @@ void TopicOpt::apply(rd_kafka_topic_conf_t *conf) {
   std::vector<char> errstr(1024);
   for (auto &c : conf_ints) {
     auto s1 = fmt::format("{:d}", c.second);
-    LOG(5, "use  {}: {}", c.first, s1);
+    LOG(Sev::Dbg, "use  {}: {}", c.first, s1);
     if (RD_KAFKA_CONF_OK != rd_kafka_topic_conf_set(conf, c.first.c_str(),
                                                     s1.c_str(), errstr.data(),
                                                     errstr.size())) {
-      LOG(2, "error setting topic config: {} = {}", c.first, s1);
+      LOG(Sev::Warn, "error setting topic config: {} = {}", c.first, s1);
     }
   }
   for (auto &c : conf_strings) {
-    LOG(5, "use  {}: {}", c.first, c.second);
+    LOG(Sev::Dbg, "use  {}: {}", c.first, c.second);
     if (RD_KAFKA_CONF_OK !=
         rd_kafka_topic_conf_set(conf, c.first.c_str(), c.second.c_str(),
                                 errstr.data(), errstr.size())) {
-      LOG(2, "error setting topic config: {} = {}", c.first, c.second);
+      LOG(Sev::Warn, "error setting topic config: {} = {}", c.first, c.second);
     }
   }
 }
@@ -181,26 +180,26 @@ Consumer::Consumer(BrokerOpt opt) : opt(opt) {
 }
 
 Consumer::~Consumer() {
-  LOG(7, "~Consumer()");
+  LOG(Sev::Dbg, "~Consumer()");
   if (rk) {
     // commit offsets?
     if (0) {
-      LOG(7, "rd_kafka_unsubscribe");
+      LOG(Sev::Dbg, "rd_kafka_unsubscribe");
       rd_kafka_unsubscribe(rk);
     }
     if (0) {
-      LOG(7, "rd_kafka_poll");
+      LOG(Sev::Dbg, "rd_kafka_poll");
       int n1 = rd_kafka_poll(rk, 100);
-      LOG(7, "  served {} reuests", n1);
+      LOG(Sev::Dbg, "  served {} reuests", n1);
     }
     if (1) {
-      LOG(7, "rd_kafka_consumer_close");
+      LOG(Sev::Dbg, "rd_kafka_consumer_close");
       rd_kafka_consumer_close(rk);
     }
     // rd_kafka_consume_stop(rd_kafka_topic_t *, partition)  therefore low-level
     // API?
     if (1) {
-      LOG(7, "rd_kafka_destroy");
+      LOG(Sev::Dbg, "rd_kafka_destroy");
       rd_kafka_destroy(rk);
       rk = nullptr;
     }
@@ -214,16 +213,16 @@ Consumer::~Consumer() {
 void Consumer::cb_log(rd_kafka_t const *rk, int level, char const *fac,
                       char const *buf) {
   auto self = reinterpret_cast<Consumer *>(rd_kafka_opaque(rk));
-  LOG(level, "IID: {}  {}  fac: {}", self->id, buf, fac);
+  LOG(Sev(level), "IID: {}  {}  fac: {}", self->id, buf, fac);
 }
 
 void Consumer::cb_error(rd_kafka_t *rk, int err_i, char const *msg,
                         void *opaque) {
   auto self = reinterpret_cast<Consumer *>(opaque);
   rd_kafka_resp_err_t err = (rd_kafka_resp_err_t)err_i;
-  int ll = 2;
+  Sev ll = Sev::Dbg;
   if (err == RD_KAFKA_RESP_ERR__TRANSPORT) {
-    ll = 5;
+    ll = Sev::Warn;
     // rd_kafka_dump(stdout, rk);
   }
   LOG(ll, "Kafka cb_error id: {}  broker: {}  errno: {}  errorname: {}  "
@@ -234,7 +233,7 @@ void Consumer::cb_error(rd_kafka_t *rk, int err_i, char const *msg,
 
 int Consumer::cb_stats(rd_kafka_t *rk, char *json, size_t json_size,
                        void *opaque) {
-  LOG(4, "INFO stats_cb {}  {:.{}}", json_size, json, json_size);
+  LOG(Sev::Dbg, "INFO stats_cb {}  {:.{}}", json_size, json, json_size);
   // What does Kafka want us to return from this callback?
   return 0;
 }
@@ -242,7 +241,7 @@ int Consumer::cb_stats(rd_kafka_t *rk, char *json, size_t json_size,
 static void print_partition_list(rd_kafka_topic_partition_list_t *plist) {
   for (int i1 = 0; i1 < plist->cnt; ++i1) {
     auto &x = plist->elems[i1];
-    LOG(7, "   {}  {}  {}", x.topic, x.partition, x.offset);
+    LOG(Sev::Dbg, "   {}  {}  {}", x.topic, x.partition, x.offset);
   }
 }
 
@@ -253,14 +252,14 @@ void Consumer::cb_rebalance(rd_kafka_t *rk, rd_kafka_resp_err_t err,
   auto self = static_cast<Consumer *>(opaque);
   switch (err) {
   case RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS:
-    LOG(6, "cb_rebalance assign {}", rd_kafka_name(rk));
+    LOG(Sev::Dbg, "cb_rebalance assign {}", rd_kafka_name(rk));
     if (auto &cb = self->on_rebalance_start) {
       cb(plist);
     }
     print_partition_list(plist);
     err2 = rd_kafka_assign(rk, plist);
     if (err2 != RD_KAFKA_RESP_ERR_NO_ERROR) {
-      LOG(0, "rebalance error: {}  {}", rd_kafka_err2name(err2),
+      LOG(Sev::Note, "rebalance error: {}  {}", rd_kafka_err2name(err2),
           rd_kafka_err2str(err2));
     }
     if (auto &cb = self->on_rebalance_assign) {
@@ -268,19 +267,19 @@ void Consumer::cb_rebalance(rd_kafka_t *rk, rd_kafka_resp_err_t err,
     }
     break;
   case RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS:
-    LOG(6, "cb_rebalance revoke:");
+    LOG(Sev::Warn, "cb_rebalance revoke:");
     print_partition_list(plist);
     err2 = rd_kafka_assign(rk, NULL);
     if (err2 != RD_KAFKA_RESP_ERR_NO_ERROR) {
-      LOG(2, "rebalance error: {}  {}", rd_kafka_err2name(err2),
+      LOG(Sev::Warn, "rebalance error: {}  {}", rd_kafka_err2name(err2),
           rd_kafka_err2str(err2));
     }
     break;
   default:
-    LOG(6, "cb_rebalance failure and revoke: {}", rd_kafka_err2str(err));
+    LOG(Sev::Info, "cb_rebalance failure and revoke: {}", rd_kafka_err2str(err));
     err2 = rd_kafka_assign(rk, NULL);
     if (err2 != RD_KAFKA_RESP_ERR_NO_ERROR) {
-      LOG(2, "rebalance error: {}  {}", rd_kafka_err2name(err2),
+      LOG(Sev::Warn, "rebalance error: {}  {}", rd_kafka_err2name(err2),
           rd_kafka_err2str(err2));
     }
     break;
@@ -304,16 +303,16 @@ void Consumer::init() {
 
   rk = rd_kafka_new(RD_KAFKA_CONSUMER, conf, errstr, errstr_N);
   if (!rk) {
-    LOG(2, "can not create kafka handle: {}", errstr);
+    LOG(Sev::Err, "can not create kafka handle: {}", errstr);
     throw std::runtime_error("can not create Kafka handle");
   }
 
   rd_kafka_set_log_level(rk, 4);
 
-  LOG(4, "New Kafka consumer {} with brokers: {}", rd_kafka_name(rk),
+  LOG(Sev::Info, "New Kafka consumer {} with brokers: {}", rd_kafka_name(rk),
       opt.address.c_str());
   if (rd_kafka_brokers_add(rk, opt.address.c_str()) == 0) {
-    LOG(2, "could not add brokers");
+    LOG(Sev::Err, "could not add brokers");
     throw std::runtime_error("could not add brokers");
   }
 
@@ -324,13 +323,13 @@ void Consumer::init() {
 }
 
 void Consumer::add_topic(std::string topic) {
-  LOG(7, "Consumer::add_topic  {}", topic);
+  LOG(Sev::Info, "Consumer::add_topic  {}", topic);
   int partition = RD_KAFKA_PARTITION_UA;
   rd_kafka_topic_partition_list_add(plist, topic.c_str(), partition);
   int err = rd_kafka_subscribe(rk, plist);
   KERR(rk, err);
   if (err) {
-    LOG(2, "could not subscribe");
+    LOG(Sev::Err, "could not subscribe");
     throw std::runtime_error("can not subscribe");
   }
 }
@@ -341,7 +340,7 @@ void Consumer::dump_current_subscription() {
   rd_kafka_subscription(rk, &l1);
   if (l1) {
     for (int i1 = 0; i1 < l1->cnt; ++i1) {
-      LOG(6, "subscribed topics: {}  {}  off {}", l1->elems[i1].topic,
+      LOG(Sev::Info, "subscribed topics: {}  {}  off {}", l1->elems[i1].topic,
           rd_kafka_err2str(l1->elems[i1].err), l1->elems[i1].offset);
     }
     rd_kafka_topic_partition_list_destroy(l1);
@@ -371,14 +370,14 @@ PollStatus Consumer::poll() {
     // Just an advisory.  msg contains which partition it is.
     return PollStatus::EOP();
   } else if (msg->err == RD_KAFKA_RESP_ERR__ALL_BROKERS_DOWN) {
-    LOG(4, "RD_KAFKA_RESP_ERR__ALL_BROKERS_DOWN");
+    LOG(Sev::Err, "RD_KAFKA_RESP_ERR__ALL_BROKERS_DOWN");
   } else if (msg->err == RD_KAFKA_RESP_ERR__BAD_MSG) {
-    LOG(2, "RD_KAFKA_RESP_ERR__BAD_MSG");
+    LOG(Sev::Err, "RD_KAFKA_RESP_ERR__BAD_MSG");
   } else if (msg->err == RD_KAFKA_RESP_ERR__DESTROY) {
-    LOG(4, "RD_KAFKA_RESP_ERR__DESTROY");
+    LOG(Sev::Err, "RD_KAFKA_RESP_ERR__DESTROY");
     // Broker will go away soon
   } else {
-    LOG(2, "unhandled msg error: {} {}", rd_kafka_err2name(msg->err),
+    LOG(Sev::Err, "unhandled msg error: {} {}", rd_kafka_err2name(msg->err),
         rd_kafka_err2str(msg->err));
   }
   return PollStatus::Err();
@@ -388,12 +387,12 @@ void Producer::cb_delivered(rd_kafka_t *rk, rd_kafka_message_t const *msg,
                             void *opaque) {
   auto self = reinterpret_cast<Producer *>(opaque);
   if (!msg) {
-    LOG(2, "IID: {}  ERROR msg should never be null", self->id);
+    LOG(Sev::Err, "IID: {}  ERROR msg should never be null", self->id);
     ++self->stats.produce_cb_fail;
     return;
   }
   if (msg->err) {
-    LOG(2, "IID: {}  ERROR on delivery, {}, topic {}, {} [{}] {}", self->id,
+    LOG(Sev::Err, "IID: {}  ERROR on delivery, {}, topic {}, {} [{}] {}", self->id,
         rd_kafka_name(rk), rd_kafka_topic_name(msg->rkt),
         rd_kafka_err2name(msg->err), msg->err, rd_kafka_err2str(msg->err));
     if (msg->err == RD_KAFKA_RESP_ERR__MSG_TIMED_OUT) {
@@ -408,7 +407,7 @@ void Producer::cb_delivered(rd_kafka_t *rk, rd_kafka_message_t const *msg,
       cb(msg);
     }
     if (false) {
-      LOG(7, "IID: {}  Ok delivered ({}, p {}, offset {}, len {})", self->id,
+      LOG(Sev::Dbg, "IID: {}  Ok delivered ({}, p {}, offset {}, len {})", self->id,
           rd_kafka_name(rk), msg->partition, msg->offset, msg->len);
     }
     ++self->stats.produce_cb;
@@ -419,9 +418,9 @@ void Producer::cb_error(rd_kafka_t *rk, int err_i, char const *msg,
                         void *opaque) {
   auto self = reinterpret_cast<Producer *>(opaque);
   rd_kafka_resp_err_t err = (rd_kafka_resp_err_t)err_i;
-  int ll = 2;
+  Sev ll = Sev::Warn;
   if (err == RD_KAFKA_RESP_ERR__TRANSPORT) {
-    ll = 5;
+    ll = Sev::Err;
     // rd_kafka_dump(stdout, rk);
   } else {
     if (self->on_error)
@@ -436,7 +435,7 @@ void Producer::cb_error(rd_kafka_t *rk, int err_i, char const *msg,
 int Producer::cb_stats(rd_kafka_t *rk, char *json, size_t json_len,
                        void *opaque) {
   auto self = reinterpret_cast<Producer *>(opaque);
-  LOG(4, "IID: {}  INFO cb_stats {} length {}   {:.{}}", self->id,
+  LOG(Sev::Dbg, "IID: {}  INFO cb_stats {} length {}   {:.{}}", self->id,
       rd_kafka_name(rk), json_len, json, json_len);
   // What does librdkafka want us to return from this callback?
   return 0;
@@ -445,20 +444,20 @@ int Producer::cb_stats(rd_kafka_t *rk, char *json, size_t json_len,
 void Producer::cb_log(rd_kafka_t const *rk, int level, char const *fac,
                       char const *buf) {
   auto self = reinterpret_cast<Producer *>(rd_kafka_opaque(rk));
-  LOG(5, "IID: {}  {}  fac: {}", self->id, buf, fac);
+  LOG(Sev::Dbg, "IID: {}  {}  fac: {}", self->id, buf, fac);
 }
 
 void Producer::cb_throttle(rd_kafka_t *rk, char const *broker_name,
                            int32_t broker_id, int throttle_time_ms,
                            void *opaque) {
   auto self = reinterpret_cast<Producer *>(opaque);
-  LOG(4, "IID: {}  INFO cb_throttle  broker_id: {}  broker_name: {}  "
+  LOG(Sev::Dbg, "IID: {}  INFO cb_throttle  broker_id: {}  broker_name: {}  "
          "throttle_time_ms: {}",
       self->id, broker_id, broker_name, throttle_time_ms);
 }
 
 Producer::~Producer() {
-  LOG(7, "~Producer");
+  LOG(Sev::Dbg, "~Producer");
   if (rk) {
     int timeout_ms = 1;
     uint32_t outq_len = 0;
@@ -469,7 +468,7 @@ Producer::~Producer() {
       }
       auto events_handled = rd_kafka_poll(rk, timeout_ms);
       if (events_handled > 0) {
-        LOG(7, "rd_kafka_poll handled: {}  outq before: {}  timeout: {}",
+        LOG(Sev::Dbg, "rd_kafka_poll handled: {}  outq before: {}  timeout: {}",
             events_handled, outq_len, timeout_ms);
       }
       timeout_ms = timeout_ms << 1;
@@ -478,10 +477,10 @@ Producer::~Producer() {
       }
     }
     if (outq_len > 0) {
-      LOG(3, "Kafka out queue still not empty: {}  destroy producer anyway.",
+      LOG(Sev::Note, "Kafka out queue still not empty: {}  destroy producer anyway.",
           outq_len);
     }
-    LOG(7, "rd_kafka_destroy");
+    LOG(Sev::Dbg, "rd_kafka_destroy");
     rd_kafka_destroy(rk);
     rk = nullptr;
   }
@@ -503,22 +502,22 @@ Producer::Producer(BrokerOpt opt) : opt(opt) {
   rd_kafka_conf_set_throttle_cb(conf, Producer::cb_throttle);
 
   rd_kafka_conf_set_opaque(conf, this);
-  LOG(7, "Producer opaque: {}", (void *)this);
+  LOG(Sev::Dbg, "Producer opaque: {}", (void *)this);
 
   opt.apply(conf);
 
   rk = rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr.data(), errstr.size());
   if (!rk) {
-    LOG(2, "can not create kafka handle: {}", errstr.data());
+    LOG(Sev::Err, "can not create kafka handle: {}", errstr.data());
     throw std::runtime_error("can not create Kafka handle");
   }
 
   rd_kafka_set_log_level(rk, 4);
 
-  LOG(4, "New Kafka {} with brokers: {}", rd_kafka_name(rk),
+  LOG(Sev::Info, "New Kafka {} with brokers: {}", rd_kafka_name(rk),
       opt.address.c_str());
   if (rd_kafka_brokers_add(rk, opt.address.c_str()) == 0) {
-    LOG(2, "could not add brokers");
+    LOG(Sev::Err, "could not add brokers");
     throw std::runtime_error("could not add brokers");
   }
 }
@@ -535,11 +534,7 @@ Producer::Producer(Producer &&x) {
 
 void Producer::poll() {
   int events_handled = rd_kafka_poll(rk, opt.poll_timeout_ms);
-  int level = 7;
-  if (events_handled == 0) {
-    level = 8;
-  }
-  LOG(level, "IID: {}  broker: {}  rd_kafka_poll()  served: {}  outq_len: {}",
+  LOG(Sev::Dbg, "IID: {}  broker: {}  rd_kafka_poll()  served: {}  outq_len: {}",
       id, opt.address, events_handled, outq());
   if (log_level >= 8) {
     rd_kafka_dump(stdout, rk);
@@ -575,9 +570,9 @@ ProducerStats::ProducerStats(ProducerStats const &x) {
 }
 
 ProducerTopic::~ProducerTopic() {
-  LOG(7, "~ProducerTopic {}", _name);
+  LOG(Sev::Dbg, "~ProducerTopic {}", _name);
   if (rkt) {
-    LOG(7, "rd_kafka_topic_destroy");
+    LOG(Sev::Dbg, "rd_kafka_topic_destroy");
     rd_kafka_topic_destroy(rkt);
     rkt = nullptr;
   }
@@ -599,10 +594,10 @@ ProducerTopic::ProducerTopic(std::shared_ptr<Producer> producer,
   if (rkt == nullptr) {
     // Seems like Kafka uses the system error code?
     auto errstr = rd_kafka_err2str(rd_kafka_errno2err(errno));
-    LOG(2, "could not create Kafka topic: {}", errstr);
+    LOG(Sev::Err, "could not create Kafka topic: {}", errstr);
     throw std::exception();
   }
-  LOG(7, "ctor topic: {}  producer: {}", rd_kafka_topic_name(rkt),
+  LOG(Sev::Dbg, "ctor topic: {}  producer: {}", rd_kafka_topic_name(rkt),
       rd_kafka_name(producer->rd_kafka_ptr()));
 }
 
@@ -648,18 +643,18 @@ int ProducerTopic::produce(unique_ptr<Producer::Msg> &msg) {
     if (err == RD_KAFKA_RESP_ERR__QUEUE_FULL) {
       ++s.local_queue_full;
       if (print_err) {
-        LOG(7, "QUEUE_FULL  outq: {}",
+        LOG(Sev::Warn, "QUEUE_FULL  outq: {}",
             rd_kafka_outq_len(producer->rd_kafka_ptr()));
       }
     } else if (err == RD_KAFKA_RESP_ERR_MSG_SIZE_TOO_LARGE) {
       ++s.msg_too_large;
       if (print_err) {
-        LOG(7, "TOO_LARGE  size: {}", msg->size);
+        LOG(Sev::Err, "TOO_LARGE  size: {}", msg->size);
       }
     } else {
       ++s.produce_fail;
       if (print_err) {
-        LOG(7, "produce topic {}  partition {}   error: {}  {}",
+        LOG(Sev::Dbg, "produce topic {}  partition {}   error: {}  {}",
             rd_kafka_topic_name(rkt), partition, x, rd_kafka_err2str(err));
       }
     }
@@ -668,7 +663,7 @@ int ProducerTopic::produce(unique_ptr<Producer::Msg> &msg) {
     s.produced_bytes += (uint64_t)msg->size;
     ++producer->total_produced_;
     if (log_level >= 8) {
-      LOG(8, "sent to topic {} partition {}", rd_kafka_topic_name(rkt),
+      LOG(Sev::Dbg, "sent to topic {} partition {}", rd_kafka_topic_name(rkt),
           partition);
     }
     msg.release();

--- a/src/KafkaW.cxx
+++ b/src/KafkaW.cxx
@@ -18,7 +18,7 @@ using std::move;
 
 #define KERR(rk, err)                                                          \
   if (err != 0) {                                                              \
-LOG(Sev::Err, "Kafka {}  error: {}, {}, {}", rd_kafka_name(rk), err,              \
+LOG(Sev::Error, "Kafka {}  error: {}, {}, {}", rd_kafka_name(rk), err,              \
         rd_kafka_err2name((rd_kafka_resp_err_t)err),                           \
         rd_kafka_err2str((rd_kafka_resp_err_t)err));                           \
   }
@@ -49,18 +49,18 @@ void BrokerOpt::apply(rd_kafka_conf_t *conf) {
   std::vector<char> errstr(256);
   for (auto &c : conf_ints) {
     auto s1 = fmt::format("{:d}", c.second);
-    LOG(Sev::Dbg, "set config: {} = {}", c.first, s1);
+    LOG(Sev::Debug, "set config: {} = {}", c.first, s1);
     if (RD_KAFKA_CONF_OK != rd_kafka_conf_set(conf, c.first.c_str(), s1.c_str(),
                                               errstr.data(), errstr.size())) {
-      LOG(Sev::Warn, "error setting config: {} = {}", c.first, s1);
+      LOG(Sev::Warning, "error setting config: {} = {}", c.first, s1);
     }
   }
   for (auto &c : conf_strings) {
-    LOG(Sev::Dbg, "set config: {} = {}", c.first, c.second);
+    LOG(Sev::Debug, "set config: {} = {}", c.first, c.second);
     if (RD_KAFKA_CONF_OK != rd_kafka_conf_set(conf, c.first.c_str(),
                                               c.second.c_str(), errstr.data(),
                                               errstr.size())) {
-      LOG(Sev::Warn, "error setting config: {} = {}", c.first, c.second);
+      LOG(Sev::Warning, "error setting config: {} = {}", c.first, c.second);
     }
   }
 }
@@ -71,19 +71,19 @@ void TopicOpt::apply(rd_kafka_topic_conf_t *conf) {
   std::vector<char> errstr(1024);
   for (auto &c : conf_ints) {
     auto s1 = fmt::format("{:d}", c.second);
-    LOG(Sev::Dbg, "use  {}: {}", c.first, s1);
+    LOG(Sev::Debug, "use  {}: {}", c.first, s1);
     if (RD_KAFKA_CONF_OK != rd_kafka_topic_conf_set(conf, c.first.c_str(),
                                                     s1.c_str(), errstr.data(),
                                                     errstr.size())) {
-      LOG(Sev::Warn, "error setting topic config: {} = {}", c.first, s1);
+      LOG(Sev::Warning, "error setting topic config: {} = {}", c.first, s1);
     }
   }
   for (auto &c : conf_strings) {
-    LOG(Sev::Dbg, "use  {}: {}", c.first, c.second);
+    LOG(Sev::Debug, "use  {}: {}", c.first, c.second);
     if (RD_KAFKA_CONF_OK !=
         rd_kafka_topic_conf_set(conf, c.first.c_str(), c.second.c_str(),
                                 errstr.data(), errstr.size())) {
-      LOG(Sev::Warn, "error setting topic config: {} = {}", c.first, c.second);
+      LOG(Sev::Warning, "error setting topic config: {} = {}", c.first, c.second);
     }
   }
 }
@@ -180,26 +180,26 @@ Consumer::Consumer(BrokerOpt opt) : opt(opt) {
 }
 
 Consumer::~Consumer() {
-  LOG(Sev::Dbg, "~Consumer()");
+  LOG(Sev::Debug, "~Consumer()");
   if (rk) {
     // commit offsets?
     if (0) {
-      LOG(Sev::Dbg, "rd_kafka_unsubscribe");
+      LOG(Sev::Debug, "rd_kafka_unsubscribe");
       rd_kafka_unsubscribe(rk);
     }
     if (0) {
-      LOG(Sev::Dbg, "rd_kafka_poll");
+      LOG(Sev::Debug, "rd_kafka_poll");
       int n1 = rd_kafka_poll(rk, 100);
-      LOG(Sev::Dbg, "  served {} reuests", n1);
+      LOG(Sev::Debug, "  served {} reuests", n1);
     }
     if (1) {
-      LOG(Sev::Dbg, "rd_kafka_consumer_close");
+      LOG(Sev::Debug, "rd_kafka_consumer_close");
       rd_kafka_consumer_close(rk);
     }
     // rd_kafka_consume_stop(rd_kafka_topic_t *, partition)  therefore low-level
     // API?
     if (1) {
-      LOG(Sev::Dbg, "rd_kafka_destroy");
+      LOG(Sev::Debug, "rd_kafka_destroy");
       rd_kafka_destroy(rk);
       rk = nullptr;
     }
@@ -220,9 +220,9 @@ void Consumer::cb_error(rd_kafka_t *rk, int err_i, char const *msg,
                         void *opaque) {
   auto self = reinterpret_cast<Consumer *>(opaque);
   rd_kafka_resp_err_t err = (rd_kafka_resp_err_t)err_i;
-  Sev ll = Sev::Dbg;
+  Sev ll = Sev::Debug;
   if (err == RD_KAFKA_RESP_ERR__TRANSPORT) {
-    ll = Sev::Warn;
+    ll = Sev::Warning;
     // rd_kafka_dump(stdout, rk);
   }
   LOG(ll, "Kafka cb_error id: {}  broker: {}  errno: {}  errorname: {}  "
@@ -233,7 +233,7 @@ void Consumer::cb_error(rd_kafka_t *rk, int err_i, char const *msg,
 
 int Consumer::cb_stats(rd_kafka_t *rk, char *json, size_t json_size,
                        void *opaque) {
-  LOG(Sev::Dbg, "INFO stats_cb {}  {:.{}}", json_size, json, json_size);
+  LOG(Sev::Debug, "INFO stats_cb {}  {:.{}}", json_size, json, json_size);
   // What does Kafka want us to return from this callback?
   return 0;
 }
@@ -241,7 +241,7 @@ int Consumer::cb_stats(rd_kafka_t *rk, char *json, size_t json_size,
 static void print_partition_list(rd_kafka_topic_partition_list_t *plist) {
   for (int i1 = 0; i1 < plist->cnt; ++i1) {
     auto &x = plist->elems[i1];
-    LOG(Sev::Dbg, "   {}  {}  {}", x.topic, x.partition, x.offset);
+    LOG(Sev::Debug, "   {}  {}  {}", x.topic, x.partition, x.offset);
   }
 }
 
@@ -252,14 +252,14 @@ void Consumer::cb_rebalance(rd_kafka_t *rk, rd_kafka_resp_err_t err,
   auto self = static_cast<Consumer *>(opaque);
   switch (err) {
   case RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS:
-    LOG(Sev::Dbg, "cb_rebalance assign {}", rd_kafka_name(rk));
+    LOG(Sev::Debug, "cb_rebalance assign {}", rd_kafka_name(rk));
     if (auto &cb = self->on_rebalance_start) {
       cb(plist);
     }
     print_partition_list(plist);
     err2 = rd_kafka_assign(rk, plist);
     if (err2 != RD_KAFKA_RESP_ERR_NO_ERROR) {
-      LOG(Sev::Note, "rebalance error: {}  {}", rd_kafka_err2name(err2),
+      LOG(Sev::Notice, "rebalance error: {}  {}", rd_kafka_err2name(err2),
           rd_kafka_err2str(err2));
     }
     if (auto &cb = self->on_rebalance_assign) {
@@ -267,11 +267,11 @@ void Consumer::cb_rebalance(rd_kafka_t *rk, rd_kafka_resp_err_t err,
     }
     break;
   case RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS:
-    LOG(Sev::Warn, "cb_rebalance revoke:");
+    LOG(Sev::Warning, "cb_rebalance revoke:");
     print_partition_list(plist);
     err2 = rd_kafka_assign(rk, NULL);
     if (err2 != RD_KAFKA_RESP_ERR_NO_ERROR) {
-      LOG(Sev::Warn, "rebalance error: {}  {}", rd_kafka_err2name(err2),
+      LOG(Sev::Warning, "rebalance error: {}  {}", rd_kafka_err2name(err2),
           rd_kafka_err2str(err2));
     }
     break;
@@ -279,7 +279,7 @@ void Consumer::cb_rebalance(rd_kafka_t *rk, rd_kafka_resp_err_t err,
     LOG(Sev::Info, "cb_rebalance failure and revoke: {}", rd_kafka_err2str(err));
     err2 = rd_kafka_assign(rk, NULL);
     if (err2 != RD_KAFKA_RESP_ERR_NO_ERROR) {
-      LOG(Sev::Warn, "rebalance error: {}  {}", rd_kafka_err2name(err2),
+      LOG(Sev::Warning, "rebalance error: {}  {}", rd_kafka_err2name(err2),
           rd_kafka_err2str(err2));
     }
     break;
@@ -303,7 +303,7 @@ void Consumer::init() {
 
   rk = rd_kafka_new(RD_KAFKA_CONSUMER, conf, errstr, errstr_N);
   if (!rk) {
-    LOG(Sev::Err, "can not create kafka handle: {}", errstr);
+    LOG(Sev::Error, "can not create kafka handle: {}", errstr);
     throw std::runtime_error("can not create Kafka handle");
   }
 
@@ -312,7 +312,7 @@ void Consumer::init() {
   LOG(Sev::Info, "New Kafka consumer {} with brokers: {}", rd_kafka_name(rk),
       opt.address.c_str());
   if (rd_kafka_brokers_add(rk, opt.address.c_str()) == 0) {
-    LOG(Sev::Err, "could not add brokers");
+    LOG(Sev::Error, "could not add brokers");
     throw std::runtime_error("could not add brokers");
   }
 
@@ -329,7 +329,7 @@ void Consumer::add_topic(std::string topic) {
   int err = rd_kafka_subscribe(rk, plist);
   KERR(rk, err);
   if (err) {
-    LOG(Sev::Err, "could not subscribe");
+    LOG(Sev::Error, "could not subscribe");
     throw std::runtime_error("can not subscribe");
   }
 }
@@ -370,14 +370,14 @@ PollStatus Consumer::poll() {
     // Just an advisory.  msg contains which partition it is.
     return PollStatus::EOP();
   } else if (msg->err == RD_KAFKA_RESP_ERR__ALL_BROKERS_DOWN) {
-    LOG(Sev::Err, "RD_KAFKA_RESP_ERR__ALL_BROKERS_DOWN");
+    LOG(Sev::Error, "RD_KAFKA_RESP_ERR__ALL_BROKERS_DOWN");
   } else if (msg->err == RD_KAFKA_RESP_ERR__BAD_MSG) {
-    LOG(Sev::Err, "RD_KAFKA_RESP_ERR__BAD_MSG");
+    LOG(Sev::Error, "RD_KAFKA_RESP_ERR__BAD_MSG");
   } else if (msg->err == RD_KAFKA_RESP_ERR__DESTROY) {
-    LOG(Sev::Err, "RD_KAFKA_RESP_ERR__DESTROY");
+    LOG(Sev::Error, "RD_KAFKA_RESP_ERR__DESTROY");
     // Broker will go away soon
   } else {
-    LOG(Sev::Err, "unhandled msg error: {} {}", rd_kafka_err2name(msg->err),
+    LOG(Sev::Error, "unhandled msg error: {} {}", rd_kafka_err2name(msg->err),
         rd_kafka_err2str(msg->err));
   }
   return PollStatus::Err();
@@ -387,12 +387,12 @@ void Producer::cb_delivered(rd_kafka_t *rk, rd_kafka_message_t const *msg,
                             void *opaque) {
   auto self = reinterpret_cast<Producer *>(opaque);
   if (!msg) {
-    LOG(Sev::Err, "IID: {}  ERROR msg should never be null", self->id);
+    LOG(Sev::Error, "IID: {}  ERROR msg should never be null", self->id);
     ++self->stats.produce_cb_fail;
     return;
   }
   if (msg->err) {
-    LOG(Sev::Err, "IID: {}  ERROR on delivery, {}, topic {}, {} [{}] {}", self->id,
+    LOG(Sev::Error, "IID: {}  ERROR on delivery, {}, topic {}, {} [{}] {}", self->id,
         rd_kafka_name(rk), rd_kafka_topic_name(msg->rkt),
         rd_kafka_err2name(msg->err), msg->err, rd_kafka_err2str(msg->err));
     if (msg->err == RD_KAFKA_RESP_ERR__MSG_TIMED_OUT) {
@@ -407,7 +407,7 @@ void Producer::cb_delivered(rd_kafka_t *rk, rd_kafka_message_t const *msg,
       cb(msg);
     }
     if (false) {
-      LOG(Sev::Dbg, "IID: {}  Ok delivered ({}, p {}, offset {}, len {})", self->id,
+      LOG(Sev::Debug, "IID: {}  Ok delivered ({}, p {}, offset {}, len {})", self->id,
           rd_kafka_name(rk), msg->partition, msg->offset, msg->len);
     }
     ++self->stats.produce_cb;
@@ -418,9 +418,9 @@ void Producer::cb_error(rd_kafka_t *rk, int err_i, char const *msg,
                         void *opaque) {
   auto self = reinterpret_cast<Producer *>(opaque);
   rd_kafka_resp_err_t err = (rd_kafka_resp_err_t)err_i;
-  Sev ll = Sev::Warn;
+  Sev ll = Sev::Warning;
   if (err == RD_KAFKA_RESP_ERR__TRANSPORT) {
-    ll = Sev::Err;
+    ll = Sev::Error;
     // rd_kafka_dump(stdout, rk);
   } else {
     if (self->on_error)
@@ -435,7 +435,7 @@ void Producer::cb_error(rd_kafka_t *rk, int err_i, char const *msg,
 int Producer::cb_stats(rd_kafka_t *rk, char *json, size_t json_len,
                        void *opaque) {
   auto self = reinterpret_cast<Producer *>(opaque);
-  LOG(Sev::Dbg, "IID: {}  INFO cb_stats {} length {}   {:.{}}", self->id,
+  LOG(Sev::Debug, "IID: {}  INFO cb_stats {} length {}   {:.{}}", self->id,
       rd_kafka_name(rk), json_len, json, json_len);
   // What does librdkafka want us to return from this callback?
   return 0;
@@ -444,20 +444,20 @@ int Producer::cb_stats(rd_kafka_t *rk, char *json, size_t json_len,
 void Producer::cb_log(rd_kafka_t const *rk, int level, char const *fac,
                       char const *buf) {
   auto self = reinterpret_cast<Producer *>(rd_kafka_opaque(rk));
-  LOG(Sev::Dbg, "IID: {}  {}  fac: {}", self->id, buf, fac);
+  LOG(Sev::Debug, "IID: {}  {}  fac: {}", self->id, buf, fac);
 }
 
 void Producer::cb_throttle(rd_kafka_t *rk, char const *broker_name,
                            int32_t broker_id, int throttle_time_ms,
                            void *opaque) {
   auto self = reinterpret_cast<Producer *>(opaque);
-  LOG(Sev::Dbg, "IID: {}  INFO cb_throttle  broker_id: {}  broker_name: {}  "
+  LOG(Sev::Debug, "IID: {}  INFO cb_throttle  broker_id: {}  broker_name: {}  "
          "throttle_time_ms: {}",
       self->id, broker_id, broker_name, throttle_time_ms);
 }
 
 Producer::~Producer() {
-  LOG(Sev::Dbg, "~Producer");
+  LOG(Sev::Debug, "~Producer");
   if (rk) {
     int timeout_ms = 1;
     uint32_t outq_len = 0;
@@ -468,7 +468,7 @@ Producer::~Producer() {
       }
       auto events_handled = rd_kafka_poll(rk, timeout_ms);
       if (events_handled > 0) {
-        LOG(Sev::Dbg, "rd_kafka_poll handled: {}  outq before: {}  timeout: {}",
+        LOG(Sev::Debug, "rd_kafka_poll handled: {}  outq before: {}  timeout: {}",
             events_handled, outq_len, timeout_ms);
       }
       timeout_ms = timeout_ms << 1;
@@ -477,10 +477,10 @@ Producer::~Producer() {
       }
     }
     if (outq_len > 0) {
-      LOG(Sev::Note, "Kafka out queue still not empty: {}  destroy producer anyway.",
+      LOG(Sev::Notice, "Kafka out queue still not empty: {}  destroy producer anyway.",
           outq_len);
     }
-    LOG(Sev::Dbg, "rd_kafka_destroy");
+    LOG(Sev::Debug, "rd_kafka_destroy");
     rd_kafka_destroy(rk);
     rk = nullptr;
   }
@@ -502,13 +502,13 @@ Producer::Producer(BrokerOpt opt) : opt(opt) {
   rd_kafka_conf_set_throttle_cb(conf, Producer::cb_throttle);
 
   rd_kafka_conf_set_opaque(conf, this);
-  LOG(Sev::Dbg, "Producer opaque: {}", (void *)this);
+  LOG(Sev::Debug, "Producer opaque: {}", (void *)this);
 
   opt.apply(conf);
 
   rk = rd_kafka_new(RD_KAFKA_PRODUCER, conf, errstr.data(), errstr.size());
   if (!rk) {
-    LOG(Sev::Err, "can not create kafka handle: {}", errstr.data());
+    LOG(Sev::Error, "can not create kafka handle: {}", errstr.data());
     throw std::runtime_error("can not create Kafka handle");
   }
 
@@ -517,7 +517,7 @@ Producer::Producer(BrokerOpt opt) : opt(opt) {
   LOG(Sev::Info, "New Kafka {} with brokers: {}", rd_kafka_name(rk),
       opt.address.c_str());
   if (rd_kafka_brokers_add(rk, opt.address.c_str()) == 0) {
-    LOG(Sev::Err, "could not add brokers");
+    LOG(Sev::Error, "could not add brokers");
     throw std::runtime_error("could not add brokers");
   }
 }
@@ -534,7 +534,7 @@ Producer::Producer(Producer &&x) {
 
 void Producer::poll() {
   int events_handled = rd_kafka_poll(rk, opt.poll_timeout_ms);
-  LOG(Sev::Dbg, "IID: {}  broker: {}  rd_kafka_poll()  served: {}  outq_len: {}",
+  LOG(Sev::Debug, "IID: {}  broker: {}  rd_kafka_poll()  served: {}  outq_len: {}",
       id, opt.address, events_handled, outq());
   if (log_level >= 8) {
     rd_kafka_dump(stdout, rk);
@@ -570,9 +570,9 @@ ProducerStats::ProducerStats(ProducerStats const &x) {
 }
 
 ProducerTopic::~ProducerTopic() {
-  LOG(Sev::Dbg, "~ProducerTopic {}", _name);
+  LOG(Sev::Debug, "~ProducerTopic {}", _name);
   if (rkt) {
-    LOG(Sev::Dbg, "rd_kafka_topic_destroy");
+    LOG(Sev::Debug, "rd_kafka_topic_destroy");
     rd_kafka_topic_destroy(rkt);
     rkt = nullptr;
   }
@@ -594,10 +594,10 @@ ProducerTopic::ProducerTopic(std::shared_ptr<Producer> producer,
   if (rkt == nullptr) {
     // Seems like Kafka uses the system error code?
     auto errstr = rd_kafka_err2str(rd_kafka_errno2err(errno));
-    LOG(Sev::Err, "could not create Kafka topic: {}", errstr);
+    LOG(Sev::Error, "could not create Kafka topic: {}", errstr);
     throw std::exception();
   }
-  LOG(Sev::Dbg, "ctor topic: {}  producer: {}", rd_kafka_topic_name(rkt),
+  LOG(Sev::Debug, "ctor topic: {}  producer: {}", rd_kafka_topic_name(rkt),
       rd_kafka_name(producer->rd_kafka_ptr()));
 }
 
@@ -643,18 +643,18 @@ int ProducerTopic::produce(unique_ptr<Producer::Msg> &msg) {
     if (err == RD_KAFKA_RESP_ERR__QUEUE_FULL) {
       ++s.local_queue_full;
       if (print_err) {
-        LOG(Sev::Warn, "QUEUE_FULL  outq: {}",
+        LOG(Sev::Warning, "QUEUE_FULL  outq: {}",
             rd_kafka_outq_len(producer->rd_kafka_ptr()));
       }
     } else if (err == RD_KAFKA_RESP_ERR_MSG_SIZE_TOO_LARGE) {
       ++s.msg_too_large;
       if (print_err) {
-        LOG(Sev::Err, "TOO_LARGE  size: {}", msg->size);
+        LOG(Sev::Error, "TOO_LARGE  size: {}", msg->size);
       }
     } else {
       ++s.produce_fail;
       if (print_err) {
-        LOG(Sev::Dbg, "produce topic {}  partition {}   error: {}  {}",
+        LOG(Sev::Debug, "produce topic {}  partition {}   error: {}  {}",
             rd_kafka_topic_name(rkt), partition, x, rd_kafka_err2str(err));
       }
     }
@@ -663,7 +663,7 @@ int ProducerTopic::produce(unique_ptr<Producer::Msg> &msg) {
     s.produced_bytes += (uint64_t)msg->size;
     ++producer->total_produced_;
     if (log_level >= 8) {
-      LOG(Sev::Dbg, "sent to topic {} partition {}", rd_kafka_topic_name(rkt),
+      LOG(Sev::Debug, "sent to topic {} partition {}", rd_kafka_topic_name(rkt),
           partition);
     }
     msg.release();

--- a/src/KafkaW.h
+++ b/src/KafkaW.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include "logger.h"
 
 namespace KafkaW {
 // Want to expose this typedef also for users of this namespace

--- a/src/MainOpt.cxx
+++ b/src/MainOpt.cxx
@@ -12,7 +12,7 @@ using uri::URI;
 
 int MainOpt::parse_config_file(std::string fname) {
   if (fname.empty()) {
-    LOG(Sev::Note, "given config filename is empty");
+    LOG(Sev::Notice, "given config filename is empty");
     return -1;
   }
   auto jsontxt = gulp(fname);
@@ -27,7 +27,7 @@ int MainOpt::parse_config_json(std::string json) {
   auto &d = config_file;
   d.Parse(json.data(), json.size());
   if (d.HasParseError()) {
-    LOG(Sev::Note, "configuration is not well formed");
+    LOG(Sev::Notice, "configuration is not well formed");
     return -5;
   }
   {
@@ -150,7 +150,7 @@ std::pair<int, std::unique_ptr<MainOpt>> parse_opt(int argc, char **argv) {
   }
 
   if (getopt_error) {
-    LOG(Sev::Note, "ERROR parsing command line options");
+    LOG(Sev::Notice, "ERROR parsing command line options");
     opt->help = true;
     ret.first = 1;
   }
@@ -162,7 +162,7 @@ void setup_logger_from_options(MainOpt const &opt) {
   if (opt.kafka_gelf != "") {
     URI uri(opt.kafka_gelf);
     log_kafka_gelf_start(uri.host, uri.topic);
-    LOG(Sev::Dbg, "Enabled kafka_gelf: //{}/{}", uri.host, uri.topic);
+    LOG(Sev::Debug, "Enabled kafka_gelf: //{}/{}", uri.host, uri.topic);
   }
 
   if (opt.graylog_logger_address != "") {

--- a/src/MainOpt.h
+++ b/src/MainOpt.h
@@ -20,7 +20,6 @@ class Master;
 // POD
 struct MainOpt {
   bool help = false;
-  bool verbose = false;
   bool gtest = false;
   bool use_signal_handler = true;
   /// Kafka options, they get parsed from the configuration file and passed on

--- a/src/Master.cxx
+++ b/src/Master.cxx
@@ -56,10 +56,10 @@ void Master::run() {
   using Clock = std::chrono::steady_clock;
   auto t_last_statistics = Clock::now();
   while (do_run) {
-    LOG(Sev::Dbg, "Master poll");
+    LOG(Sev::Debug, "Master poll");
     auto p = command_listener.poll();
     if (auto msg = p.is_Msg()) {
-      LOG(Sev::Dbg, "Handle a command");
+      LOG(Sev::Debug, "Handle a command");
       this->handle_command_message(std::move(msg));
     }
     if (config.do_kafka_status &&

--- a/src/Report.hpp
+++ b/src/Report.hpp
@@ -48,7 +48,7 @@ private:
   SMEC produce_single_report(S &streamer,
                              std::atomic<SMEC> &stream_master_status) {
     if (!report_producer_) {
-      LOG(Sev::Err, "ProucerTopic error: can't produce StreamMaster status report");
+      LOG(Sev::Error, "ProucerTopic error: can't produce StreamMaster status report");
       return SMEC::report_failure;
     }
 

--- a/src/Report.hpp
+++ b/src/Report.hpp
@@ -48,7 +48,7 @@ private:
   SMEC produce_single_report(S &streamer,
                              std::atomic<SMEC> &stream_master_status) {
     if (!report_producer_) {
-      LOG(1, "ProucerTopic error: can't produce StreamMaster status report");
+      LOG(Sev::Err, "ProucerTopic error: can't produce StreamMaster status report");
       return SMEC::report_failure;
     }
 

--- a/src/Source.cxx
+++ b/src/Source.cxx
@@ -28,7 +28,7 @@ ProcessMessageResult Source::process_message(Msg const &msg) {
   }
   auto &reader = FlatbufferReaderRegistry::find(msg);
   if (!reader->verify(msg)) {
-    LOG(Sev::Err, "buffer not verified");
+    LOG(Sev::Error, "buffer not verified");
     return ProcessMessageResult::ERR();
   }
   auto ret = _hdf_writer_module->write(msg);

--- a/src/Source.cxx
+++ b/src/Source.cxx
@@ -28,7 +28,7 @@ ProcessMessageResult Source::process_message(Msg const &msg) {
   }
   auto &reader = FlatbufferReaderRegistry::find(msg);
   if (!reader->verify(msg)) {
-    LOG(5, "buffer not verified");
+    LOG(Sev::Err, "buffer not verified");
     return ProcessMessageResult::ERR();
   }
   auto ret = _hdf_writer_module->write(msg);

--- a/src/StreamMaster.hpp
+++ b/src/StreamMaster.hpp
@@ -80,7 +80,7 @@ public:
   }
 
   bool start() {
-    LOG(7, "StreamMaster: start");
+    LOG(Sev::Info, "StreamMaster: start");
     do_write = true;
     stop_ = false;
 
@@ -96,7 +96,7 @@ public:
       std::call_once(stop_once_guard,
                      &FileWriter::StreamMaster<Streamer>::stop_impl, this);
     } catch (std::exception &e) {
-      LOG(0, "Error while stopping: {}", e.what());
+      LOG(Sev::Warn, "Error while stopping: {}", e.what());
     }
     return !(loop.joinable() || report_thread_.joinable());
   }
@@ -111,7 +111,7 @@ public:
   void report(std::shared_ptr<KafkaW::ProducerTopic> p,
               const int &delay = 1000) {
     if (delay < 0) {
-      LOG(2, "Required negative delay in statistics collection: use default");
+      LOG(Sev::Warn, "Required negative delay in statistics collection: use default");
       return report(p);
     }
     if (!report_thread_.joinable()) {
@@ -119,7 +119,7 @@ public:
       report_thread_ =
           std::thread([&] { report_->report(streamer, stop_, runstatus); });
     } else {
-      LOG(5, "Status report already started, nothing to do");
+      LOG(Sev::Dbg, "Status report already started, nothing to do");
     }
   }
 
@@ -168,7 +168,7 @@ private:
           continue;
         }
         if (int(s.runstatus()) < 0) {
-          LOG(0, "Error in topic {} : {}", d.topic(), int(s.runstatus()));
+          LOG(Sev::Err, "Error in topic {} : {}", d.topic(), int(s.runstatus()));
           if (remove_source(d.topic()) != SMEC::running) {
             break;
           }
@@ -186,7 +186,7 @@ private:
       s.n_sources()--;
       return SMEC::running;
     } else {
-      LOG(3, "All sources in {} have expired, remove streamer", topic);
+      LOG(Sev::Dbg, "All sources in {} have expired, remove streamer", topic);
       s.close_stream();
       streamer.erase(topic);
       if (streamer.size() != 0) {
@@ -199,7 +199,7 @@ private:
   }
 
   void stop_impl() {
-    LOG(7, "StreamMaster: stop");
+    LOG(Sev::Info, "StreamMaster: stop");
     do_write = false;
     stop_ = true;
     if (loop.joinable()) {
@@ -209,12 +209,12 @@ private:
       report_thread_.join();
     }
     for (auto &s : streamer) {
-      LOG(7, "Shut down {} : {}", s.first);
+      LOG(Sev::Info, "Shut down {} : {}", s.first);
       auto v = s.second.close_stream();
       if (v != SEC::has_finished) {
-        LOG(1, "Error while stopping {} : {}", s.first, Status::Err2Str(v));
+        LOG(Sev::Warn, "Error while stopping {} : {}", s.first, Status::Err2Str(v));
       } else {
-        LOG(7, "\t...done");
+        LOG(Sev::Info, "\t...done");
       }
     }
     streamer.clear();

--- a/src/StreamMaster.hpp
+++ b/src/StreamMaster.hpp
@@ -96,7 +96,7 @@ public:
       std::call_once(stop_once_guard,
                      &FileWriter::StreamMaster<Streamer>::stop_impl, this);
     } catch (std::exception &e) {
-      LOG(Sev::Warn, "Error while stopping: {}", e.what());
+      LOG(Sev::Warning, "Error while stopping: {}", e.what());
     }
     return !(loop.joinable() || report_thread_.joinable());
   }
@@ -111,7 +111,7 @@ public:
   void report(std::shared_ptr<KafkaW::ProducerTopic> p,
               const int &delay = 1000) {
     if (delay < 0) {
-      LOG(Sev::Warn, "Required negative delay in statistics collection: use default");
+      LOG(Sev::Warning, "Required negative delay in statistics collection: use default");
       return report(p);
     }
     if (!report_thread_.joinable()) {
@@ -119,7 +119,7 @@ public:
       report_thread_ =
           std::thread([&] { report_->report(streamer, stop_, runstatus); });
     } else {
-      LOG(Sev::Dbg, "Status report already started, nothing to do");
+      LOG(Sev::Debug, "Status report already started, nothing to do");
     }
   }
 
@@ -168,7 +168,7 @@ private:
           continue;
         }
         if (int(s.runstatus()) < 0) {
-          LOG(Sev::Err, "Error in topic {} : {}", d.topic(), int(s.runstatus()));
+          LOG(Sev::Error, "Error in topic {} : {}", d.topic(), int(s.runstatus()));
           if (remove_source(d.topic()) != SMEC::running) {
             break;
           }
@@ -186,7 +186,7 @@ private:
       s.n_sources()--;
       return SMEC::running;
     } else {
-      LOG(Sev::Dbg, "All sources in {} have expired, remove streamer", topic);
+      LOG(Sev::Debug, "All sources in {} have expired, remove streamer", topic);
       s.close_stream();
       streamer.erase(topic);
       if (streamer.size() != 0) {
@@ -212,7 +212,7 @@ private:
       LOG(Sev::Info, "Shut down {} : {}", s.first);
       auto v = s.second.close_stream();
       if (v != SEC::has_finished) {
-        LOG(Sev::Warn, "Error while stopping {} : {}", s.first, Status::Err2Str(v));
+        LOG(Sev::Warning, "Error while stopping {} : {}", s.first, Status::Err2Str(v));
       } else {
         LOG(Sev::Info, "\t...done");
       }

--- a/src/Streamer.cxx
+++ b/src/Streamer.cxx
@@ -36,9 +36,9 @@ bool FileWriter::Streamer::set_conf_opt(
   std::string errstr;
   if (!(option.first.empty() || option.second.empty())) {
     auto result = conf->set(option.first, option.second, errstr);
-    LOG(5, "set kafka config: {} = {}", option.first, option.second);
+    LOG(Sev::Dbg, "set kafka config: {} = {}", option.first, option.second);
     if (result != RdKafka::Conf::CONF_OK) {
-      LOG(3, "Failed to initialise configuration: {}", errstr);
+      LOG(Sev::Err, "Failed to initialise configuration: {}", errstr);
       return false;
     }
   }
@@ -52,7 +52,7 @@ FileWriter::Streamer::get_metadata(const int &retry) {
   std::unique_ptr<RdKafka::Topic> ptopic;
   auto err = _consumer->metadata(ptopic.get() != NULL, ptopic.get(), &md, 1000);
   if (err != RdKafka::ERR_NO_ERROR) {
-    LOG(3, "Can't request metadata");
+    LOG(Sev::Err, "Can't request metadata");
     if (retry) {
       get_metadata(retry - 1);
     } else {
@@ -68,7 +68,7 @@ FileWriter::Streamer::SEC FileWriter::Streamer::get_topic_partitions(
     const std::string &topic, std::unique_ptr<RdKafka::Metadata> _metadata) {
   bool topic_found = false;
   if (!_metadata) {
-    LOG(3, "Missing metadata informations");
+    LOG(Sev::Err, "Missing metadata informations");
     return SEC::metadata_error;
   }
   auto partition_metadata = _metadata->topics()->at(0)->partitions();
@@ -79,7 +79,7 @@ FileWriter::Streamer::SEC FileWriter::Streamer::get_topic_partitions(
     }
   }
   if (!topic_found) {
-    LOG(3, "Can't find topic : {}", topic);
+    LOG(Sev::Err, "Can't find topic : {}", topic);
     return SEC::topic_error;
   }
   for (auto &i : (*partition_metadata)) {
@@ -94,7 +94,7 @@ FileWriter::Streamer::SEC FileWriter::Streamer::get_offset_boundaries() {
     auto err = _consumer->query_watermark_offsets(i->topic(), i->partition(),
                                                   &low, &high, 5000);
     if (err) {
-      LOG(1, "Unable to get boundaries for topic {}, partition {} : {}",
+      LOG(Sev::Err, "Unable to get boundaries for topic {}, partition {} : {}",
           i->topic(), i->partition(), RdKafka::err2str(err));
       return SEC::topic_partition_error;
     }
@@ -115,7 +115,7 @@ std::shared_ptr<RdKafka::Conf> FileWriter::Streamer::initialize_configuration(
                       kafka_options.end());
   if (!kafka_options.empty()) {
     for (auto &item : kafka_options) {
-      LOG(3, "Unknown option: {} [{}]", item.first, item.second);
+      LOG(Sev::Warn, "Unknown option: {} [{}]", item.first, item.second);
     }
   }
   return conf;
@@ -131,7 +131,7 @@ void FileWriter::Streamer::initialize_streamer(
                            filewriter_options.end());
   if (!filewriter_options.empty()) {
     for (auto &item : filewriter_options) {
-      LOG(3, "Unknown option: {} [{}]", item.first, item.second);
+      LOG(Sev::Warn, "Unknown option: {} [{}]", item.first, item.second);
     }
   }
 }
@@ -143,7 +143,7 @@ FileWriter::Streamer::Streamer(const std::string &broker,
     : run_status_{SEC::not_initialized} {
 
   if (topic_name.empty() || broker.empty()) {
-    LOG(0, "Broker and topic required");
+    LOG(Sev::Warn, "Broker and topic required");
     run_status_ = SEC::not_initialized;
     return;
   }
@@ -174,12 +174,12 @@ void FileWriter::Streamer::connect(
   initilialising_ = true;
   connection_init_.notify_all();
 
-  LOG(7, "Connecting to {}", topic_name);
+  LOG(Sev::Info, "Connecting to {}", topic_name);
   for (auto &i : filewriter_options) {
-    LOG(7, "{} :\t{}", i.first, i.second);
+    LOG(Sev::Dbg, "{} :\t{}", i.first, i.second);
   }
   for (auto &i : kafka_options) {
-    LOG(7, "{} :\t{}", i.first, i.second);
+    LOG(Sev::Dbg, "{} :\t{}", i.first, i.second);
   }
 
   // set streamer options
@@ -189,7 +189,7 @@ void FileWriter::Streamer::connect(
   // Initialize configuration and consumer
   auto conf = initialize_configuration(kafka_options);
   if (!conf) {
-    LOG(0, "Unable to initialize configuration ({})", topic_name);
+    LOG(Sev::Err, "Unable to initialize configuration ({})", topic_name);
     run_status_ = SEC::configuration_error;
     return;
   }
@@ -197,7 +197,7 @@ void FileWriter::Streamer::connect(
       RdKafka::KafkaConsumer::create(conf.get(), errstr);
   _consumer.reset(c);
   if (!_consumer) {
-    LOG(0, "Failed to create consumer: {}", errstr);
+    LOG(Sev::Err, "Failed to create consumer: {}", errstr);
     run_status_ = SEC::consumer_error;
     return;
   }
@@ -205,12 +205,12 @@ void FileWriter::Streamer::connect(
   // Retrieve informations
   std::unique_ptr<RdKafka::Metadata> metadata = get_metadata(metadata_retry);
   if (!metadata) {
-    LOG(1, "Unable to retrieve metadata");
+    LOG(Sev::Err, "Unable to retrieve metadata");
     run_status_ = SEC::metadata_error;
     return;
   }
   if (get_topic_partitions(topic_name, std::move(metadata)) != SEC::no_error) {
-    LOG(1, "Unable to build TopicPartitions structure");
+    LOG(Sev::Err, "Unable to build TopicPartitions structure");
     run_status_ = SEC::topic_partition_error;
     return;
   }
@@ -220,7 +220,7 @@ void FileWriter::Streamer::connect(
   }
   auto err = _consumer->assign(_tp);
   if (err) {
-    LOG(0, "Failed to subscribe to {} ", topic_name);
+    LOG(Sev::Warn, "Failed to subscribe to {} ", topic_name);
     run_status_ = SEC::assign_error;
     return;
   }
@@ -230,7 +230,7 @@ void FileWriter::Streamer::connect(
     return;
   }
 
-  LOG(7, "Connected to topic {}", topic_name);
+  LOG(Sev::Dbg, "Connected to topic {}", topic_name);
   run_status_ = SEC::writing;
 }
 
@@ -271,11 +271,11 @@ FileWriter::Streamer::write(FileWriter::DemuxTopic &mp) {
 
   if (msg->err() == RdKafka::ERR__PARTITION_EOF ||
       msg->err() == RdKafka::ERR__TIMED_OUT) {
-    LOG(5, "consume :\t{}", RdKafka::err2str(msg->err()));
+    LOG(Sev::Dbg, "consume :\t{}", RdKafka::err2str(msg->err()));
     return ProcessMessageResult::OK();
   }
   if (msg->err() != RdKafka::ERR_NO_ERROR) {
-    LOG(5, "Failed to consume :\t{}", RdKafka::err2str(msg->err()));
+    LOG(Sev::Warn, "Failed to consume :\t{}", RdKafka::err2str(msg->err()));
     message_info_.error();
     return ProcessMessageResult::ERR();
   }
@@ -284,7 +284,7 @@ FileWriter::Streamer::write(FileWriter::DemuxTopic &mp) {
   _offset = RdKafkaOffset(msg->offset());
 
   auto result = mp.process_message((char *)msg->payload(), msg->len());
-  LOG(6, "{} : Message timestamp : {}", _tp[0]->topic(), result.ts());
+  LOG(Sev::Dbg, "{} : Message timestamp : {}", _tp[0]->topic(), result.ts());
   if (!result.is_OK()) {
     message_info_.error();
   }
@@ -304,9 +304,9 @@ FileWriter::Streamer::set_start_time(const ESSTimeStamp &timepoint) {
   auto err = _consumer->offsetsForTimes(_tp, 1000);
   if (err != RdKafka::ERR_NO_ERROR) {
     run_status_ = SEC::start_time_error;
-    LOG(3, "Error searching initial time: {}", err2str(err));
+    LOG(Sev::Err, "Error searching initial time: {}", err2str(err));
     for (auto &i : _tp) {
-      LOG(3, "TopicPartition {}-{} : {}", i->topic(), i->partition(),
+      LOG(Sev::Err, "TopicPartition {}-{} : {}", i->topic(), i->partition(),
           RdKafka::err2str(i->err()));
     }
     run_status_ = SEC::start_time_error;
@@ -320,7 +320,7 @@ FileWriter::Streamer::set_start_time(const ESSTimeStamp &timepoint) {
   }
   err = _consumer->assign(_tp);
   if (err != RdKafka::ERR_NO_ERROR) {
-    LOG(3, "Error assigning initial time: {}", err2str(err));
+    LOG(Sev::Err, "Error assigning initial time: {}", err2str(err));
     run_status_ = SEC::start_time_error;
     return SEC::start_time_error;
   }

--- a/src/Streamer.cxx
+++ b/src/Streamer.cxx
@@ -36,9 +36,9 @@ bool FileWriter::Streamer::set_conf_opt(
   std::string errstr;
   if (!(option.first.empty() || option.second.empty())) {
     auto result = conf->set(option.first, option.second, errstr);
-    LOG(Sev::Dbg, "set kafka config: {} = {}", option.first, option.second);
+    LOG(Sev::Debug, "set kafka config: {} = {}", option.first, option.second);
     if (result != RdKafka::Conf::CONF_OK) {
-      LOG(Sev::Err, "Failed to initialise configuration: {}", errstr);
+      LOG(Sev::Error, "Failed to initialise configuration: {}", errstr);
       return false;
     }
   }
@@ -52,7 +52,7 @@ FileWriter::Streamer::get_metadata(const int &retry) {
   std::unique_ptr<RdKafka::Topic> ptopic;
   auto err = _consumer->metadata(ptopic.get() != NULL, ptopic.get(), &md, 1000);
   if (err != RdKafka::ERR_NO_ERROR) {
-    LOG(Sev::Err, "Can't request metadata");
+    LOG(Sev::Error, "Can't request metadata");
     if (retry) {
       get_metadata(retry - 1);
     } else {
@@ -68,7 +68,7 @@ FileWriter::Streamer::SEC FileWriter::Streamer::get_topic_partitions(
     const std::string &topic, std::unique_ptr<RdKafka::Metadata> _metadata) {
   bool topic_found = false;
   if (!_metadata) {
-    LOG(Sev::Err, "Missing metadata informations");
+    LOG(Sev::Error, "Missing metadata informations");
     return SEC::metadata_error;
   }
   auto partition_metadata = _metadata->topics()->at(0)->partitions();
@@ -79,7 +79,7 @@ FileWriter::Streamer::SEC FileWriter::Streamer::get_topic_partitions(
     }
   }
   if (!topic_found) {
-    LOG(Sev::Err, "Can't find topic : {}", topic);
+    LOG(Sev::Error, "Can't find topic : {}", topic);
     return SEC::topic_error;
   }
   for (auto &i : (*partition_metadata)) {
@@ -94,7 +94,7 @@ FileWriter::Streamer::SEC FileWriter::Streamer::get_offset_boundaries() {
     auto err = _consumer->query_watermark_offsets(i->topic(), i->partition(),
                                                   &low, &high, 5000);
     if (err) {
-      LOG(Sev::Err, "Unable to get boundaries for topic {}, partition {} : {}",
+      LOG(Sev::Error, "Unable to get boundaries for topic {}, partition {} : {}",
           i->topic(), i->partition(), RdKafka::err2str(err));
       return SEC::topic_partition_error;
     }
@@ -115,7 +115,7 @@ std::shared_ptr<RdKafka::Conf> FileWriter::Streamer::initialize_configuration(
                       kafka_options.end());
   if (!kafka_options.empty()) {
     for (auto &item : kafka_options) {
-      LOG(Sev::Warn, "Unknown option: {} [{}]", item.first, item.second);
+      LOG(Sev::Warning, "Unknown option: {} [{}]", item.first, item.second);
     }
   }
   return conf;
@@ -131,7 +131,7 @@ void FileWriter::Streamer::initialize_streamer(
                            filewriter_options.end());
   if (!filewriter_options.empty()) {
     for (auto &item : filewriter_options) {
-      LOG(Sev::Warn, "Unknown option: {} [{}]", item.first, item.second);
+      LOG(Sev::Warning, "Unknown option: {} [{}]", item.first, item.second);
     }
   }
 }
@@ -143,7 +143,7 @@ FileWriter::Streamer::Streamer(const std::string &broker,
     : run_status_{SEC::not_initialized} {
 
   if (topic_name.empty() || broker.empty()) {
-    LOG(Sev::Warn, "Broker and topic required");
+    LOG(Sev::Warning, "Broker and topic required");
     run_status_ = SEC::not_initialized;
     return;
   }
@@ -176,10 +176,10 @@ void FileWriter::Streamer::connect(
 
   LOG(Sev::Info, "Connecting to {}", topic_name);
   for (auto &i : filewriter_options) {
-    LOG(Sev::Dbg, "{} :\t{}", i.first, i.second);
+    LOG(Sev::Debug, "{} :\t{}", i.first, i.second);
   }
   for (auto &i : kafka_options) {
-    LOG(Sev::Dbg, "{} :\t{}", i.first, i.second);
+    LOG(Sev::Debug, "{} :\t{}", i.first, i.second);
   }
 
   // set streamer options
@@ -189,7 +189,7 @@ void FileWriter::Streamer::connect(
   // Initialize configuration and consumer
   auto conf = initialize_configuration(kafka_options);
   if (!conf) {
-    LOG(Sev::Err, "Unable to initialize configuration ({})", topic_name);
+    LOG(Sev::Error, "Unable to initialize configuration ({})", topic_name);
     run_status_ = SEC::configuration_error;
     return;
   }
@@ -197,7 +197,7 @@ void FileWriter::Streamer::connect(
       RdKafka::KafkaConsumer::create(conf.get(), errstr);
   _consumer.reset(c);
   if (!_consumer) {
-    LOG(Sev::Err, "Failed to create consumer: {}", errstr);
+    LOG(Sev::Error, "Failed to create consumer: {}", errstr);
     run_status_ = SEC::consumer_error;
     return;
   }
@@ -205,12 +205,12 @@ void FileWriter::Streamer::connect(
   // Retrieve informations
   std::unique_ptr<RdKafka::Metadata> metadata = get_metadata(metadata_retry);
   if (!metadata) {
-    LOG(Sev::Err, "Unable to retrieve metadata");
+    LOG(Sev::Error, "Unable to retrieve metadata");
     run_status_ = SEC::metadata_error;
     return;
   }
   if (get_topic_partitions(topic_name, std::move(metadata)) != SEC::no_error) {
-    LOG(Sev::Err, "Unable to build TopicPartitions structure");
+    LOG(Sev::Error, "Unable to build TopicPartitions structure");
     run_status_ = SEC::topic_partition_error;
     return;
   }
@@ -220,7 +220,7 @@ void FileWriter::Streamer::connect(
   }
   auto err = _consumer->assign(_tp);
   if (err) {
-    LOG(Sev::Warn, "Failed to subscribe to {} ", topic_name);
+    LOG(Sev::Warning, "Failed to subscribe to {} ", topic_name);
     run_status_ = SEC::assign_error;
     return;
   }
@@ -230,7 +230,7 @@ void FileWriter::Streamer::connect(
     return;
   }
 
-  LOG(Sev::Dbg, "Connected to topic {}", topic_name);
+  LOG(Sev::Debug, "Connected to topic {}", topic_name);
   run_status_ = SEC::writing;
 }
 
@@ -271,11 +271,11 @@ FileWriter::Streamer::write(FileWriter::DemuxTopic &mp) {
 
   if (msg->err() == RdKafka::ERR__PARTITION_EOF ||
       msg->err() == RdKafka::ERR__TIMED_OUT) {
-    LOG(Sev::Dbg, "consume :\t{}", RdKafka::err2str(msg->err()));
+    LOG(Sev::Debug, "consume :\t{}", RdKafka::err2str(msg->err()));
     return ProcessMessageResult::OK();
   }
   if (msg->err() != RdKafka::ERR_NO_ERROR) {
-    LOG(Sev::Warn, "Failed to consume :\t{}", RdKafka::err2str(msg->err()));
+    LOG(Sev::Warning, "Failed to consume :\t{}", RdKafka::err2str(msg->err()));
     message_info_.error();
     return ProcessMessageResult::ERR();
   }
@@ -284,7 +284,7 @@ FileWriter::Streamer::write(FileWriter::DemuxTopic &mp) {
   _offset = RdKafkaOffset(msg->offset());
 
   auto result = mp.process_message((char *)msg->payload(), msg->len());
-  LOG(Sev::Dbg, "{} : Message timestamp : {}", _tp[0]->topic(), result.ts());
+  LOG(Sev::Debug, "{} : Message timestamp : {}", _tp[0]->topic(), result.ts());
   if (!result.is_OK()) {
     message_info_.error();
   }
@@ -304,9 +304,9 @@ FileWriter::Streamer::set_start_time(const ESSTimeStamp &timepoint) {
   auto err = _consumer->offsetsForTimes(_tp, 1000);
   if (err != RdKafka::ERR_NO_ERROR) {
     run_status_ = SEC::start_time_error;
-    LOG(Sev::Err, "Error searching initial time: {}", err2str(err));
+    LOG(Sev::Error, "Error searching initial time: {}", err2str(err));
     for (auto &i : _tp) {
-      LOG(Sev::Err, "TopicPartition {}-{} : {}", i->topic(), i->partition(),
+      LOG(Sev::Error, "TopicPartition {}-{} : {}", i->topic(), i->partition(),
           RdKafka::err2str(i->err()));
     }
     run_status_ = SEC::start_time_error;
@@ -320,7 +320,7 @@ FileWriter::Streamer::set_start_time(const ESSTimeStamp &timepoint) {
   }
   err = _consumer->assign(_tp);
   if (err != RdKafka::ERR_NO_ERROR) {
-    LOG(Sev::Err, "Error assigning initial time: {}", err2str(err));
+    LOG(Sev::Error, "Error assigning initial time: {}", err2str(err));
     run_status_ = SEC::start_time_error;
     return SEC::start_time_error;
   }

--- a/src/h5.cxx
+++ b/src/h5.cxx
@@ -146,7 +146,7 @@ append_ret h5d::append_data_1d(T const *data, hsize_t nlen) {
     array<char, 64> buf1;
     auto n1 = H5Iget_name(id, buf1.data(), buf1.size());
     if (n1 > 0) {
-      LOG(9, "append_data_1d {} for dataset {:.{}}", nlen, buf1.data(), n1);
+      LOG(Sev::Dbg, "append_data_1d {} for dataset {:.{}}", nlen, buf1.data(), n1);
     }
   }
   auto tgt = H5Dget_space(id);
@@ -158,14 +158,14 @@ append_ret h5d::append_data_1d(T const *data, hsize_t nlen) {
   H5Sget_simple_extent_dims(tgt, snow.data(), smax.data());
   if (log_level >= 9) {
     for (size_t i1 = 0; i1 < snow.size(); ++i1) {
-      LOG(9, "H5Sget_simple_extent_dims {:3}", snow.at(i1));
+      LOG(Sev::Dbg, "H5Sget_simple_extent_dims {:3}", snow.at(i1));
     }
   }
 
   snow[0] += nlen;
   err = H5Dextend(id, snow.data());
   if (err < 0) {
-    LOG(3, "can not extend dataset");
+    LOG(Sev::Err, "can not extend dataset");
     H5Sclose(tgt);
     return {-1};
   }
@@ -182,7 +182,7 @@ append_ret h5d::append_data_1d(T const *data, hsize_t nlen) {
     err = H5Sselect_hyperslab(dsp_mem, H5S_SELECT_SET, start.data(), nullptr,
                               count.data(), nullptr);
     if (err < 0) {
-      LOG(3, "can not select mem hyperslab");
+      LOG(Sev::Err, "can not select mem hyperslab");
       return {-3};
     }
   }
@@ -192,13 +192,13 @@ append_ret h5d::append_data_1d(T const *data, hsize_t nlen) {
   err = H5Sselect_hyperslab(tgt, H5S_SELECT_SET, tgt_start.data(), nullptr,
                             tgt_count.data(), nullptr);
   if (err < 0) {
-    LOG(3, "can not select tgt hyperslab");
+    LOG(Sev::Err, "can not select tgt hyperslab");
     return {-3};
   }
 
   err = H5Dwrite(id, type, dsp_mem, tgt, H5P_DEFAULT, data);
   if (err < 0) {
-    LOG(3, "writing failed");
+    LOG(Sev::Err, "writing failed");
     return {-4};
   }
   return {0, sizeof(T) * nlen, tgt_start[0]};
@@ -210,7 +210,7 @@ append_ret h5d::append_data_2d(T const *data, hsize_t nlen) {
     array<char, 64> buf1;
     auto n1 = H5Iget_name(id, buf1.data(), buf1.size());
     if (n1 > 0) {
-      LOG(9, "append_data_2d {} for dataset {:.{}}", nlen, buf1.data(), n1);
+      LOG(Sev::Dbg, "append_data_2d {} for dataset {:.{}}", nlen, buf1.data(), n1);
     }
   }
   auto tgt = H5Dget_space(id);
@@ -220,19 +220,19 @@ append_ret h5d::append_data_2d(T const *data, hsize_t nlen) {
   A1 smax;
   herr_t err;
   if (NDIM != H5Sget_simple_extent_ndims(tgt)) {
-    LOG(3, "dataset dimensions do not match");
+    LOG(Sev::Err, "dataset dimensions do not match");
     return {-1};
   }
   H5Sget_simple_extent_dims(tgt, snow.data(), smax.data());
   if (log_level >= 9) {
     for (size_t i1 = 0; i1 < snow.size(); ++i1) {
-      LOG(9, "snow {} {:3}", i1, snow.at(i1));
+      LOG(Sev::Dbg, "snow {} {:3}", i1, snow.at(i1));
     }
   }
 
   hsize_t ncols = snow[1];
   if (nlen % ncols != 0) {
-    LOG(3, "dataset dimensions do not match");
+    LOG(Sev::Err, "dataset dimensions do not match");
     return {-1};
   }
 
@@ -241,7 +241,7 @@ append_ret h5d::append_data_2d(T const *data, hsize_t nlen) {
   snow[0] += nrows;
   err = H5Dextend(id, snow.data());
   if (err < 0) {
-    LOG(3, "can not extend dataset");
+    LOG(Sev::Err, "can not extend dataset");
     H5Sclose(tgt);
     return {-1};
   }
@@ -258,7 +258,7 @@ append_ret h5d::append_data_2d(T const *data, hsize_t nlen) {
     err = H5Sselect_hyperslab(dsp_mem, H5S_SELECT_SET, start.data(), nullptr,
                               count.data(), nullptr);
     if (err < 0) {
-      LOG(3, "can not select mem hyperslab");
+      LOG(Sev::Err, "can not select mem hyperslab");
       return {-3};
     }
   }
@@ -268,13 +268,13 @@ append_ret h5d::append_data_2d(T const *data, hsize_t nlen) {
   err = H5Sselect_hyperslab(tgt, H5S_SELECT_SET, tgt_start.data(), nullptr,
                             tgt_count.data(), nullptr);
   if (err < 0) {
-    LOG(3, "can not select tgt hyperslab");
+    LOG(Sev::Err, "can not select tgt hyperslab");
     return {-3};
   }
 
   err = H5Dwrite(id, type, dsp_mem, tgt, H5P_DEFAULT, data);
   if (err < 0) {
-    LOG(3, "writing failed");
+    LOG(Sev::Err, "writing failed");
     return {-4};
   }
   return {0, sizeof(T) * nlen, tgt_start[0]};

--- a/src/h5.cxx
+++ b/src/h5.cxx
@@ -146,7 +146,7 @@ append_ret h5d::append_data_1d(T const *data, hsize_t nlen) {
     array<char, 64> buf1;
     auto n1 = H5Iget_name(id, buf1.data(), buf1.size());
     if (n1 > 0) {
-      LOG(Sev::Dbg, "append_data_1d {} for dataset {:.{}}", nlen, buf1.data(), n1);
+      LOG(Sev::Debug, "append_data_1d {} for dataset {:.{}}", nlen, buf1.data(), n1);
     }
   }
   auto tgt = H5Dget_space(id);
@@ -158,14 +158,14 @@ append_ret h5d::append_data_1d(T const *data, hsize_t nlen) {
   H5Sget_simple_extent_dims(tgt, snow.data(), smax.data());
   if (log_level >= 9) {
     for (size_t i1 = 0; i1 < snow.size(); ++i1) {
-      LOG(Sev::Dbg, "H5Sget_simple_extent_dims {:3}", snow.at(i1));
+      LOG(Sev::Debug, "H5Sget_simple_extent_dims {:3}", snow.at(i1));
     }
   }
 
   snow[0] += nlen;
   err = H5Dextend(id, snow.data());
   if (err < 0) {
-    LOG(Sev::Err, "can not extend dataset");
+    LOG(Sev::Error, "can not extend dataset");
     H5Sclose(tgt);
     return {-1};
   }
@@ -182,7 +182,7 @@ append_ret h5d::append_data_1d(T const *data, hsize_t nlen) {
     err = H5Sselect_hyperslab(dsp_mem, H5S_SELECT_SET, start.data(), nullptr,
                               count.data(), nullptr);
     if (err < 0) {
-      LOG(Sev::Err, "can not select mem hyperslab");
+      LOG(Sev::Error, "can not select mem hyperslab");
       return {-3};
     }
   }
@@ -192,13 +192,13 @@ append_ret h5d::append_data_1d(T const *data, hsize_t nlen) {
   err = H5Sselect_hyperslab(tgt, H5S_SELECT_SET, tgt_start.data(), nullptr,
                             tgt_count.data(), nullptr);
   if (err < 0) {
-    LOG(Sev::Err, "can not select tgt hyperslab");
+    LOG(Sev::Error, "can not select tgt hyperslab");
     return {-3};
   }
 
   err = H5Dwrite(id, type, dsp_mem, tgt, H5P_DEFAULT, data);
   if (err < 0) {
-    LOG(Sev::Err, "writing failed");
+    LOG(Sev::Error, "writing failed");
     return {-4};
   }
   return {0, sizeof(T) * nlen, tgt_start[0]};
@@ -210,7 +210,7 @@ append_ret h5d::append_data_2d(T const *data, hsize_t nlen) {
     array<char, 64> buf1;
     auto n1 = H5Iget_name(id, buf1.data(), buf1.size());
     if (n1 > 0) {
-      LOG(Sev::Dbg, "append_data_2d {} for dataset {:.{}}", nlen, buf1.data(), n1);
+      LOG(Sev::Debug, "append_data_2d {} for dataset {:.{}}", nlen, buf1.data(), n1);
     }
   }
   auto tgt = H5Dget_space(id);
@@ -220,19 +220,19 @@ append_ret h5d::append_data_2d(T const *data, hsize_t nlen) {
   A1 smax;
   herr_t err;
   if (NDIM != H5Sget_simple_extent_ndims(tgt)) {
-    LOG(Sev::Err, "dataset dimensions do not match");
+    LOG(Sev::Error, "dataset dimensions do not match");
     return {-1};
   }
   H5Sget_simple_extent_dims(tgt, snow.data(), smax.data());
   if (log_level >= 9) {
     for (size_t i1 = 0; i1 < snow.size(); ++i1) {
-      LOG(Sev::Dbg, "snow {} {:3}", i1, snow.at(i1));
+      LOG(Sev::Debug, "snow {} {:3}", i1, snow.at(i1));
     }
   }
 
   hsize_t ncols = snow[1];
   if (nlen % ncols != 0) {
-    LOG(Sev::Err, "dataset dimensions do not match");
+    LOG(Sev::Error, "dataset dimensions do not match");
     return {-1};
   }
 
@@ -241,7 +241,7 @@ append_ret h5d::append_data_2d(T const *data, hsize_t nlen) {
   snow[0] += nrows;
   err = H5Dextend(id, snow.data());
   if (err < 0) {
-    LOG(Sev::Err, "can not extend dataset");
+    LOG(Sev::Error, "can not extend dataset");
     H5Sclose(tgt);
     return {-1};
   }
@@ -258,7 +258,7 @@ append_ret h5d::append_data_2d(T const *data, hsize_t nlen) {
     err = H5Sselect_hyperslab(dsp_mem, H5S_SELECT_SET, start.data(), nullptr,
                               count.data(), nullptr);
     if (err < 0) {
-      LOG(Sev::Err, "can not select mem hyperslab");
+      LOG(Sev::Error, "can not select mem hyperslab");
       return {-3};
     }
   }
@@ -268,13 +268,13 @@ append_ret h5d::append_data_2d(T const *data, hsize_t nlen) {
   err = H5Sselect_hyperslab(tgt, H5S_SELECT_SET, tgt_start.data(), nullptr,
                             tgt_count.data(), nullptr);
   if (err < 0) {
-    LOG(Sev::Err, "can not select tgt hyperslab");
+    LOG(Sev::Error, "can not select tgt hyperslab");
     return {-3};
   }
 
   err = H5Dwrite(id, type, dsp_mem, tgt, H5P_DEFAULT, data);
   if (err < 0) {
-    LOG(Sev::Err, "writing failed");
+    LOG(Sev::Error, "writing failed");
     return {-4};
   }
   return {0, sizeof(T) * nlen, tgt_start[0]};

--- a/src/kafka-to-nexus.cxx
+++ b/src/kafka-to-nexus.cxx
@@ -8,7 +8,7 @@
 #include <string>
 
 void signal_handler(int signal) {
-  LOG(0, "SIGNAL {}", signal);
+  LOG(Sev::Note, "SIGNAL {}", signal);
   if (auto opt = g_main_opt.load()) {
     if (auto m = opt->master.load()) {
       m->stop();
@@ -55,7 +55,7 @@ int main(int argc, char **argv) {
                "\n");
 
     fmt::print("  -v\n"
-               "      Increase verbosity\n"
+               "      Set logging level. 3 == Error, 7 == Debug. Default: 6 (Info).\n"
                "\n");
     return 1;
   }

--- a/src/kafka-to-nexus.cxx
+++ b/src/kafka-to-nexus.cxx
@@ -8,7 +8,7 @@
 #include <string>
 
 void signal_handler(int signal) {
-  LOG(Sev::Note, "SIGNAL {}", signal);
+  LOG(Sev::Notice, "SIGNAL {}", signal);
   if (auto opt = g_main_opt.load()) {
     if (auto m = opt->master.load()) {
       m->stop();

--- a/src/logger.cxx
+++ b/src/logger.cxx
@@ -98,7 +98,7 @@ void Logger::fwd_graylog_logger_enable(std::string address) {
   Log::AddLogHandler(new GraylogInterface(addr, port));
   do_use_graylog_logger = true;
 #else
-  LOG(Sev::Note, "ERROR not compiled with support for graylog_logger. Would have used "
+  LOG(Sev::Notice, "ERROR not compiled with support for graylog_logger. Would have used "
          "{}:{}",
       addr, port);
 #endif

--- a/src/logger.cxx
+++ b/src/logger.cxx
@@ -49,7 +49,7 @@ Logger::Logger() {}
 Logger::~Logger() {
   do_run_kafka = false;
   if (log_file != nullptr and log_file != stdout) {
-    LOG(0, "Closing log");
+    LOG(Sev::Info, "Closing log");
     fclose(log_file);
   }
   if (thread_poll.joinable()) {
@@ -94,11 +94,11 @@ void Logger::fwd_graylog_logger_enable(std::string address) {
   }
 #ifdef HAVE_GRAYLOG_LOGGER
   Log::RemoveAllHandlers();
-  LOG(4, "Enable graylog_logger on {}:{}", addr, port);
+  LOG(Sev::Info, "Enable graylog_logger on {}:{}", addr, port);
   Log::AddLogHandler(new GraylogInterface(addr, port));
   do_use_graylog_logger = true;
 #else
-  LOG(0, "ERROR not compiled with support for graylog_logger. Would have used "
+  LOG(Sev::Note, "ERROR not compiled with support for graylog_logger. Would have used "
          "{}:{}",
       addr, port);
 #endif

--- a/src/logger.h
+++ b/src/logger.h
@@ -17,18 +17,30 @@
 
 extern int log_level;
 
+//These severity level correspond to the RFC3164 (syslog) severity levels
+enum class Sev : int {
+  Emergency = 0,  //Do not use, reserved for system errors
+  Alert = 1,      //Do not use, reserved for system errors
+  Crit = 2,       //Critical, i.e. wake me up in the middle of the night
+  Err = 3,        //Error, I should fix this as soon as possible
+  Warn = 4,       //Could be an indication of a problem that needs fixing
+  Note = 5,       //Notice, potentially important events that might need special treatment
+  Info = 6,       //Informational, general run time info for checking the state of the application
+  Dbg = 7,      //Debug, give me a flood of information
+};
+
 void dwlog_inner(int level, char const *file, int line, char const *func,
                  std::string const &s1);
 
 template <typename... TT>
-void dwlog(int level, char const *fmt, char const *file, int line,
+void dwlog(Sev level, char const *fmt, char const *file, int line,
            char const *func, TT const &... args) {
-  if (level > log_level)
+  if (static_cast<int>(level) > log_level)
     return;
   try {
-    dwlog_inner(level, file, line, func, fmt::format(fmt, args...));
+    dwlog_inner(static_cast<int>(level), file, line, func, fmt::format(fmt, args...));
   } catch (fmt::FormatError &e) {
-    dwlog_inner(level, file, line, func,
+    dwlog_inner(static_cast<int>(level), file, line, func,
                 fmt::format("ERROR in format: {}: {}", e.what(), fmt));
   }
 }

--- a/src/logger.h
+++ b/src/logger.h
@@ -21,12 +21,12 @@ extern int log_level;
 enum class Sev : int {
   Emergency = 0,  //Do not use, reserved for system errors
   Alert = 1,      //Do not use, reserved for system errors
-  Crit = 2,       //Critical, i.e. wake me up in the middle of the night
-  Err = 3,        //Error, I should fix this as soon as possible
-  Warn = 4,       //Could be an indication of a problem that needs fixing
-  Note = 5,       //Notice, potentially important events that might need special treatment
+  Critical = 2,   //Critical, i.e. wake me up in the middle of the night
+  Error = 3,      //Error, I should fix this as soon as possible
+  Warning = 4,    //Could be an indication of a problem that needs fixing
+  Notice = 5,     //Notice, potentially important events that might need special treatment
   Info = 6,       //Informational, general run time info for checking the state of the application
-  Dbg = 7,      //Debug, give me a flood of information
+  Debug = 7,      //Debug, give me a flood of information
 };
 
 void dwlog_inner(int level, char const *file, int line, char const *func,

--- a/src/schemas/ev42/ev42_rw.cxx
+++ b/src/schemas/ev42/ev42_rw.cxx
@@ -42,7 +42,7 @@ std::string FlatbufferReader::source_name(Msg const &msg) const {
   auto fbuf = get_fbuf(msg.data);
   auto s1 = fbuf->source_name();
   if (!s1) {
-    LOG(Sev::Note, "message has no source_name");
+    LOG(Sev::Notice, "message has no source_name");
     return "";
   }
   return s1->str();
@@ -93,14 +93,14 @@ HDFWriterModule::init_hdf(hid_t hdf_file, std::string hdf_parent_name,
 
   if (auto x = get_int(&config_stream, "nexus.indices.index_every_kb")) {
     index_every_bytes = uint64_t(x.v * 1024);
-    LOG(Sev::Dbg, "index_every_bytes: {}", index_every_bytes);
+    LOG(Sev::Debug, "index_every_bytes: {}", index_every_bytes);
   } else if (auto x = get_int(&config_stream, "nexus.indices.index_every_mb")) {
     index_every_bytes = uint64_t(x.v * 1024 * 1024);
-    LOG(Sev::Dbg, "index_every_bytes: {}", index_every_bytes);
+    LOG(Sev::Debug, "index_every_bytes: {}", index_every_bytes);
   }
   if (auto x = get_int(&config_stream, "nexus.chunk.chunk_n_elements")) {
     chunk_n_elements = hsize_t(x.v);
-    LOG(Sev::Dbg, "chunk_n_elements: {}", chunk_n_elements);
+    LOG(Sev::Debug, "chunk_n_elements: {}", chunk_n_elements);
   }
 
   this->ds_event_time_offset = h5::h5d_chunked_1d<uint32_t>::create(
@@ -140,7 +140,7 @@ HDFWriterModule::WriteResult HDFWriterModule::write(Msg const &msg) {
   auto w2ret = this->ds_event_id->append_data_1d(fbuf->detector_id()->data(),
                                                  fbuf->detector_id()->size());
   if (w1ret.ix0 != w2ret.ix0) {
-    LOG(Sev::Warn, "written data lengths differ");
+    LOG(Sev::Warning, "written data lengths differ");
   }
   auto pulse_time = fbuf->pulse_time();
   this->ds_event_time_zero->append_data_1d(&pulse_time, 1);

--- a/src/schemas/ev42/ev42_rw.cxx
+++ b/src/schemas/ev42/ev42_rw.cxx
@@ -42,7 +42,7 @@ std::string FlatbufferReader::source_name(Msg const &msg) const {
   auto fbuf = get_fbuf(msg.data);
   auto s1 = fbuf->source_name();
   if (!s1) {
-    LOG(4, "message has no source_name");
+    LOG(Sev::Note, "message has no source_name");
     return "";
   }
   return s1->str();
@@ -93,14 +93,14 @@ HDFWriterModule::init_hdf(hid_t hdf_file, std::string hdf_parent_name,
 
   if (auto x = get_int(&config_stream, "nexus.indices.index_every_kb")) {
     index_every_bytes = uint64_t(x.v * 1024);
-    LOG(7, "index_every_bytes: {}", index_every_bytes);
+    LOG(Sev::Dbg, "index_every_bytes: {}", index_every_bytes);
   } else if (auto x = get_int(&config_stream, "nexus.indices.index_every_mb")) {
     index_every_bytes = uint64_t(x.v * 1024 * 1024);
-    LOG(7, "index_every_bytes: {}", index_every_bytes);
+    LOG(Sev::Dbg, "index_every_bytes: {}", index_every_bytes);
   }
   if (auto x = get_int(&config_stream, "nexus.chunk.chunk_n_elements")) {
     chunk_n_elements = hsize_t(x.v);
-    LOG(7, "chunk_n_elements: {}", chunk_n_elements);
+    LOG(Sev::Dbg, "chunk_n_elements: {}", chunk_n_elements);
   }
 
   this->ds_event_time_offset = h5::h5d_chunked_1d<uint32_t>::create(
@@ -140,7 +140,7 @@ HDFWriterModule::WriteResult HDFWriterModule::write(Msg const &msg) {
   auto w2ret = this->ds_event_id->append_data_1d(fbuf->detector_id()->data(),
                                                  fbuf->detector_id()->size());
   if (w1ret.ix0 != w2ret.ix0) {
-    LOG(3, "written data lengths differ");
+    LOG(Sev::Warn, "written data lengths differ");
   }
   auto pulse_time = fbuf->pulse_time();
   this->ds_event_time_zero->append_data_1d(&pulse_time, 1);

--- a/src/schemas/ev42/ev42_synth.cxx
+++ b/src/schemas/ev42/ev42_synth.cxx
@@ -36,7 +36,7 @@ fb synth::next(uint32_t size) {
       ret.builder->CreateUninitializedVector(size, sizeof(DT), (uint8_t **)&a2);
 
   if ((!a1) || (!a2)) {
-    LOG(7, "ERROR can not create test data");
+    LOG(Sev::Dbg, "ERROR can not create test data");
   } else {
     for (size_t i1 = 0; i1 < size; ++i1) {
       auto eid = impl->rnd();
@@ -56,7 +56,7 @@ fb synth::next(uint32_t size) {
   b1.add_time_of_flight(v1);
   b1.add_detector_id(v2);
   FinishEventMessageBuffer(*ret.builder, b1.Finish());
-  // LOG(7, "SIZE: {}", ret.builder->GetSize());
+  // LOG(Sev::Dbg, "SIZE: {}", ret.builder->GetSize());
   ++impl->seq;
   return ret;
 }

--- a/src/schemas/ev42/ev42_synth.cxx
+++ b/src/schemas/ev42/ev42_synth.cxx
@@ -36,7 +36,7 @@ fb synth::next(uint32_t size) {
       ret.builder->CreateUninitializedVector(size, sizeof(DT), (uint8_t **)&a2);
 
   if ((!a1) || (!a2)) {
-    LOG(Sev::Dbg, "ERROR can not create test data");
+    LOG(Sev::Debug, "ERROR can not create test data");
   } else {
     for (size_t i1 = 0; i1 < size; ++i1) {
       auto eid = impl->rnd();

--- a/src/schemas/f142/f142_rw.cxx
+++ b/src/schemas/f142/f142_rw.cxx
@@ -58,14 +58,14 @@ writer_typed_array<DT, FV>::writer_typed_array(hid_t hdf_group,
                                                Value fb_value_type_id)
     : _fb_value_type_id(fb_value_type_id) {
   if (ncols <= 0) {
-    LOG(4, "can not handle number of columns ncols == {}", ncols);
+    LOG(Sev::Err, "can not handle number of columns ncols == {}", ncols);
     return;
   }
-  LOG(7, "f142 init_impl  ncols: {}", ncols);
+  LOG(Sev::Dbg, "f142 init_impl  ncols: {}", ncols);
   this->ds =
       h5::h5d_chunked_2d<DT>::create(hdf_group, source_name, ncols, 64 * 1024);
   if (!this->ds) {
-    LOG(3,
+    LOG(Sev::Err,
         "could not create hdf dataset  source_name: {}  number of columns: {}",
         source_name, ncols);
   }
@@ -96,10 +96,10 @@ writer_typed_scalar<DT, FV>::writer_typed_scalar(hid_t hdf_group,
                                                  std::string const &source_name,
                                                  Value fb_value_type_id)
     : _fb_value_type_id(fb_value_type_id) {
-  LOG(7, "f142 init_impl  scalar");
+  LOG(Sev::Dbg, "f142 init_impl  scalar");
   this->ds = h5::h5d_chunked_1d<DT>::create(hdf_group, source_name, 64 * 1024);
   if (!this->ds) {
-    LOG(3, "could not create hdf dataset  source_name: {}", source_name);
+    LOG(Sev::Err, "could not create hdf dataset  source_name: {}", source_name);
   }
 }
 
@@ -135,7 +135,7 @@ std::string FlatbufferReader::source_name(Msg const &msg) const {
   auto fbuf = get_fbuf(msg.data);
   auto s1 = fbuf->source_name();
   if (!s1) {
-    LOG(4, "message has no source name");
+    LOG(Sev::Warn, "message has no source name");
     return "";
   }
   return s1->str();
@@ -280,7 +280,7 @@ HDFWriterModule::init_hdf(hid_t hdf_file, std::string hdf_parent_name,
   if (auto x = get_uint(&config_stream, "array_size")) {
     array_size = size_t(x.v);
   }
-  LOG(7, "HDFWriterModule::init_hdf f142 source_name: {}  type: {}  "
+  LOG(Sev::Dbg, "HDFWriterModule::init_hdf f142 source_name: {}  type: {}  "
          "array_size: {}",
       source_name, type, array_size);
 
@@ -294,7 +294,7 @@ HDFWriterModule::init_hdf(hid_t hdf_file, std::string hdf_parent_name,
 
   impl.reset(impl_fac(hdf_group, array_size, type, s));
   if (!impl) {
-    LOG(4, "Could not create a writer implementation for value_type {}", type);
+    LOG(Sev::Err, "Could not create a writer implementation for value_type {}", type);
     return HDFWriterModule::InitResult::ERROR_IO();
   }
 
@@ -327,12 +327,12 @@ HDFWriterModule::init_hdf(hid_t hdf_file, std::string hdf_parent_name,
 HDFWriterModule::WriteResult HDFWriterModule::write(Msg const &msg) {
   auto fbuf = get_fbuf(msg.data);
   if (!impl) {
-    LOG(5, "sorry, but we were unable to initialize for this kind of messages");
+    LOG(Sev::Warn, "sorry, but we were unable to initialize for this kind of messages");
     return HDFWriterModule::WriteResult::ERROR_IO();
   }
   auto wret = impl->write_impl(fbuf);
   if (!wret) {
-    LOG(5, "write failed");
+    LOG(Sev::Err, "write failed");
   }
   total_written_bytes += wret.written_bytes;
   ts_max = std::max(fbuf->timestamp(), ts_max);

--- a/src/schemas/f142/f142_rw.cxx
+++ b/src/schemas/f142/f142_rw.cxx
@@ -58,14 +58,14 @@ writer_typed_array<DT, FV>::writer_typed_array(hid_t hdf_group,
                                                Value fb_value_type_id)
     : _fb_value_type_id(fb_value_type_id) {
   if (ncols <= 0) {
-    LOG(Sev::Err, "can not handle number of columns ncols == {}", ncols);
+    LOG(Sev::Error, "can not handle number of columns ncols == {}", ncols);
     return;
   }
-  LOG(Sev::Dbg, "f142 init_impl  ncols: {}", ncols);
+  LOG(Sev::Debug, "f142 init_impl  ncols: {}", ncols);
   this->ds =
       h5::h5d_chunked_2d<DT>::create(hdf_group, source_name, ncols, 64 * 1024);
   if (!this->ds) {
-    LOG(Sev::Err,
+    LOG(Sev::Error,
         "could not create hdf dataset  source_name: {}  number of columns: {}",
         source_name, ncols);
   }
@@ -96,10 +96,10 @@ writer_typed_scalar<DT, FV>::writer_typed_scalar(hid_t hdf_group,
                                                  std::string const &source_name,
                                                  Value fb_value_type_id)
     : _fb_value_type_id(fb_value_type_id) {
-  LOG(Sev::Dbg, "f142 init_impl  scalar");
+  LOG(Sev::Debug, "f142 init_impl  scalar");
   this->ds = h5::h5d_chunked_1d<DT>::create(hdf_group, source_name, 64 * 1024);
   if (!this->ds) {
-    LOG(Sev::Err, "could not create hdf dataset  source_name: {}", source_name);
+    LOG(Sev::Error, "could not create hdf dataset  source_name: {}", source_name);
   }
 }
 
@@ -135,7 +135,7 @@ std::string FlatbufferReader::source_name(Msg const &msg) const {
   auto fbuf = get_fbuf(msg.data);
   auto s1 = fbuf->source_name();
   if (!s1) {
-    LOG(Sev::Warn, "message has no source name");
+    LOG(Sev::Warning, "message has no source name");
     return "";
   }
   return s1->str();
@@ -280,7 +280,7 @@ HDFWriterModule::init_hdf(hid_t hdf_file, std::string hdf_parent_name,
   if (auto x = get_uint(&config_stream, "array_size")) {
     array_size = size_t(x.v);
   }
-  LOG(Sev::Dbg, "HDFWriterModule::init_hdf f142 source_name: {}  type: {}  "
+  LOG(Sev::Debug, "HDFWriterModule::init_hdf f142 source_name: {}  type: {}  "
          "array_size: {}",
       source_name, type, array_size);
 
@@ -294,7 +294,7 @@ HDFWriterModule::init_hdf(hid_t hdf_file, std::string hdf_parent_name,
 
   impl.reset(impl_fac(hdf_group, array_size, type, s));
   if (!impl) {
-    LOG(Sev::Err, "Could not create a writer implementation for value_type {}", type);
+    LOG(Sev::Error, "Could not create a writer implementation for value_type {}", type);
     return HDFWriterModule::InitResult::ERROR_IO();
   }
 
@@ -327,12 +327,12 @@ HDFWriterModule::init_hdf(hid_t hdf_file, std::string hdf_parent_name,
 HDFWriterModule::WriteResult HDFWriterModule::write(Msg const &msg) {
   auto fbuf = get_fbuf(msg.data);
   if (!impl) {
-    LOG(Sev::Warn, "sorry, but we were unable to initialize for this kind of messages");
+    LOG(Sev::Warning, "sorry, but we were unable to initialize for this kind of messages");
     return HDFWriterModule::WriteResult::ERROR_IO();
   }
   auto wret = impl->write_impl(fbuf);
   if (!wret) {
-    LOG(Sev::Err, "write failed");
+    LOG(Sev::Error, "write failed");
   }
   total_written_bytes += wret.written_bytes;
   ts_max = std::max(fbuf->timestamp(), ts_max);

--- a/src/send-command.cxx
+++ b/src/send-command.cxx
@@ -90,10 +90,10 @@ std::string make_command_from_file(const std::string &filename) {
   using namespace rapidjson;
   std::ifstream ifs(filename);
   if (!ifs.good()) {
-    LOG(Sev::Warn, "can not open file {}", filename);
+    LOG(Sev::Warning, "can not open file {}", filename);
     return "";
   }
-  LOG(Sev::Dbg, "make_command_from_file {}", filename);
+  LOG(Sev::Debug, "make_command_from_file {}", filename);
   auto buf1 = gulp(filename);
   return {buf1.data(), buf1.size()};
 }
@@ -151,7 +151,7 @@ int main(int argc, char **argv) {
   }
 
   if (getopt_error) {
-    LOG(Sev::Note, "ERROR parsing command line options");
+    LOG(Sev::Notice, "ERROR parsing command line options");
     opt.help = true;
     return 1;
   }
@@ -185,15 +185,15 @@ int main(int argc, char **argv) {
   KafkaW::Producer::Topic pt(producer, opt.broker.topic);
   if (opt.cmd == "new") {
     auto m1 = make_command(opt.broker_opt.address, opt.teamid);
-    LOG(Sev::Dbg, "sending {}", m1);
+    LOG(Sev::Debug, "sending {}", m1);
     pt.produce((uint8_t *)m1.data(), m1.size(), true);
   } else if (opt.cmd == "exit") {
     auto m1 = make_command_exit(opt.broker_opt.address, opt.teamid);
-    LOG(Sev::Dbg, "sending {}", m1);
+    LOG(Sev::Debug, "sending {}", m1);
     pt.produce((uint8_t *)m1.data(), m1.size(), true);
   } else if (opt.cmd.substr(0, 5) == "file:") {
     auto m1 = make_command_from_file(opt.cmd.substr(5));
-    LOG(Sev::Dbg, "sending:\n{}", m1);
+    LOG(Sev::Debug, "sending:\n{}", m1);
     pt.produce((uint8_t *)m1.data(), m1.size(), true);
   } else if (opt.cmd.substr(0, 5) == "stop:") {
     auto input = opt.cmd.substr(5);
@@ -210,7 +210,7 @@ int main(int argc, char **argv) {
     } else {
       m1 = make_command_stop(opt.broker_opt.address, input);
     }
-    LOG(Sev::Dbg, "sending {}", m1);
+    LOG(Sev::Debug, "sending {}", m1);
     pt.produce((uint8_t *)m1.data(), m1.size(), true);
   }
   return 0;

--- a/src/send-command.cxx
+++ b/src/send-command.cxx
@@ -21,7 +21,6 @@ using ESSTimeStamp = FileWriter::ESSTimeStamp;
 // POD
 struct MainOpt {
   bool help = false;
-  bool verbose = false;
   uint64_t teamid = 0;
   URI broker{"localhost:9092/commands"};
   KafkaW::BrokerOpt broker_opt;
@@ -91,10 +90,10 @@ std::string make_command_from_file(const std::string &filename) {
   using namespace rapidjson;
   std::ifstream ifs(filename);
   if (!ifs.good()) {
-    LOG(3, "can not open file {}", filename);
+    LOG(Sev::Warn, "can not open file {}", filename);
     return "";
   }
-  LOG(4, "make_command_from_file {}", filename);
+  LOG(Sev::Dbg, "make_command_from_file {}", filename);
   auto buf1 = gulp(filename);
   return {buf1.data(), buf1.size()};
 }
@@ -115,8 +114,8 @@ int main(int argc, char **argv) {
   int option_index = 0;
   bool getopt_error = false;
   while (true) {
-    int c = getopt_long(argc, argv, "vh", long_options, &option_index);
-    // LOG(2, "c getopt {}", c);
+    int c = getopt_long(argc, argv, "v:h", long_options, &option_index);
+    // LOG(Sev::Dbg, "c getopt {}", c);
     if (c == -1)
       break;
     if (c == '?') {
@@ -124,8 +123,11 @@ int main(int argc, char **argv) {
     }
     switch (c) {
     case 'v':
-      opt.verbose = true;
-      log_level = std::min(9, log_level + 1);
+        try {
+          log_level = std::stoi(std::string(optarg));
+        } catch (std::invalid_argument &e) {
+          std::cout << "Severity level of verbosity argument is not an integer." << std::endl;
+        }
       break;
     case 'h':
       opt.help = true;
@@ -149,7 +151,7 @@ int main(int argc, char **argv) {
   }
 
   if (getopt_error) {
-    LOG(2, "ERROR parsing command line options");
+    LOG(Sev::Note, "ERROR parsing command line options");
     opt.help = true;
     return 1;
   }
@@ -183,15 +185,15 @@ int main(int argc, char **argv) {
   KafkaW::Producer::Topic pt(producer, opt.broker.topic);
   if (opt.cmd == "new") {
     auto m1 = make_command(opt.broker_opt.address, opt.teamid);
-    LOG(4, "sending {}", m1);
+    LOG(Sev::Dbg, "sending {}", m1);
     pt.produce((uint8_t *)m1.data(), m1.size(), true);
   } else if (opt.cmd == "exit") {
     auto m1 = make_command_exit(opt.broker_opt.address, opt.teamid);
-    LOG(4, "sending {}", m1);
+    LOG(Sev::Dbg, "sending {}", m1);
     pt.produce((uint8_t *)m1.data(), m1.size(), true);
   } else if (opt.cmd.substr(0, 5) == "file:") {
     auto m1 = make_command_from_file(opt.cmd.substr(5));
-    LOG(4, "sending:\n{}", m1);
+    LOG(Sev::Dbg, "sending:\n{}", m1);
     pt.produce((uint8_t *)m1.data(), m1.size(), true);
   } else if (opt.cmd.substr(0, 5) == "stop:") {
     auto input = opt.cmd.substr(5);
@@ -208,7 +210,7 @@ int main(int argc, char **argv) {
     } else {
       m1 = make_command_stop(opt.broker_opt.address, input);
     }
-    LOG(4, "sending {}", m1);
+    LOG(Sev::Dbg, "sending {}", m1);
     pt.produce((uint8_t *)m1.data(), m1.size(), true);
   }
   return 0;

--- a/src/tests/HDFFile.cxx
+++ b/src/tests/HDFFile.cxx
@@ -38,7 +38,7 @@ public:
   static void new_03() {
     using namespace FileWriter;
     auto cmd = gulp("tests/msg-cmd-new-03.json");
-    LOG(Sev::Dbg, "cmd: {:.{}}", cmd.data(), cmd.size());
+    LOG(Sev::Debug, "cmd: {:.{}}", cmd.data(), cmd.size());
     rapidjson::Document d;
     d.Parse(cmd.data(), cmd.size());
     char const *fname = d["file_attributes"]["file_name"].GetString();
@@ -301,7 +301,7 @@ public:
     /// Generates n test messages which we can later feed from memory into the
     /// file writer.
     void pregenerate(int n, int n_events_per_message) {
-      LOG(Sev::Dbg, "generating {} {}...", topic, source);
+      LOG(Sev::Debug, "generating {} {}...", topic, source);
       FlatBufs::ev42::synth synth(source, seed);
       rnd.seed(seed);
       for (int i1 = 0; i1 < n; ++i1) {
@@ -363,32 +363,32 @@ public:
     if (auto x =
             get_int(&main_opt.config_file, "unit_test.hdf.do_verification")) {
       do_verification = x.v == 1;
-      LOG(Sev::Dbg, "do_verification: {}", do_verification);
+      LOG(Sev::Debug, "do_verification: {}", do_verification);
     }
 
     int n_msgs_per_source = 1;
     if (auto x =
             get_int(&main_opt.config_file, "unit_test.n_msgs_per_source")) {
-      LOG(Sev::Dbg, "unit_test.n_msgs_per_source: {}", x.v);
+      LOG(Sev::Debug, "unit_test.n_msgs_per_source: {}", x.v);
       n_msgs_per_source = x.v;
     }
 
     int n_sources = 1;
     if (auto x = get_int(&main_opt.config_file, "unit_test.n_sources")) {
-      LOG(Sev::Dbg, "unit_test.n_sources: {}", x.v);
+      LOG(Sev::Debug, "unit_test.n_sources: {}", x.v);
       n_sources = x.v;
     }
 
     int n_events_per_message = 1;
     if (auto x =
             get_int(&main_opt.config_file, "unit_test.n_events_per_message")) {
-      LOG(Sev::Dbg, "unit_test.n_events_per_message: {}", x.v);
+      LOG(Sev::Debug, "unit_test.n_events_per_message: {}", x.v);
       n_events_per_message = x.v;
     }
 
     int n_msgs_per_batch = 1;
     if (auto x = get_int(&main_opt.config_file, "unit_test.n_msgs_per_batch")) {
-      LOG(Sev::Dbg, "unit_test.n_msgs_per_batch: {}", x.v);
+      LOG(Sev::Debug, "unit_test.n_msgs_per_batch: {}", x.v);
       n_msgs_per_batch = x.v;
     }
 
@@ -517,7 +517,7 @@ public:
       auto &fwt = ch.file_writer_tasks.at(0);
       ASSERT_EQ(fwt->demuxers().size(), (size_t)1);
 
-      LOG(Sev::Dbg, "processing...");
+      LOG(Sev::Debug, "processing...");
       using CLK = std::chrono::steady_clock;
       using MS = std::chrono::milliseconds;
       auto t1 = CLK::now();
@@ -531,7 +531,7 @@ public:
               auto &msg = source.msgs[source.n_fed];
               if (false) {
                 auto v = binary_to_hex(msg.data, msg.size);
-                LOG(Sev::Dbg, "msg:\n{:.{}}", v.data(), v.size());
+                LOG(Sev::Debug, "msg:\n{:.{}}", v.data(), v.size());
               }
               fwt->demuxers().at(0).process_message(msg.data, msg.size);
               source.n_fed++;
@@ -544,16 +544,16 @@ public:
         }
       }
       auto t2 = CLK::now();
-      LOG(Sev::Dbg, "processing done in {} ms", duration_cast<MS>(t2 - t1).count());
-      LOG(Sev::Dbg, "finishing...");
+      LOG(Sev::Debug, "processing done in {} ms", duration_cast<MS>(t2 - t1).count());
+      LOG(Sev::Debug, "finishing...");
       {
         string cmd("{\"recv_type\":\"FileWriter\", "
                    "\"cmd\":\"file_writer_tasks_clear_all\"}");
         ch.handle({(char *)cmd.data(), cmd.size()});
       }
       auto t3 = CLK::now();
-      LOG(Sev::Dbg, "finishing done in {} ms", duration_cast<MS>(t3 - t2).count());
-      LOG(Sev::Dbg, "done in total {} ms", duration_cast<MS>(t3 - t1).count());
+      LOG(Sev::Debug, "finishing done in {} ms", duration_cast<MS>(t3 - t2).count());
+      LOG(Sev::Debug, "done in total {} ms", duration_cast<MS>(t3 - t1).count());
     }
 
     if (!do_verification) {
@@ -701,7 +701,7 @@ public:
     /// Generates n test messages which we can later feed from memory into the
     /// file writer.
     void pregenerate(size_t array_size, uint64_t n) {
-      LOG(Sev::Dbg, "generating {} {}...", topic, source);
+      LOG(Sev::Debug, "generating {} {}...", topic, source);
       auto ty = FlatBufs::f142::Value::Double;
       if (array_size > 0) {
         ty = FlatBufs::f142::Value::ArrayFloat;
@@ -751,25 +751,25 @@ public:
     if (auto x =
             get_int(&main_opt.config_file, "unit_test.hdf.do_verification")) {
       do_verification = x.v == 1;
-      LOG(Sev::Dbg, "do_verification: {}", do_verification);
+      LOG(Sev::Debug, "do_verification: {}", do_verification);
     }
 
     int n_msgs_per_source = 1;
     if (auto x =
             get_int(&main_opt.config_file, "unit_test.n_msgs_per_source")) {
-      LOG(Sev::Dbg, "unit_test.n_msgs_per_source: {}", x.v);
+      LOG(Sev::Debug, "unit_test.n_msgs_per_source: {}", x.v);
       n_msgs_per_source = int(x.v);
     }
 
     int n_sources = 1;
     if (auto x = get_int(&main_opt.config_file, "unit_test.n_sources")) {
-      LOG(Sev::Dbg, "unit_test.n_sources: {}", x.v);
+      LOG(Sev::Debug, "unit_test.n_sources: {}", x.v);
       n_sources = int(x.v);
     }
 
     int n_msgs_per_batch = 1;
     if (auto x = get_int(&main_opt.config_file, "unit_test.n_msgs_per_batch")) {
-      LOG(Sev::Dbg, "unit_test.n_msgs_per_batch: {}", x.v);
+      LOG(Sev::Debug, "unit_test.n_msgs_per_batch: {}", x.v);
       n_msgs_per_batch = int(x.v);
     }
 
@@ -786,7 +786,7 @@ public:
 
     if (false) {
       for (auto &source : sources) {
-        LOG(Sev::Dbg, "msgs: {}  {}", source.source, source.msgs.size());
+        LOG(Sev::Debug, "msgs: {}  {}", source.source, source.msgs.size());
       }
     }
 
@@ -940,7 +940,7 @@ public:
       auto &fwt = ch.file_writer_tasks.at(0);
       ASSERT_EQ(fwt->demuxers().size(), (size_t)1);
 
-      LOG(Sev::Dbg, "processing...");
+      LOG(Sev::Debug, "processing...");
       using CLK = std::chrono::steady_clock;
       using MS = std::chrono::milliseconds;
       auto t1 = CLK::now();
@@ -954,7 +954,7 @@ public:
               auto &msg = source.msgs[source.n_fed];
               if (false) {
                 auto v = binary_to_hex(msg.data, msg.size);
-                LOG(Sev::Dbg, "msg:\n{:.{}}", v.data(), v.size());
+                LOG(Sev::Debug, "msg:\n{:.{}}", v.data(), v.size());
               }
               fwt->demuxers().at(0).process_message(msg.data, msg.size);
               source.n_fed++;
@@ -967,16 +967,16 @@ public:
         }
       }
       auto t2 = CLK::now();
-      LOG(Sev::Dbg, "processing done in {} ms", duration_cast<MS>(t2 - t1).count());
-      LOG(Sev::Dbg, "finishing...");
+      LOG(Sev::Debug, "processing done in {} ms", duration_cast<MS>(t2 - t1).count());
+      LOG(Sev::Debug, "finishing...");
       {
         string cmd("{\"recv_type\":\"FileWriter\", "
                    "\"cmd\":\"file_writer_tasks_clear_all\"}");
         ch.handle({(char *)cmd.data(), cmd.size()});
       }
       auto t3 = CLK::now();
-      LOG(Sev::Dbg, "finishing done in {} ms", duration_cast<MS>(t3 - t2).count());
-      LOG(Sev::Dbg, "done in total {} ms", duration_cast<MS>(t3 - t1).count());
+      LOG(Sev::Debug, "finishing done in {} ms", duration_cast<MS>(t3 - t2).count());
+      LOG(Sev::Debug, "done in total {} ms", duration_cast<MS>(t3 - t1).count());
     }
   }
 

--- a/src/tests/HDFFile.cxx
+++ b/src/tests/HDFFile.cxx
@@ -38,7 +38,7 @@ public:
   static void new_03() {
     using namespace FileWriter;
     auto cmd = gulp("tests/msg-cmd-new-03.json");
-    LOG(7, "cmd: {:.{}}", cmd.data(), cmd.size());
+    LOG(Sev::Dbg, "cmd: {:.{}}", cmd.data(), cmd.size());
     rapidjson::Document d;
     d.Parse(cmd.data(), cmd.size());
     char const *fname = d["file_attributes"]["file_name"].GetString();
@@ -301,7 +301,7 @@ public:
     /// Generates n test messages which we can later feed from memory into the
     /// file writer.
     void pregenerate(int n, int n_events_per_message) {
-      LOG(7, "generating {} {}...", topic, source);
+      LOG(Sev::Dbg, "generating {} {}...", topic, source);
       FlatBufs::ev42::synth synth(source, seed);
       rnd.seed(seed);
       for (int i1 = 0; i1 < n; ++i1) {
@@ -363,32 +363,32 @@ public:
     if (auto x =
             get_int(&main_opt.config_file, "unit_test.hdf.do_verification")) {
       do_verification = x.v == 1;
-      LOG(4, "do_verification: {}", do_verification);
+      LOG(Sev::Dbg, "do_verification: {}", do_verification);
     }
 
     int n_msgs_per_source = 1;
     if (auto x =
             get_int(&main_opt.config_file, "unit_test.n_msgs_per_source")) {
-      LOG(4, "unit_test.n_msgs_per_source: {}", x.v);
+      LOG(Sev::Dbg, "unit_test.n_msgs_per_source: {}", x.v);
       n_msgs_per_source = x.v;
     }
 
     int n_sources = 1;
     if (auto x = get_int(&main_opt.config_file, "unit_test.n_sources")) {
-      LOG(4, "unit_test.n_sources: {}", x.v);
+      LOG(Sev::Dbg, "unit_test.n_sources: {}", x.v);
       n_sources = x.v;
     }
 
     int n_events_per_message = 1;
     if (auto x =
             get_int(&main_opt.config_file, "unit_test.n_events_per_message")) {
-      LOG(4, "unit_test.n_events_per_message: {}", x.v);
+      LOG(Sev::Dbg, "unit_test.n_events_per_message: {}", x.v);
       n_events_per_message = x.v;
     }
 
     int n_msgs_per_batch = 1;
     if (auto x = get_int(&main_opt.config_file, "unit_test.n_msgs_per_batch")) {
-      LOG(4, "unit_test.n_msgs_per_batch: {}", x.v);
+      LOG(Sev::Dbg, "unit_test.n_msgs_per_batch: {}", x.v);
       n_msgs_per_batch = x.v;
     }
 
@@ -493,7 +493,7 @@ public:
     }
 
     auto cmd = json_to_string(json_command);
-    // LOG(4, "command: {}", cmd);
+    // LOG(Sev::Dbg, "command: {}", cmd);
 
     auto &d = json_command;
     auto fname = get_string(&d, "file_attributes.file_name");
@@ -517,7 +517,7 @@ public:
       auto &fwt = ch.file_writer_tasks.at(0);
       ASSERT_EQ(fwt->demuxers().size(), (size_t)1);
 
-      LOG(6, "processing...");
+      LOG(Sev::Dbg, "processing...");
       using CLK = std::chrono::steady_clock;
       using MS = std::chrono::milliseconds;
       auto t1 = CLK::now();
@@ -531,7 +531,7 @@ public:
               auto &msg = source.msgs[source.n_fed];
               if (false) {
                 auto v = binary_to_hex(msg.data, msg.size);
-                LOG(7, "msg:\n{:.{}}", v.data(), v.size());
+                LOG(Sev::Dbg, "msg:\n{:.{}}", v.data(), v.size());
               }
               fwt->demuxers().at(0).process_message(msg.data, msg.size);
               source.n_fed++;
@@ -544,16 +544,16 @@ public:
         }
       }
       auto t2 = CLK::now();
-      LOG(6, "processing done in {} ms", duration_cast<MS>(t2 - t1).count());
-      LOG(6, "finishing...");
+      LOG(Sev::Dbg, "processing done in {} ms", duration_cast<MS>(t2 - t1).count());
+      LOG(Sev::Dbg, "finishing...");
       {
         string cmd("{\"recv_type\":\"FileWriter\", "
                    "\"cmd\":\"file_writer_tasks_clear_all\"}");
         ch.handle({(char *)cmd.data(), cmd.size()});
       }
       auto t3 = CLK::now();
-      LOG(6, "finishing done in {} ms", duration_cast<MS>(t3 - t2).count());
-      LOG(6, "done in total {} ms", duration_cast<MS>(t3 - t1).count());
+      LOG(Sev::Dbg, "finishing done in {} ms", duration_cast<MS>(t3 - t2).count());
+      LOG(Sev::Dbg, "done in total {} ms", duration_cast<MS>(t3 - t1).count());
     }
 
     if (!do_verification) {
@@ -601,7 +601,7 @@ public:
                                 count.data(), nullptr);
       ASSERT_GE(err, 0);
 
-      // LOG(4, "have {} messages", source.msgs.size());
+      // LOG(Sev::Dbg, "have {} messages", source.msgs.size());
       for (size_t msg_i = 0; msg_i < source.msgs.size(); ++msg_i) {
         auto &fb = source.fbs.at(msg_i);
         A start = {{(hsize_t)msg_i * n_events_per_message}};
@@ -612,7 +612,7 @@ public:
         ASSERT_GE(err, 0);
         auto fbd = fb.root()->detector_id();
         for (int i1 = 0; i1 < n_events_per_message; ++i1) {
-          // LOG(4, "found: {:4}  {:6} vs {:6}", i1, data.at(i1),
+          // LOG(Sev::Dbg, "found: {:4}  {:6} vs {:6}", i1, data.at(i1),
           ASSERT_EQ(data.at(i1), fbd->Get(i1));
         }
       }
@@ -701,7 +701,7 @@ public:
     /// Generates n test messages which we can later feed from memory into the
     /// file writer.
     void pregenerate(size_t array_size, uint64_t n) {
-      LOG(7, "generating {} {}...", topic, source);
+      LOG(Sev::Dbg, "generating {} {}...", topic, source);
       auto ty = FlatBufs::f142::Value::Double;
       if (array_size > 0) {
         ty = FlatBufs::f142::Value::ArrayFloat;
@@ -751,25 +751,25 @@ public:
     if (auto x =
             get_int(&main_opt.config_file, "unit_test.hdf.do_verification")) {
       do_verification = x.v == 1;
-      LOG(4, "do_verification: {}", do_verification);
+      LOG(Sev::Dbg, "do_verification: {}", do_verification);
     }
 
     int n_msgs_per_source = 1;
     if (auto x =
             get_int(&main_opt.config_file, "unit_test.n_msgs_per_source")) {
-      LOG(4, "unit_test.n_msgs_per_source: {}", x.v);
+      LOG(Sev::Dbg, "unit_test.n_msgs_per_source: {}", x.v);
       n_msgs_per_source = int(x.v);
     }
 
     int n_sources = 1;
     if (auto x = get_int(&main_opt.config_file, "unit_test.n_sources")) {
-      LOG(4, "unit_test.n_sources: {}", x.v);
+      LOG(Sev::Dbg, "unit_test.n_sources: {}", x.v);
       n_sources = int(x.v);
     }
 
     int n_msgs_per_batch = 1;
     if (auto x = get_int(&main_opt.config_file, "unit_test.n_msgs_per_batch")) {
-      LOG(4, "unit_test.n_msgs_per_batch: {}", x.v);
+      LOG(Sev::Dbg, "unit_test.n_msgs_per_batch: {}", x.v);
       n_msgs_per_batch = int(x.v);
     }
 
@@ -786,7 +786,7 @@ public:
 
     if (false) {
       for (auto &source : sources) {
-        LOG(4, "msgs: {}  {}", source.source, source.msgs.size());
+        LOG(Sev::Dbg, "msgs: {}  {}", source.source, source.msgs.size());
       }
     }
 
@@ -917,7 +917,7 @@ public:
     }
 
     auto cmd = json_to_string(json_command);
-    // LOG(4, "command: {}", cmd);
+    // LOG(Sev::Dbg, "command: {}", cmd);
 
     auto &d = json_command;
     auto fname = get_string(&d, "file_attributes.file_name");
@@ -940,7 +940,7 @@ public:
       auto &fwt = ch.file_writer_tasks.at(0);
       ASSERT_EQ(fwt->demuxers().size(), (size_t)1);
 
-      LOG(6, "processing...");
+      LOG(Sev::Dbg, "processing...");
       using CLK = std::chrono::steady_clock;
       using MS = std::chrono::milliseconds;
       auto t1 = CLK::now();
@@ -954,7 +954,7 @@ public:
               auto &msg = source.msgs[source.n_fed];
               if (false) {
                 auto v = binary_to_hex(msg.data, msg.size);
-                LOG(7, "msg:\n{:.{}}", v.data(), v.size());
+                LOG(Sev::Dbg, "msg:\n{:.{}}", v.data(), v.size());
               }
               fwt->demuxers().at(0).process_message(msg.data, msg.size);
               source.n_fed++;
@@ -967,16 +967,16 @@ public:
         }
       }
       auto t2 = CLK::now();
-      LOG(6, "processing done in {} ms", duration_cast<MS>(t2 - t1).count());
-      LOG(6, "finishing...");
+      LOG(Sev::Dbg, "processing done in {} ms", duration_cast<MS>(t2 - t1).count());
+      LOG(Sev::Dbg, "finishing...");
       {
         string cmd("{\"recv_type\":\"FileWriter\", "
                    "\"cmd\":\"file_writer_tasks_clear_all\"}");
         ch.handle({(char *)cmd.data(), cmd.size()});
       }
       auto t3 = CLK::now();
-      LOG(6, "finishing done in {} ms", duration_cast<MS>(t3 - t2).count());
-      LOG(6, "done in total {} ms", duration_cast<MS>(t3 - t1).count());
+      LOG(Sev::Dbg, "finishing done in {} ms", duration_cast<MS>(t3 - t2).count());
+      LOG(Sev::Dbg, "done in total {} ms", duration_cast<MS>(t3 - t1).count());
     }
   }
 

--- a/src/tests/command_handler.cxx
+++ b/src/tests/command_handler.cxx
@@ -19,7 +19,7 @@ std::string parse_json_command(const std::string &filename) {
   std::stringstream buffer;
   buffer << t.rdbuf();
   std::string cmd{buffer.str()};
-  LOG(Sev::Dbg, "cmd: {}", cmd.c_str());
+  LOG(Sev::Debug, "cmd: {}", cmd.c_str());
   return cmd;
 }
 

--- a/src/tests/command_handler.cxx
+++ b/src/tests/command_handler.cxx
@@ -19,7 +19,7 @@ std::string parse_json_command(const std::string &filename) {
   std::stringstream buffer;
   buffer << t.rdbuf();
   std::string cmd{buffer.str()};
-  LOG(7, "cmd: {}", cmd.c_str());
+  LOG(Sev::Dbg, "cmd: {}", cmd.c_str());
   return cmd;
 }
 

--- a/src/tests/json.cxx
+++ b/src/tests/json.cxx
@@ -9,7 +9,7 @@ TEST(json, merge_with_exactly_one_conflicting_key) {
   jd1.Parse(R""({"k1": "string1"})"");
   jd2.Parse(R""({"k1": "string2"})"");
   auto jd3 = merge(jd1, jd2);
-  LOG(9, "{}", json_to_string(jd3));
+  LOG(Sev::Dbg, "{}", json_to_string(jd3));
   ASSERT_TRUE(jd3 == jd2);
 }
 
@@ -22,7 +22,7 @@ TEST(json, merge_two_different_keys) {
   "k2": "string2"
 })"");
   auto jd3 = merge(jd1, jd2);
-  LOG(9, "{}", json_to_string(jd3));
+  LOG(Sev::Dbg, "{}", json_to_string(jd3));
   ASSERT_TRUE(jd3 == jde);
 }
 
@@ -55,7 +55,7 @@ TEST(json, merge_3_keys_with_more_complicated_structures) {
   }
 })"");
   auto jd3 = merge(jd1, jd2);
-  LOG(9, "{}", json_to_string(jd3));
+  LOG(Sev::Dbg, "{}", json_to_string(jd3));
   ASSERT_TRUE(jd3 == jde);
 }
 
@@ -106,7 +106,7 @@ TEST(json, merge_deeper_nested_keys) {
 })"");
 
   auto jd3 = merge(jd1, jd2);
-  LOG(9, "expected: {}", json_to_string(jde));
-  LOG(9, "returned: {}", json_to_string(jd3));
+  LOG(Sev::Dbg, "expected: {}", json_to_string(jde));
+  LOG(Sev::Dbg, "returned: {}", json_to_string(jd3));
   ASSERT_TRUE(jd3 == jde);
 }

--- a/src/tests/json.cxx
+++ b/src/tests/json.cxx
@@ -9,7 +9,7 @@ TEST(json, merge_with_exactly_one_conflicting_key) {
   jd1.Parse(R""({"k1": "string1"})"");
   jd2.Parse(R""({"k1": "string2"})"");
   auto jd3 = merge(jd1, jd2);
-  LOG(Sev::Dbg, "{}", json_to_string(jd3));
+  LOG(Sev::Debug, "{}", json_to_string(jd3));
   ASSERT_TRUE(jd3 == jd2);
 }
 
@@ -22,7 +22,7 @@ TEST(json, merge_two_different_keys) {
   "k2": "string2"
 })"");
   auto jd3 = merge(jd1, jd2);
-  LOG(Sev::Dbg, "{}", json_to_string(jd3));
+  LOG(Sev::Debug, "{}", json_to_string(jd3));
   ASSERT_TRUE(jd3 == jde);
 }
 
@@ -55,7 +55,7 @@ TEST(json, merge_3_keys_with_more_complicated_structures) {
   }
 })"");
   auto jd3 = merge(jd1, jd2);
-  LOG(Sev::Dbg, "{}", json_to_string(jd3));
+  LOG(Sev::Debug, "{}", json_to_string(jd3));
   ASSERT_TRUE(jd3 == jde);
 }
 
@@ -106,7 +106,7 @@ TEST(json, merge_deeper_nested_keys) {
 })"");
 
   auto jd3 = merge(jd1, jd2);
-  LOG(Sev::Dbg, "expected: {}", json_to_string(jde));
-  LOG(Sev::Dbg, "returned: {}", json_to_string(jd3));
+  LOG(Sev::Debug, "expected: {}", json_to_string(jde));
+  LOG(Sev::Debug, "returned: {}", json_to_string(jd3));
   ASSERT_TRUE(jd3 == jde);
 }

--- a/src/tests/roundtrip.cxx
+++ b/src/tests/roundtrip.cxx
@@ -43,7 +43,7 @@ int64_t produce_command_from_string(uri::URI const &uri,
   if (x == std::future_status::ready) {
     return fut.get();
   }
-  LOG(Sev::Warn, "Timeout on production of test message");
+  LOG(Sev::Warning, "Timeout on production of test message");
   return -1;
 }
 
@@ -153,7 +153,7 @@ TEST_F(Roundtrip, simple_01) {
 }
 
 void roundtrip_remote_kafka(MainOpt &opt, string fn_cmd) {
-  LOG(Sev::Dbg, "roundtrip_remote_kafka");
+  LOG(Sev::Debug, "roundtrip_remote_kafka");
   using namespace FileWriter;
   using namespace rapidjson;
   using CLK = std::chrono::steady_clock;
@@ -167,7 +167,7 @@ void roundtrip_remote_kafka(MainOpt &opt, string fn_cmd) {
   Document d;
   d.Parse(json_data.data(), json_data.size());
   if (d.HasParseError()) {
-    LOG(Sev::Warn, "ERROR can not parse command");
+    LOG(Sev::Warning, "ERROR can not parse command");
     return;
   }
   auto &a = d.GetAllocator();
@@ -215,7 +215,7 @@ void roundtrip_remote_kafka(MainOpt &opt, string fn_cmd) {
                               fb.builder->GetSize()};
         {
           auto v = binary_to_hex(msg.data, msg.size);
-          LOG(Sev::Dbg, "msg:\n{:.{}}", v.data(), v.size());
+          LOG(Sev::Debug, "msg:\n{:.{}}", v.data(), v.size());
         }
         if (true) {
           topic.produce((uint8_t *)msg.data, msg.size);

--- a/src/tests/roundtrip.cxx
+++ b/src/tests/roundtrip.cxx
@@ -43,7 +43,7 @@ int64_t produce_command_from_string(uri::URI const &uri,
   if (x == std::future_status::ready) {
     return fut.get();
   }
-  LOG(0, "Timeout on production of test message");
+  LOG(Sev::Warn, "Timeout on production of test message");
   return -1;
 }
 
@@ -62,7 +62,7 @@ struct _has_teamid<T, decltype((void)T::teamid, 0)> : std::true_type {
 };
 
 void roundtrip_simple_01(MainOpt &opt) {
-  LOG(5, "Run test:  Test::roundtrip_simple_01");
+  LOG(Sev::Info, "Run test:  Test::roundtrip_simple_01");
   using namespace FileWriter;
   using namespace rapidjson;
   using namespace BrightnESS::FlatBufs::f141_epics_nt;
@@ -141,7 +141,7 @@ void roundtrip_simple_01(MainOpt &opt) {
   while (CLK::now() - start < MS(5000)) {
     std::this_thread::sleep_for(MS(200));
   }
-  LOG(5, "Stop Master");
+  LOG(Sev::Info, "Stop Master");
   m.stop();
   t1.join();
 }
@@ -153,7 +153,7 @@ TEST_F(Roundtrip, simple_01) {
 }
 
 void roundtrip_remote_kafka(MainOpt &opt, string fn_cmd) {
-  LOG(7, "roundtrip_remote_kafka");
+  LOG(Sev::Dbg, "roundtrip_remote_kafka");
   using namespace FileWriter;
   using namespace rapidjson;
   using CLK = std::chrono::steady_clock;
@@ -167,7 +167,7 @@ void roundtrip_remote_kafka(MainOpt &opt, string fn_cmd) {
   Document d;
   d.Parse(json_data.data(), json_data.size());
   if (d.HasParseError()) {
-    LOG(3, "ERROR can not parse command");
+    LOG(Sev::Warn, "ERROR can not parse command");
     return;
   }
   auto &a = d.GetAllocator();
@@ -215,7 +215,7 @@ void roundtrip_remote_kafka(MainOpt &opt, string fn_cmd) {
                               fb.builder->GetSize()};
         {
           auto v = binary_to_hex(msg.data, msg.size);
-          LOG(7, "msg:\n{:.{}}", v.data(), v.size());
+          LOG(Sev::Dbg, "msg:\n{:.{}}", v.data(), v.size());
         }
         if (true) {
           topic.produce((uint8_t *)msg.data, msg.size);
@@ -231,7 +231,7 @@ void roundtrip_remote_kafka(MainOpt &opt, string fn_cmd) {
   while (CLK::now() - start < MS(4000)) {
     std::this_thread::sleep_for(MS(200));
   }
-  LOG(5, "Stop Master");
+  LOG(Sev::Info, "Stop Master");
   m.stop();
   t1.join();
 }


### PR DESCRIPTION
The ambiguity in the log message severity level required some attention and I have for this reason modified the logging code a bit. These are the changes I have made:

* Added severity levels in the form of `enum class Sev`. This class is found in `logger.h` and defines 8 (syslog based) severity levels. The levels are commented in order to help you select which one to use.

* `dwlog()` has been modified to require the severity level in the form of a `enum class Sev` instance.

* All calls to `dwlog()` (the macro `LOG`) have been modified with a `enum class Sev` level to replace the previous `int` level.

* The argument parsers of of *kafka-to-nexus* and *send-command* have been modified to take an explicit severity level (as an integer) instead of as previously, counting the number of occurrences of the `-v` flag.

I tried to infer the appropriate severity levels when replacing the old integer based severity levels.  However, some one more familiar with the code should probably look through all calls to `dwlog()`(`LOG`), there are only 242 of them.