### PR TITLE
More fields for Master status output

### DIFF
--- a/src/DemuxTopic.h
+++ b/src/DemuxTopic.h
@@ -46,6 +46,18 @@ public:
   to_json(rapidjson::MemoryPoolAllocator<> *_a = nullptr) const;
   ESSTimeStamp &stop_time();
 
+  /// Counts the number of processed message.
+  std::atomic<size_t> messages_processed {0};
+  /// Counts the number of times when a received message is so small that it
+  /// can not be a valid flatbuffer.
+  std::atomic<size_t> error_message_too_small {0};
+  /// Counts the number of times when we can not find a reader for this type of
+  /// flatbuffer.
+  std::atomic<size_t> error_no_flatbuffer_reader {0};
+  /// Counts the number of times when we can not find a source instance for the
+  /// source_name mentioned in the the flatbuffer message.
+  std::atomic<size_t> error_no_source_instance {0};
+
 private:
   std::string _topic;
   std::unordered_map<std::string, Source> _sources_map;

--- a/src/DemuxTopic.h
+++ b/src/DemuxTopic.h
@@ -47,16 +47,16 @@ public:
   ESSTimeStamp &stop_time();
 
   /// Counts the number of processed message.
-  std::atomic<size_t> messages_processed {0};
+  std::atomic<size_t> messages_processed{0};
   /// Counts the number of times when a received message is so small that it
   /// can not be a valid flatbuffer.
-  std::atomic<size_t> error_message_too_small {0};
+  std::atomic<size_t> error_message_too_small{0};
   /// Counts the number of times when we can not find a reader for this type of
   /// flatbuffer.
-  std::atomic<size_t> error_no_flatbuffer_reader {0};
+  std::atomic<size_t> error_no_flatbuffer_reader{0};
   /// Counts the number of times when we can not find a source instance for the
   /// source_name mentioned in the the flatbuffer message.
-  std::atomic<size_t> error_no_source_instance {0};
+  std::atomic<size_t> error_no_source_instance{0};
 
 private:
   std::string _topic;

--- a/src/FileWriterTask.cxx
+++ b/src/FileWriterTask.cxx
@@ -91,9 +91,12 @@ rapidjson::Value FileWriterTask::stats(
     Value demux;
     demux.SetObject();
     demux.AddMember("messages_processed", d.messages_processed.load(), a);
-    demux.AddMember("error_message_too_small", d.error_message_too_small.load(), a);
-    demux.AddMember("error_no_flatbuffer_reader", d.error_no_flatbuffer_reader.load(), a);
-    demux.AddMember("error_no_source_instance", d.error_no_source_instance.load(), a);
+    demux.AddMember("error_message_too_small", d.error_message_too_small.load(),
+                    a);
+    demux.AddMember("error_no_flatbuffer_reader",
+                    d.error_no_flatbuffer_reader.load(), a);
+    demux.AddMember("error_no_source_instance",
+                    d.error_no_source_instance.load(), a);
     js_topics.AddMember(Value(d.topic().c_str(), a), demux, a);
   }
   Value js_fwt;

--- a/src/FileWriterTask.cxx
+++ b/src/FileWriterTask.cxx
@@ -88,7 +88,13 @@ rapidjson::Value FileWriterTask::stats(
   Value js_topics;
   js_topics.SetObject();
   for (auto &d : _demuxers) {
-    js_topics.AddMember(Value(d.topic().c_str(), a), Value(0), a);
+    Value demux;
+    demux.SetObject();
+    demux.AddMember("messages_processed", d.messages_processed.load(), a);
+    demux.AddMember("error_message_too_small", d.error_message_too_small.load(), a);
+    demux.AddMember("error_no_flatbuffer_reader", d.error_no_flatbuffer_reader.load(), a);
+    demux.AddMember("error_no_source_instance", d.error_no_source_instance.load(), a);
+    js_topics.AddMember(Value(d.topic().c_str(), a), demux, a);
   }
   Value js_fwt;
   js_fwt.SetObject();

--- a/src/HDFFile.cxx
+++ b/src/HDFFile.cxx
@@ -906,9 +906,10 @@ int HDFFile::init(hid_t h5file, std::string filename,
                   write_attribute_str(h5file, "HDF5_Version",
                                       h5_version_string_linked().data());
                   write_attribute_str(h5file, "file_name", filename.data());
-                  write_attribute_str(h5file, "creator",
-                                      fmt::format("kafka-to-nexus commit {:.7}",
-                                                  GIT_COMMIT).data());
+                  write_attribute_str(
+                      h5file, "creator",
+                      fmt::format("kafka-to-nexus commit {:.7}", GIT_COMMIT)
+                          .data());
                   write_hdf_iso8601_now(h5file, "file_time");
                   write_attributes_if_present(h5file, &nexus_structure);
 

--- a/src/Master.cxx
+++ b/src/Master.cxx
@@ -87,7 +87,8 @@ void Master::statistics() {
   Value js_files;
   js_files.SetObject();
   for (auto &stream_master : stream_masters) {
-    auto fwt_id_str = fmt::format("{}", stream_master->file_writer_task().job_id());
+    auto fwt_id_str =
+        fmt::format("{}", stream_master->file_writer_task().job_id());
     auto fwt = stream_master->file_writer_task().stats(a);
     js_files.AddMember(Value(fwt_id_str.c_str(), a), fwt, a);
   }

--- a/src/Master.cxx
+++ b/src/Master.cxx
@@ -96,7 +96,6 @@ void Master::statistics() {
   rapidjson::PrettyWriter<rapidjson::StringBuffer> writer(buffer);
   writer.SetIndent(' ', 2);
   js_status.Accept(writer);
-  LOG(Sev::Critical, "Status: {}", buffer.GetString());
   if (status_producer) {
     status_producer->produce((KafkaW::uchar *)buffer.GetString(),
                              buffer.GetSize());

--- a/src/logger.h
+++ b/src/logger.h
@@ -26,9 +26,9 @@ enum class Sev : int {
   Warning = 4,   // Could be an indication of a problem that needs fixing
   Notice = 5,    // Notice, potentially important events that might need special
                  // treatment
-  Info = 6,   // Informational, general run time info for checking the state of
-              // the application
-  Debug = 7,  // Debug, give me a flood of information
+  Info = 6,  // Informational, general run time info for checking the state of
+             // the application
+  Debug = 7, // Debug, give me a flood of information
 };
 
 void dwlog_inner(int level, char const *file, int line, char const *func,


### PR DESCRIPTION
Added top-level `type` key.

Added a few counter. More to come in another PR.

Example:

```
{
  "type": "filewriter_status_master",
  "files": {
    "the_job_id": {
      "filename": "nexus-output.h5",
      "topics": {
        "kafka_topic_number_one": {
          "messages_processed": 632,
          "error_message_too_small": 0,
          "error_no_flatbuffer_reader": 0,
          "error_no_source_instance": 0
        }
      }
    }
  }
}
```