### PR TITLE
Do not overwrite existing HDF file, but produce error instead

### DIFF
--- a/src/HDFFile.cxx
+++ b/src/HDFFile.cxx
@@ -835,7 +835,7 @@ int HDFFile::init(std::string filename, rapidjson::Value const &nexus_structure,
   auto fcpl = H5Pcreate(H5P_FILE_CREATE);
   auto fapl = H5Pcreate(H5P_FILE_ACCESS);
   set_common_props(fcpl, fapl);
-  hid_t h5file = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, fcpl, fapl);
+  hid_t h5file = H5Fcreate(filename.c_str(), H5F_ACC_EXCL, fcpl, fapl);
   if (h5file < 0) {
     std::array<char, 256> cwd;
     getcwd(cwd.data(), cwd.size());

--- a/src/tests/HDFFile.cxx
+++ b/src/tests/HDFFile.cxx
@@ -130,9 +130,11 @@ public:
   static void create_static_file_with_hdf_output_prefix() {
     MainOpt &main_opt = *g_main_opt.load();
     std::string hdf_output_prefix = "tmp-relative-output";
+    std::string hdf_output_filename = "tmp-file-with-hdf-prefix.h5";
 #ifdef _MSC_VER
 #else
     mkdir(hdf_output_prefix.c_str(), 0777);
+    unlink((hdf_output_prefix + "/" + hdf_output_filename).c_str());
 #endif
     {
       std::string jsontxt =
@@ -140,8 +142,7 @@ public:
       merge_config_into_main_opt(main_opt, jsontxt);
       main_opt.hdf_output_prefix = hdf_output_prefix;
     }
-    rapidjson::Document json_command =
-        basic_command("tmp-file-with-hdf-prefix.h5");
+    rapidjson::Document json_command = basic_command(hdf_output_filename);
     command_add_static_dataset_1d(json_command);
 
     auto cmd = json_to_string(json_command);
@@ -165,6 +166,8 @@ public:
   static void create_static_dataset() {
     MainOpt &main_opt = *g_main_opt.load();
     merge_config_into_main_opt(main_opt, R""({})"");
+    std::string hdf_output_filename = "tmp-static-dataset.h5";
+    unlink(hdf_output_filename.c_str());
     rapidjson::Document json_command;
     {
       using namespace rapidjson;
@@ -334,7 +337,7 @@ public:
       {
         Value v;
         v.SetObject();
-        v.AddMember("file_name", StringRef("tmp-static-dataset.h5"), a);
+        v.AddMember("file_name", StringRef(hdf_output_filename.c_str()), a);
         j.AddMember("file_attributes", v, a);
       }
       j.AddMember("cmd", StringRef("FileWriter_new"), a);
@@ -370,6 +373,8 @@ public:
   static void write_attributes_at_top_level_of_the_file() {
     MainOpt &main_opt = *g_main_opt.load();
     merge_config_into_main_opt(main_opt, R""({})"");
+    std::string hdf_output_filename = "tmp_write_top_level_attributes.h5";
+    unlink(hdf_output_filename.c_str());
     rapidjson::Document json_command;
     json_command.Parse(R""({
       "cmd": "FileWriter_new",
@@ -380,10 +385,14 @@ public:
         }
       },
       "file_attributes": {
-        "file_name": "tmp_write_top_level_attributes.h5"
       },
       "job_id": "832yhtwgfskdf"
     })"");
+    json_command.FindMember("file_attributes")
+        ->value.GetObject()
+        .AddMember("file_name", rapidjson::Value(hdf_output_filename.c_str(),
+                                                 json_command.GetAllocator()),
+                   json_command.GetAllocator());
     auto cmd = json_to_string(json_command);
     auto fname = get_string(&json_command, "file_attributes.file_name");
     ASSERT_GT(fname.v.size(), 8);

--- a/src/tests/HDFFile.cxx
+++ b/src/tests/HDFFile.cxx
@@ -127,8 +127,8 @@ public:
 
   static void create_static_file_with_hdf_output_prefix() {
     MainOpt &main_opt = *g_main_opt.load();
-    std::string hdf_output_prefix = "tmp-relative-output";
-    std::string hdf_output_filename = "tmp-file-with-hdf-prefix.h5";
+    std::string const hdf_output_prefix = "tmp-relative-output";
+    std::string const hdf_output_filename = "tmp-file-with-hdf-prefix.h5";
 #ifdef _MSC_VER
 #else
     mkdir(hdf_output_prefix.c_str(), 0777);
@@ -163,7 +163,7 @@ public:
   static void create_static_dataset() {
     MainOpt &main_opt = *g_main_opt.load();
     merge_config_into_main_opt(main_opt, R""({})"");
-    std::string hdf_output_filename = "tmp-static-dataset.h5";
+    std::string const hdf_output_filename = "tmp-static-dataset.h5";
     unlink(hdf_output_filename.c_str());
     rapidjson::Document json_command;
     {
@@ -362,7 +362,7 @@ public:
   static void write_attributes_at_top_level_of_the_file() {
     MainOpt &main_opt = *g_main_opt.load();
     merge_config_into_main_opt(main_opt, R""({})"");
-    std::string hdf_output_filename = "tmp_write_top_level_attributes.h5";
+    std::string const hdf_output_filename = "tmp_write_top_level_attributes.h5";
     unlink(hdf_output_filename.c_str());
     rapidjson::Document json_command;
     json_command.Parse(R""({


### PR DESCRIPTION
Do not overwrite existing HDF file, but produce error instead.

Adjust test cases to `unlink` an existing file before running the test.

Updates #116 