### PR TITLE
Pull in h5cpp as a dependency, supports Conan as well as non-Conan

### DIFF
--- a/cmake/Findh5cpp.cmake
+++ b/cmake/Findh5cpp.cmake
@@ -1,0 +1,7 @@
+find_path(H5CPP_INCLUDE_DIR NAMES h5cpp/hdf5.hpp)
+find_library(H5CPP_LIBRARIES NAMES h5cpp)
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(H5CPP DEFAULT_MSG
+  H5CPP_INCLUDE_DIR
+  H5CPP_LIBRARIES
+)

--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -6,10 +6,12 @@ hdf5/1.10.1-dm3@ess-dmsc/stable
 librdkafka/0.11.1-dm1@ess-dmsc/stable
 RapidJSON/1.1.0-dm1@ess-dmsc/stable
 graylog-logger/1.0.3@ess-dmsc/stable
+h5cpp/0.0.4-dm1@ess-dmsc/stable
 
 [generators]
 cmake
 virtualrunenv
+virtualbuildenv
 
 [options]
 FlatBuffers:shared=True

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,8 @@ find_package(FlatBuffers REQUIRED)
 find_package(StreamingDataTypes COMPONENTS d2247ffd906ebeeb68c9b8a2ea9f1d36c1d88a46)
 find_package(GraylogLogger)
 find_package(GitCommitExtract)
+find_package(h5cpp REQUIRED)
+find_package(Boost COMPONENTS filesystem system REQUIRED)
 
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -fPIC -g -D_GLIBCXX_USE_NANOSLEEP")
@@ -40,6 +42,8 @@ set(path_include_common
   ${HDF5_INCLUDE_DIRS}
   ${FLATBUFFERS_INCLUDE_DIR}
   ${RAPIDJSON_INCLUDE_DIR}
+  ${H5CPP_INCLUDE_DIR}
+  ${Boost_INCLUDE_DIRS}
   ${CURL_INCLUDE_DIRS}
   ${PROJECT_SOURCE_DIR}/src
   ${PROJECT_BINARY_DIR}/src
@@ -48,7 +52,9 @@ set(path_include_common
 set(libraries_common
   ${RDKAFKA_LIBRARIES}
   ${HDF5_C_LIBRARIES}
+  ${H5CPP_LIBRARIES}
   ${CURL_LIBRARIES}
+  ${Boost_LIBRARIES}
   pthread
   z
 )


### PR DESCRIPTION
In preparation for the switch to h5cpp, this commit declares for cmake h5cpp
and the required dependencies.
h5cpp depends on Boost, therefore this is also a dependency now.

Using the new minimal Findh5cpp.cmake we can support Conan-builds as well as
non-Conan-builds.