### PR TITLE
Support vector attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ Depending on the `HDFWriterModule`, there will be more options specific to the
 #### Command to start writing a file:
 
 Further documentation:
-- [Groups]()
-- [Datasets]()
+- [Groups](docs/groups.md)
+- [~~Datasets~~]()
 - [Attributes](docs/attributes.md)
-- [File Attributes]()
-- [Streams]()
+- [~~File Attributes~~]()
+- [~~Streams~~]()
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ Depending on the `HDFWriterModule`, there will be more options specific to the
 
 Further documentation:
 - [Groups](docs/groups.md)
-- [~~Datasets~~]()
+- [~~Datasets~~ documentation not yet written]()
 - [Attributes](docs/attributes.md)
-- [~~File Attributes~~]()
-- [~~Streams~~]()
+- [~~File Attributes~~ documentation not yet written]()
+- [~~Streams~~ documentation not yet written]()
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -79,7 +79,14 @@ the `HDFWriterModule` which should be used for writing.
 Depending on the `HDFWriterModule`, there will be more options specific to the
 `HDFWriterModule`.
 
-Command to start writing a file:
+#### Command to start writing a file:
+
+Further documentation:
+- [Groups]()
+- [Datasets]()
+- [Attributes](docs/attributes.md)
+- [File Attributes]()
+- [Streams]()
 
 ```json
 {
@@ -160,7 +167,18 @@ Command to start writing a file:
               "string_size": 32,
               "size": ["unlimited"]
             },
-            "values": ["the-scalar-string", "another-one"]
+            "values": ["the-scalar-string", "another-one"],
+            "attributes": [
+            {
+              "name": "scalar_attribute",
+              "values": 42
+            },
+            {
+              "name": "vector_attribute",
+              "values": [1,2,3],
+              "type": "uint32"
+            }
+            ]
           }
         ]
       }
@@ -177,13 +195,13 @@ Command to start writing a file:
 }
 ```
 
-Command to exit the file writer:
+#### Command to exit the file writer:
 
 ```json
 {"cmd": "FileWriter_exit"}
 ```
 
-Command to stop a single file:
+#### Command to stop a single file:
 
 ```json
 {
@@ -193,7 +211,7 @@ Command to stop a single file:
 }
 ```
 
-Commands can be given in the configuration file as well:
+#### Commands can be given in the configuration file as well:
 
 ```json
 {
@@ -202,7 +220,6 @@ Commands can be given in the configuration file as well:
   ]
 }
 ```
-
 
 
 ### Options for the f142 writer module

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -2,12 +2,14 @@
 
 [Attributes](https://support.hdfgroup.org/HDF5/doc1.6/UG/13_Attributes.html) are
 metadata which can be attached to groups or datasets. They are added using the
-`attributes` keyword with the value as either an object or an array. If an
-object is provided it contains attribute names and values as key-value pairs.
+`attributes` key with the value as either an object or an array. NeXus classes
+are defined using a [group](groups.md) with an attribute named `NX_class`.
 
 ## Attributes object
 
-Here is a dataset with an `attributes` object as an example:
+If an object is provided as the `attributes`, it contains attribute names
+and values as key-value pairs. Here is a dataset with an `attributes`
+object as an example:
 
 ```json
 

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -1,0 +1,53 @@
+# Attributes
+
+[Attributes](https://support.hdfgroup.org/HDF5/doc1.6/UG/13_Attributes.html) are
+metadata which can be attached to groups or datasets. They are added using the
+`attributes` keyword with the value as either an object or an array. If an
+object is provided it contains attribute names and values as key-value pairs.
+
+## Attributes object
+
+Here is a dataset with an `attributes` object as an example:
+
+```json
+
+{
+  "type": "dataset",
+  "name": "some_dataset",
+  "values": 42.24,
+  "attributes": {
+    "units": "Kelvin",
+    "error": 0.02
+  }
+}
+
+```
+
+In this case the type which should be used in the NeXus file for each attribute
+value is inferred by the file writer. The other limitation is that attribute
+values which are arrays are not supported. If these are required an
+`attributes` array must be used instead.
+
+## Attributes array
+
+Using an array for the `attributes` is more verbose but allows specification
+of types and also for attributes with an array of values. Specifying
+type is optional in the case of scalars, but compulsory for arrays.
+
+```json
+{
+  "type": "group",
+  "name": "group_with_attributes_array",
+  "attributes": [
+  {
+    "name": "scalar_attribute",
+    "values": 42
+  },
+  {
+    "name": "vector_attribute",
+    "values": [1, 2, 3],
+    "type": "uint32"
+  }
+  ]
+}
+``` 

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -1,0 +1,29 @@
+# Groups
+
+Groups are analogous to directories in a filesystem. They can have datasets,
+streams or other groups in their array of `children`. They can also have
+[attributes](attributes.md).
+
+Possible fields are:
+- `"type": "group"` (required)
+- `"name": "<GROUP NAME>"` (required)
+- `"children": []` - array may contain `dataset`, `stream`, `group`.
+- `"attributes":` - object or array of [attributes](attributes.md).
+
+Example:
+```json
+
+{
+  "type": "group",
+  "name": "instrument",
+  "attributes": {
+    "NX_class": "NXinstrument"
+  },
+  "children": [
+    {
+      "type": "dataset",
+      "values": 42
+    }
+  ]
+}
+```

--- a/src/HDFFile.cxx
+++ b/src/HDFFile.cxx
@@ -186,21 +186,21 @@ void HDFFile::write_attributes(hdf5::node::Node &node,
 /// \param JsonValue : json value array of attribute objects
 void HDFFile::writeArrayOfAttributes(hdf5::node::Node &Node,
                                      const rapidjson::Value *JsonValue) {
-  for (const auto &attribute : JsonValue->GetArray()) {
-    if (attribute.IsObject()) {
+  for (const auto &Attribute : JsonValue->GetArray()) {
+    if (Attribute.IsObject()) {
       string Name;
-      if (auto NameString = get_string(&attribute, "name")) {
+      if (auto NameString = get_string(&Attribute, "name")) {
         Name = NameString.v;
       } else {
         continue;
       }
 
-      auto attr = attribute.GetObject();
+      auto attr = Attribute.GetObject();
       auto ValuesField = attr.FindMember("values");
 
       if (ValuesField != attr.MemberEnd()) {
         std::string DType;
-        auto AttrType = get_string(&attribute, "type");
+        auto AttrType = get_string(&Attribute, "type");
         auto Values = &ValuesField->value;
         if (AttrType) {
           DType = AttrType.v;
@@ -227,46 +227,101 @@ void HDFFile::writeAttrOfSpecifiedType(std::string const &DType,
                                        std::string const &Name,
                                        rapidjson::Value const *Values) {
   try {
-    if (Values->IsArray()) {
-      //TODO something
-
-      //populate_blob(Values, Values->GetArray().Size());
-    }
-
     if (DType == "uint8") {
-      write_attribute(Node, Name, static_cast<uint8_t>(Values->GetUint()));
+      if (Values->IsArray()) {
+        auto ValueArray =
+            populate_blob<uint8_t>(Values, Values->GetArray().Size());
+        write_attribute(Node, Name, ValueArray);
+      } else {
+        write_attribute(Node, Name, static_cast<uint8_t>(Values->GetUint()));
+      }
     }
     if (DType == "uint16") {
-      write_attribute(Node, Name, static_cast<uint16_t>(Values->GetUint()));
+      if (Values->IsArray()) {
+        auto ValueArray =
+            populate_blob<uint16_t>(Values, Values->GetArray().Size());
+        write_attribute(Node, Name, ValueArray);
+      } else {
+        write_attribute(Node, Name, static_cast<uint16_t>(Values->GetUint()));
+      }
     }
     if (DType == "uint32") {
-      write_attribute(Node, Name, static_cast<uint32_t>(Values->GetUint()));
+      if (Values->IsArray()) {
+        auto ValueArray =
+            populate_blob<uint32_t>(Values, Values->GetArray().Size());
+        write_attribute(Node, Name, ValueArray);
+      } else {
+        write_attribute(Node, Name, static_cast<uint32_t>(Values->GetUint()));
+      }
     }
     if (DType == "uint64") {
-      write_attribute(Node, Name, static_cast<uint64_t>(Values->GetUint64()));
+      if (Values->IsArray()) {
+        auto ValueArray =
+            populate_blob<uint64_t>(Values, Values->GetArray().Size());
+        write_attribute(Node, Name, ValueArray);
+      } else {
+        write_attribute(Node, Name, static_cast<uint64_t>(Values->GetUint64()));
+      }
     }
     if (DType == "int8") {
-      write_attribute(Node, Name, static_cast<int8_t>(Values->GetInt()));
+      if (Values->IsArray()) {
+        auto ValueArray =
+            populate_blob<int8_t>(Values, Values->GetArray().Size());
+        write_attribute(Node, Name, ValueArray);
+      } else {
+        write_attribute(Node, Name, static_cast<int8_t>(Values->GetInt()));
+      }
     }
     if (DType == "int16") {
-      write_attribute(Node, Name, static_cast<int16_t>(Values->GetInt()));
+      if (Values->IsArray()) {
+        auto ValueArray =
+            populate_blob<int16_t>(Values, Values->GetArray().Size());
+        write_attribute(Node, Name, ValueArray);
+      } else {
+        write_attribute(Node, Name, static_cast<int16_t>(Values->GetInt()));
+      }
     }
     if (DType == "int32") {
-      write_attribute(Node, Name, static_cast<int32_t>(Values->GetInt()));
+      if (Values->IsArray()) {
+        auto ValueArray =
+            populate_blob<int32_t>(Values, Values->GetArray().Size());
+        write_attribute(Node, Name, ValueArray);
+      } else {
+        write_attribute(Node, Name, static_cast<int32_t>(Values->GetInt()));
+      }
     }
     if (DType == "int64") {
-      write_attribute(Node, Name, static_cast<int64_t>(Values->GetInt64()));
+      if (Values->IsArray()) {
+        auto ValueArray =
+            populate_blob<int64_t>(Values, Values->GetArray().Size());
+        write_attribute(Node, Name, ValueArray);
+      } else {
+        write_attribute(Node, Name, static_cast<int64_t>(Values->GetInt64()));
+      }
     }
     if (DType == "float") {
-      write_attribute(Node, Name, Values->GetFloat());
+      if (Values->IsArray()) {
+        auto ValueArray =
+            populate_blob<float>(Values, Values->GetArray().Size());
+        write_attribute(Node, Name, ValueArray);
+      } else {
+        write_attribute(Node, Name, Values->GetFloat());
+      }
     }
     if (DType == "double") {
-      write_attribute(Node, Name, Values->GetDouble());
+      if (Values->IsArray()) {
+        auto ValueArray =
+            populate_blob<double>(Values, Values->GetArray().Size());
+        write_attribute(Node, Name, ValueArray);
+      } else {
+        write_attribute(Node, Name, Values->GetDouble());
+      }
     }
     if (DType == "string") {
       const std::string StringValue = Values->GetString();
       auto string_type = hdf5::datatype::String::fixed(StringValue.size());
-      auto StringAttr = Node.attributes.create(Name, string_type, hdf5::dataspace::Scalar());
+      auto StringAttr =
+          Node.attributes.create(Name, string_type, hdf5::dataspace::Scalar());
       StringAttr.write(Values->GetString(), string_type);
     }
   } catch (std::exception &e) {

--- a/src/HDFFile.cxx
+++ b/src/HDFFile.cxx
@@ -318,11 +318,19 @@ void HDFFile::writeAttrOfSpecifiedType(std::string const &DType,
       }
     }
     if (DType == "string") {
-      const std::string StringValue = Values->GetString();
-      auto string_type = hdf5::datatype::String::fixed(StringValue.size());
-      auto StringAttr =
-          Node.attributes.create(Name, string_type, hdf5::dataspace::Scalar());
-      StringAttr.write(Values->GetString(), string_type);
+      if (Values->IsArray()) {
+        auto ValueArray = populate_strings(Values, Values->GetArray().Size());
+        auto StringAttr = Node.attributes.create(
+            Name, hdf5::datatype::create<std::string>(),
+            hdf5::dataspace::Simple{{Values->GetArray().Size()}});
+        StringAttr.write(ValueArray);
+      } else {
+        const std::string StringValue = Values->GetString();
+        auto string_type = hdf5::datatype::String::fixed(StringValue.size());
+        auto StringAttr = Node.attributes.create(Name, string_type,
+                                                 hdf5::dataspace::Scalar());
+        StringAttr.write(Values->GetString(), string_type);
+      }
     }
   } catch (std::exception &e) {
     std::stringstream ss;

--- a/src/HDFFile.cxx
+++ b/src/HDFFile.cxx
@@ -107,7 +107,7 @@ static void writeAttrNumeric(hdf5::node::Node &Node, const std::string &Name,
   if (Values->IsArray()) {
     length = Values->GetArray().Size();
   }
-  auto ValueData = populate_blob<uint8_t>(Values, length);
+  auto ValueData = populate_blob<T>(Values, length);
   try {
     if (Values->IsArray()) {
       write_attribute(Node, Name, ValueData);
@@ -678,9 +678,7 @@ void HDFFile::write_dataset(hdf5::node::Group &parent,
   write_ds_generic(dtype, parent, name, sizes, max, element_size, vals);
   auto dset = hdf5::node::Dataset(parent.nodes[name]);
 
-  // Handle attributes on this dataset
-  if (auto x = get_object(*value, "attributes"))
-    write_attributes(dset, x.v);
+  write_attributes_if_present(dset , value);
 }
 
 void HDFFile::create_hdf_structures(rapidjson::Value const *value,

--- a/src/HDFFile.cxx
+++ b/src/HDFFile.cxx
@@ -804,8 +804,7 @@ void HDFFile::init(const std::string &nexus_structure,
                    std::vector<StreamHDFInfo> &stream_hdf_info) {
   rapidjson::Document document;
   document.Parse(nexus_structure.c_str());
-  const rapidjson::Value &nexus_structure_json = document["nexus_structure"];
-  init(nexus_structure_json, stream_hdf_info);
+  init(document, stream_hdf_info);
 }
 
 void HDFFile::init(rapidjson::Value const &nexus_structure,

--- a/src/HDFFile.cxx
+++ b/src/HDFFile.cxx
@@ -117,11 +117,9 @@ void HDFFile::write_attributes(hdf5::node::Node &node,
     for (auto &at : jsv->GetObject()) {
       if (at.value.IsString()) {
         write_attribute_str(node, at.name.GetString(), at.value.GetString());
-      }
-      if (at.value.IsInt64()) {
+      } else if (at.value.IsInt64()) {
         write_attribute(node, at.name.GetString(), at.value.GetInt64());
-      }
-      if (at.value.IsDouble()) {
+      } else if (at.value.IsDouble()) {
         write_attribute(node, at.name.GetString(), at.value.GetDouble());
       }
     }

--- a/src/HDFFile.cxx
+++ b/src/HDFFile.cxx
@@ -642,6 +642,14 @@ void HDFFile::init(std::string filename,
   }
 }
 
+void HDFFile::init(const std::string &nexus_structure,
+                   std::vector<StreamHDFInfo> &stream_hdf_info) {
+  rapidjson::Document document;
+  document.Parse(nexus_structure.c_str());
+  const rapidjson::Value& nexus_structure_json = document["nexus_structure"];
+  init(nexus_structure_json, stream_hdf_info);
+}
+
 void HDFFile::init(rapidjson::Value const &nexus_structure,
                    std::vector<StreamHDFInfo> &stream_hdf_info) {
 

--- a/src/HDFFile.cxx
+++ b/src/HDFFile.cxx
@@ -678,7 +678,7 @@ void HDFFile::write_dataset(hdf5::node::Group &parent,
   write_ds_generic(dtype, parent, name, sizes, max, element_size, vals);
   auto dset = hdf5::node::Dataset(parent.nodes[name]);
 
-  write_attributes_if_present(dset , value);
+  write_attributes_if_present(dset, value);
 }
 
 void HDFFile::create_hdf_structures(rapidjson::Value const *value,

--- a/src/HDFFile.h
+++ b/src/HDFFile.h
@@ -104,15 +104,34 @@ private:
                                hdf5::property::FileAccessList &fapl) {}
 
   template <typename T>
-  static void write_attribute(hdf5::node::Node &node, std::string name,
+  static void write_attribute(hdf5::node::Node &node, const std::string &name,
                               T value) {
     hdf5::property::AttributeCreationList acpl;
     acpl.character_encoding(hdf5::datatype::CharacterEncoding::UTF8);
     node.attributes.create<T>(name, acpl).write(value);
   }
+
+  template <typename T>
+  static void write_attribute(hdf5::node::Node &node, const std::string &name,
+                              std::vector<T> values) {
+    hdf5::property::AttributeCreationList acpl;
+    acpl.character_encoding(hdf5::datatype::CharacterEncoding::UTF8);
+    node.attributes.create<T>(name, {values.size()}, acpl).write(values);
+  }
+
   template <typename T>
   void write_hdf_ds_iso8601(hdf5::node::Group &parent, const std::string &name,
                             T &ts);
+
+  static void writeObjectOfAttributes(hdf5::node::Node &node,
+                                      const rapidjson::Value *jsv);
+
+  static void writeArrayOfAttributes(hdf5::node::Node &node,
+                                     const rapidjson::Value *jsv);
+
+  static void writeScalarAttribute(hdf5::node::Node &node,
+                                   const std::string &Name,
+                                   const rapidjson::Value *attrValue);
 };
 
 } // namespace FileWriter

--- a/src/HDFFile.h
+++ b/src/HDFFile.h
@@ -28,6 +28,9 @@ public:
             rapidjson::Value const &config_file,
             std::vector<StreamHDFInfo> &stream_hdf_info);
 
+  void init(const std::string &nexus_structure,
+            std::vector<StreamHDFInfo> &stream_hdf_info);
+
   void init(rapidjson::Value const &nexus_structure,
             std::vector<StreamHDFInfo> &stream_hdf_info);
 

--- a/src/HDFFile.h
+++ b/src/HDFFile.h
@@ -104,22 +104,6 @@ private:
                                hdf5::property::FileAccessList &fapl) {}
 
   template <typename T>
-  static void write_attribute(hdf5::node::Node &node, const std::string &name,
-                              T value) {
-    hdf5::property::AttributeCreationList acpl;
-    acpl.character_encoding(hdf5::datatype::CharacterEncoding::UTF8);
-    node.attributes.create<T>(name, acpl).write(value);
-  }
-
-  template <typename T>
-  static void write_attribute(hdf5::node::Node &node, const std::string &name,
-                              std::vector<T> values) {
-    hdf5::property::AttributeCreationList acpl;
-    acpl.character_encoding(hdf5::datatype::CharacterEncoding::UTF8);
-    node.attributes.create<T>(name, {values.size()}, acpl).write(values);
-  }
-
-  template <typename T>
   void write_hdf_ds_iso8601(hdf5::node::Group &parent, const std::string &name,
                             T &ts);
 

--- a/src/HDFFile.h
+++ b/src/HDFFile.h
@@ -126,12 +126,17 @@ private:
   static void writeObjectOfAttributes(hdf5::node::Node &node,
                                       const rapidjson::Value *jsv);
 
-  static void writeArrayOfAttributes(hdf5::node::Node &node,
-                                     const rapidjson::Value *jsv);
+  static void writeArrayOfAttributes(hdf5::node::Node &Node,
+                                     const rapidjson::Value *JsonValue);
 
-  static void writeScalarAttribute(hdf5::node::Node &node,
+  static void writeScalarAttribute(hdf5::node::Node &Node,
                                    const std::string &Name,
-                                   const rapidjson::Value *attrValue);
+                                   const rapidjson::Value *AttrValue);
+
+  static void writeAttrOfSpecifiedType(std::string const &DType,
+                                       hdf5::node::Node &Node,
+                                       std::string const &Name,
+                                       rapidjson::Value const *Values);
 };
 
 } // namespace FileWriter

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(sources
 tests.cxx
 roundtrip.cxx
 HDFFile.cxx
+HDFFileTest.cpp
 helper.cxx
 json.cxx
 uri.cxx

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -6,7 +6,7 @@ set(sources
 tests.cxx
 roundtrip.cxx
 HDFFile.cxx
-HDFFileTest.cpp
+HDFFileAttributesTest.cpp
 helper.cxx
 json.cxx
 uri.cxx

--- a/src/tests/HDFFile.cxx
+++ b/src/tests/HDFFile.cxx
@@ -1146,7 +1146,7 @@ public:
 
   static void attribute_string_scalar() {
     hdf5::property::FileAccessList fapl;
-    //    fapl.driver(hdf5::file::MemoryDriver());
+    fapl.driver(hdf5::file::MemoryDriver());
 
     FileWriter::HDFFile hdf_file;
     hdf_file.h5file = hdf5::file::create(
@@ -1197,7 +1197,7 @@ public:
 
   static void dataset_static_1d_string_fixed() {
     hdf5::property::FileAccessList fapl;
-    //    fapl.driver(hdf5::file::MemoryDriver());
+    fapl.driver(hdf5::file::MemoryDriver());
 
     FileWriter::HDFFile hdf_file;
     hdf_file.h5file =
@@ -1234,7 +1234,7 @@ public:
 
   static void dataset_static_1d_string_variable() {
     hdf5::property::FileAccessList fapl;
-    //    fapl.driver(hdf5::file::MemoryDriver());
+    fapl.driver(hdf5::file::MemoryDriver());
 
     FileWriter::HDFFile hdf_file;
     hdf_file.h5file =

--- a/src/tests/HDFFile.cxx
+++ b/src/tests/HDFFile.cxx
@@ -1144,39 +1144,6 @@ public:
     }
   }
 
-  static void attribute_string_scalar() {
-    hdf5::property::FileAccessList fapl;
-    fapl.driver(hdf5::file::MemoryDriver());
-
-    FileWriter::HDFFile hdf_file;
-    hdf_file.h5file = hdf5::file::create(
-        "tmp-attr-scalar.h5", hdf5::file::AccessFlags::TRUNCATE,
-        hdf5::property::FileCreationList(), fapl);
-
-    rapidjson::Document nexus_structure;
-    nexus_structure.Parse(R""({
-      "children": [
-        {
-          "type": "group",
-          "name": "group1",
-          "attributes": {
-            "hello": "world"
-          }
-        }
-      ]
-    })"");
-    ASSERT_EQ(nexus_structure.HasParseError(), false);
-    std::vector<FileWriter::StreamHDFInfo> stream_hdf_info;
-    hdf_file.init(nexus_structure, stream_hdf_info);
-
-    auto a1 = hdf5::node::get_group(hdf_file.root_group, "/group1")
-                  .attributes["hello"];
-    ASSERT_EQ(a1.datatype().get_class(), hdf5::datatype::Class::STRING);
-    std::string val;
-    a1.read(val, a1.datatype());
-    ASSERT_EQ(val, "world");
-  }
-
   /// Read a string from the given dataset at the given position.
   /// Helper for other unit tests.
   /// So far only for 1d datasets.
@@ -1286,10 +1253,6 @@ TEST_F(T_CommandHandler, write_attributes_at_top_level_of_the_file) {
 TEST_F(T_CommandHandler, data_ev42) { T_CommandHandler::data_ev42(); }
 
 TEST_F(T_CommandHandler, data_f142) { T_CommandHandler::data_f142(); }
-
-TEST_F(T_CommandHandler, attribute_string_scalar) {
-  T_CommandHandler::attribute_string_scalar();
-}
 
 TEST_F(T_CommandHandler, dataset_static_1d_string_fixed) {
   T_CommandHandler::dataset_static_1d_string_fixed();

--- a/src/tests/HDFFileAttributesTest.cpp
+++ b/src/tests/HDFFileAttributesTest.cpp
@@ -14,7 +14,39 @@ FileWriter::HDFFile createInMemoryTestFile(const std::string &Filename) {
   return TestFile;
 }
 
-TEST(HDFFileAttributesTest, whenCommandContainsScalarStringAttributeItIsWrittenToFile) {
+TEST(HDFFileAttributesTest,
+     whenCommandContainsNumericalAttributeItIsWrittenToFile) {
+  using namespace hdf5;
+
+  auto TestFile = createInMemoryTestFile("test-numerical-attribute.nxs");
+
+  std::string CommandWithNumericalAttr = R""({
+      "nexus_structure": {
+        "children": [
+          {
+            "type": "dataset",
+            "name": "dataset_with_numerical_attr",
+            "values" : 3,
+            "attributes": {
+              "the_answer_is": 42
+            }
+          }
+        ]
+      }
+    })"";
+  std::vector<FileWriter::StreamHDFInfo> EmptyStreamHDFInfo;
+  TestFile.init(CommandWithNumericalAttr, EmptyStreamHDFInfo);
+
+  auto Attr = hdf5::node::get_dataset(TestFile.root_group,
+                                      "/dataset_with_numerical_attr")
+                  .attributes["the_answer_is"];
+  int AttrValue;
+  Attr.read(AttrValue);
+  ASSERT_EQ(AttrValue, 42);
+}
+
+TEST(HDFFileAttributesTest,
+     whenCommandContainsScalarStringAttributeItIsWrittenToFile) {
   using namespace hdf5;
 
   auto TestFile = createInMemoryTestFile("test-scalar-string-attribute.nxs");
@@ -44,7 +76,8 @@ TEST(HDFFileAttributesTest, whenCommandContainsScalarStringAttributeItIsWrittenT
   ASSERT_EQ(StringValue, "world");
 }
 
-TEST(HDFFileAttributesTest, whenCommandContainsArrayOfAttributesTheyAreWrittenToFile) {
+TEST(HDFFileAttributesTest,
+     whenCommandContainsArrayOfAttributesTheyAreWrittenToFile) {
   using namespace hdf5;
 
   auto TestFile = createInMemoryTestFile("test-array-of-attributes.nxs");
@@ -88,7 +121,8 @@ TEST(HDFFileAttributesTest, whenCommandContainsArrayOfAttributesTheyAreWrittenTo
   ASSERT_EQ(StringValue, "string_value");
 }
 
-TEST(HDFFileAttributesTest, whenCommandContainsAttrOfSpecifiedTypeItIsWrittenToFile) {
+TEST(HDFFileAttributesTest,
+     whenCommandContainsAttrOfSpecifiedTypeItIsWrittenToFile) {
   using namespace hdf5;
 
   auto TestFile = createInMemoryTestFile("test-typed-attribute.nxs");
@@ -114,9 +148,8 @@ TEST(HDFFileAttributesTest, whenCommandContainsAttrOfSpecifiedTypeItIsWrittenToF
   std::vector<FileWriter::StreamHDFInfo> EmptyStreamHDFInfo;
   TestFile.init(CommandWithTypedAttrs, EmptyStreamHDFInfo);
 
-  auto IntAttr =
-      node::get_group(TestFile.root_group, "group_with_typed_attrs")
-          .attributes["uint32_attribute"];
+  auto IntAttr = node::get_group(TestFile.root_group, "group_with_typed_attrs")
+                     .attributes["uint32_attribute"];
   uint32_t IntValue;
   IntAttr.read(IntValue);
   ASSERT_EQ(IntValue, 42);

--- a/src/tests/HDFFileAttributesTest.cpp
+++ b/src/tests/HDFFileAttributesTest.cpp
@@ -132,12 +132,17 @@ TEST(HDFFileAttributesTest, whenCommandContainsArrayAttrItIsWrittenToFile) {
       "children": [
         {
           "type": "group",
-          "name": "group_with_array_attr",
+          "name": "group_with_array_attrs",
           "attributes": [
             {
               "name": "array_attribute",
               "values": [1, 2, 3],
               "type": "uint64"
+            },
+            {
+              "name": "array_string_attribute",
+              "values": ["A", "B"],
+              "type": "string"
             }
           ]
         }
@@ -149,11 +154,19 @@ TEST(HDFFileAttributesTest, whenCommandContainsArrayAttrItIsWrittenToFile) {
   TestFile.init(CommandWithArrayAttr, EmptyStreamHDFInfo);
 
   auto ArrayAttr =
-      node::get_group(TestFile.root_group, "group_with_array_attr")
+      node::get_group(TestFile.root_group, "group_with_array_attrs")
           .attributes["array_attribute"];
   std::vector<int> ArrayAttrValues(3);
   ArrayAttr.read(ArrayAttrValues);
   ASSERT_EQ(ArrayAttrValues[0], 1);
   ASSERT_EQ(ArrayAttrValues[1], 2);
   ASSERT_EQ(ArrayAttrValues[2], 3);
+
+  auto ArrayStringAttr =
+      node::get_group(TestFile.root_group, "group_with_array_attrs")
+          .attributes["array_string_attribute"];
+  std::vector<std::string> ArrayStringAttrValues(2);
+  ArrayStringAttr.read(ArrayStringAttrValues);
+  ASSERT_EQ(ArrayStringAttrValues[0], "A");
+  ASSERT_EQ(ArrayStringAttrValues[1], "B");
 }

--- a/src/tests/HDFFileAttributesTest.cpp
+++ b/src/tests/HDFFileAttributesTest.cpp
@@ -21,18 +21,16 @@ TEST(HDFFileAttributesTest,
   auto TestFile = createInMemoryTestFile("test-numerical-attribute.nxs");
 
   std::string CommandWithNumericalAttr = R""({
-      "nexus_structure": {
-        "children": [
-          {
-            "type": "dataset",
-            "name": "dataset_with_numerical_attr",
-            "values" : 3,
-            "attributes": {
-              "the_answer_is": 42
-            }
+      "children": [
+        {
+          "type": "dataset",
+          "name": "dataset_with_numerical_attr",
+          "values" : 3,
+          "attributes": {
+            "the_answer_is": 42
           }
-        ]
-      }
+        }
+      ]
     })"";
   std::vector<FileWriter::StreamHDFInfo> EmptyStreamHDFInfo;
   TestFile.init(CommandWithNumericalAttr, EmptyStreamHDFInfo);
@@ -52,17 +50,15 @@ TEST(HDFFileAttributesTest,
   auto TestFile = createInMemoryTestFile("test-scalar-string-attribute.nxs");
 
   std::string CommandWithScalarStringAttr = R""({
-      "nexus_structure": {
-        "children": [
-          {
-            "type": "group",
-            "name": "group_with_scalar_string_attr",
-            "attributes": {
-              "hello": "world"
-            }
+      "children": [
+        {
+          "type": "group",
+          "name": "group_with_scalar_string_attr",
+          "attributes": {
+            "hello": "world"
           }
-        ]
-      }
+        }
+      ]
     })"";
   std::vector<FileWriter::StreamHDFInfo> EmptyStreamHDFInfo;
   TestFile.init(CommandWithScalarStringAttr, EmptyStreamHDFInfo);
@@ -83,24 +79,22 @@ TEST(HDFFileAttributesTest,
   auto TestFile = createInMemoryTestFile("test-array-of-attributes.nxs");
 
   std::string CommandWithArrayOfAttrs = R""({
-    "nexus_structure": {
-      "children": [
-        {
-          "type": "group",
-          "name": "group_with_array_of_attrs",
-          "attributes": [
-            {
-              "name": "integer_attribute",
-              "values": 42
-            },
-            {
-              "name": "string_attribute",
-              "values": "string_value"
-            }
-          ]
-        }
-      ]
-    }
+    "children": [
+      {
+        "type": "group",
+        "name": "group_with_array_of_attrs",
+        "attributes": [
+          {
+            "name": "integer_attribute",
+            "values": 42
+          },
+          {
+            "name": "string_attribute",
+            "values": "string_value"
+          }
+        ]
+      }
+    ]
   })"";
 
   std::vector<FileWriter::StreamHDFInfo> EmptyStreamHDFInfo;
@@ -128,21 +122,19 @@ TEST(HDFFileAttributesTest,
   auto TestFile = createInMemoryTestFile("test-typed-attribute.nxs");
 
   std::string CommandWithTypedAttrs = R""({
-    "nexus_structure": {
-      "children": [
-        {
-          "type": "group",
-          "name": "group_with_typed_attrs",
-          "attributes": [
-            {
-              "name": "uint32_attribute",
-              "values": 42,
-              "type": "uint32"
-            }
-          ]
-        }
-      ]
-    }
+    "children": [
+      {
+        "type": "group",
+        "name": "group_with_typed_attrs",
+        "attributes": [
+          {
+            "name": "uint32_attribute",
+            "values": 42,
+            "type": "uint32"
+          }
+        ]
+      }
+    ]
   })"";
 
   std::vector<FileWriter::StreamHDFInfo> EmptyStreamHDFInfo;
@@ -161,26 +153,24 @@ TEST(HDFFileAttributesTest, whenCommandContainsArrayAttrItIsWrittenToFile) {
   auto TestFile = createInMemoryTestFile("test-array-attribute.nxs");
 
   std::string CommandWithArrayAttr = R""({
-    "nexus_structure": {
-      "children": [
-        {
-          "type": "group",
-          "name": "group_with_array_attrs",
-          "attributes": [
-            {
-              "name": "array_attribute",
-              "values": [1, 2, 3],
-              "type": "uint64"
-            },
-            {
-              "name": "array_string_attribute",
-              "values": ["A", "B"],
-              "type": "string"
-            }
-          ]
-        }
-      ]
-    }
+    "children": [
+      {
+        "type": "group",
+        "name": "group_with_array_attrs",
+        "attributes": [
+          {
+            "name": "array_attribute",
+            "values": [1, 2, 3],
+            "type": "uint64"
+          },
+          {
+            "name": "array_string_attribute",
+            "values": ["A", "B"],
+            "type": "string"
+          }
+        ]
+      }
+    ]
   })"";
 
   std::vector<FileWriter::StreamHDFInfo> EmptyStreamHDFInfo;

--- a/src/tests/HDFFileAttributesTest.cpp
+++ b/src/tests/HDFFileAttributesTest.cpp
@@ -103,9 +103,7 @@ TEST(HDFFileAttributesTest, whenCommandContainsAttrOfSpecifiedTypeItIsWrittenToF
             {
               "name": "uint32_attribute",
               "values": 42,
-              "dataset": {
-                "type": "uint32"
-              }
+              "type": "uint32"
             }
           ]
         }
@@ -137,11 +135,9 @@ TEST(HDFFileAttributesTest, whenCommandContainsArrayAttrItIsWrittenToFile) {
           "name": "group_with_array_attr",
           "attributes": [
             {
-              "name": "array",
-              "values":[1, 2, 3],
-              "dataset": {
-                "type": "uint64"
-              }
+              "name": "array_attribute",
+              "values": [1, 2, 3],
+              "type": "uint64"
             }
           ]
         }
@@ -153,9 +149,9 @@ TEST(HDFFileAttributesTest, whenCommandContainsArrayAttrItIsWrittenToFile) {
   TestFile.init(CommandWithArrayAttr, EmptyStreamHDFInfo);
 
   auto ArrayAttr =
-      node::get_group(TestFile.root_group, "group_with_vector_attr")
-          .attributes["array"];
-  std::vector<int> ArrayAttrValues;
+      node::get_group(TestFile.root_group, "group_with_array_attr")
+          .attributes["array_attribute"];
+  std::vector<int> ArrayAttrValues(3);
   ArrayAttr.read(ArrayAttrValues);
   ASSERT_EQ(ArrayAttrValues[0], 1);
   ASSERT_EQ(ArrayAttrValues[1], 2);

--- a/src/tests/HDFFileAttributesTest.cpp
+++ b/src/tests/HDFFileAttributesTest.cpp
@@ -14,7 +14,7 @@ FileWriter::HDFFile createInMemoryTestFile(const std::string &Filename) {
   return TestFile;
 }
 
-TEST(HDFFileTest, whenCommandContainsScalarStringAttributeItIsWrittenToFile) {
+TEST(HDFFileAttributesTest, whenCommandContainsScalarStringAttributeItIsWrittenToFile) {
   using namespace hdf5;
 
   auto TestFile = createInMemoryTestFile("test-scalar-string-attribute.nxs");
@@ -44,7 +44,7 @@ TEST(HDFFileTest, whenCommandContainsScalarStringAttributeItIsWrittenToFile) {
   ASSERT_EQ(StringValue, "world");
 }
 
-TEST(HDFFileTest, whenCommandContainsArrayOfAttributesTheyAreWrittenToFile) {
+TEST(HDFFileAttributesTest, whenCommandContainsArrayOfAttributesTheyAreWrittenToFile) {
   using namespace hdf5;
 
   auto TestFile = createInMemoryTestFile("test-array-of-attributes.nxs");
@@ -88,7 +88,7 @@ TEST(HDFFileTest, whenCommandContainsArrayOfAttributesTheyAreWrittenToFile) {
   ASSERT_EQ(StringValue, "string_value");
 }
 
-TEST(HDFFileTest, whenCommandContainsAttrOfSpecifiedTypeItIsWrittenToFile) {
+TEST(HDFFileAttributesTest, whenCommandContainsAttrOfSpecifiedTypeItIsWrittenToFile) {
   using namespace hdf5;
 
   auto TestFile = createInMemoryTestFile("test-typed-attribute.nxs");
@@ -124,7 +124,7 @@ TEST(HDFFileTest, whenCommandContainsAttrOfSpecifiedTypeItIsWrittenToFile) {
   ASSERT_EQ(IntValue, 42);
 }
 
-TEST(HDFFileTest, whenCommandContainsArrayAttrItIsWrittenToFile) {
+TEST(HDFFileAttributesTest, whenCommandContainsArrayAttrItIsWrittenToFile) {
   using namespace hdf5;
 
   auto TestFile = createInMemoryTestFile("test-array-attribute.nxs");

--- a/src/tests/HDFFileTest.cpp
+++ b/src/tests/HDFFileTest.cpp
@@ -88,6 +88,42 @@ TEST(HDFFileTest, whenCommandContainsArrayOfAttributesTheyAreWrittenToFile) {
   ASSERT_EQ(StringValue, "string_value");
 }
 
+TEST(HDFFileTest, whenCommandContainsAttrOfSpecifiedTypeItIsWrittenToFile) {
+  using namespace hdf5;
+
+  auto TestFile = createInMemoryTestFile("test-typed-attribute.nxs");
+
+  std::string CommandWithTypedAttrs = R""({
+    "nexus_structure": {
+      "children": [
+        {
+          "type": "group",
+          "name": "group_with_typed_attrs",
+          "attributes": [
+            {
+              "name": "uint32_attribute",
+              "values": 42,
+              "dataset": {
+                "type": "uint32"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  })"";
+
+  std::vector<FileWriter::StreamHDFInfo> EmptyStreamHDFInfo;
+  TestFile.init(CommandWithTypedAttrs, EmptyStreamHDFInfo);
+
+  auto IntAttr =
+      node::get_group(TestFile.root_group, "group_with_typed_attrs")
+          .attributes["uint32_attribute"];
+  uint32_t IntValue;
+  IntAttr.read(IntValue);
+  ASSERT_EQ(IntValue, 42);
+}
+
 TEST(HDFFileTest, whenCommandContainsArrayAttrItIsWrittenToFile) {
   using namespace hdf5;
 
@@ -116,14 +152,12 @@ TEST(HDFFileTest, whenCommandContainsArrayAttrItIsWrittenToFile) {
   std::vector<FileWriter::StreamHDFInfo> EmptyStreamHDFInfo;
   TestFile.init(CommandWithArrayAttr, EmptyStreamHDFInfo);
 
-  auto Group =
-      node::get_group(TestFile.root_group, "group_with_vector_attr");
-
-  ASSERT_TRUE(Group.attributes.exists("array"));
-  auto vector_attr = Group.attributes["array"];
-  std::vector<int> vector_attr_values;
-  vector_attr.read(vector_attr_values);
-  ASSERT_EQ(vector_attr_values[0], 1);
-  ASSERT_EQ(vector_attr_values[1], 2);
-  ASSERT_EQ(vector_attr_values[2], 3);
+  auto ArrayAttr =
+      node::get_group(TestFile.root_group, "group_with_vector_attr")
+          .attributes["array"];
+  std::vector<int> ArrayAttrValues;
+  ArrayAttr.read(ArrayAttrValues);
+  ASSERT_EQ(ArrayAttrValues[0], 1);
+  ASSERT_EQ(ArrayAttrValues[1], 2);
+  ASSERT_EQ(ArrayAttrValues[2], 3);
 }

--- a/src/tests/HDFFileTest.cpp
+++ b/src/tests/HDFFileTest.cpp
@@ -2,12 +2,24 @@
 #include <gtest/gtest.h>
 #include <h5cpp/hdf5.hpp>
 
+FileWriter::HDFFile createInMemoryTestFile(const std::string &Filename) {
+  auto fapl = H5Pcreate(H5P_FILE_ACCESS);
+  // _core uses the in-memory file driver
+  H5Pset_fapl_core(fapl, 100 * 1024, H5P_DEFAULT);
+
+  auto file_id = H5Fcreate(Filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
+  H5Pclose(fapl);
+
+  FileWriter::HDFFile TestFile;
+  TestFile.h5file = hdf5::file::File(hdf5::ObjectHandle(file_id));
+
+  return TestFile;
+}
+
 TEST(HDFFileTest, givenCommandContainsVectorAttrItIsWrittenToFile) {
   using namespace hdf5;
 
-  FileWriter::HDFFile TestFile;
-  TestFile.h5file =
-      file::create("test-vector-attribute.h5", file::AccessFlags::TRUNCATE);
+  auto TestFile = createInMemoryTestFile("test-vector-attribute.nxs");
 
   std::string CommandWithVectorAttr = R""({
     "nexus_structure": {

--- a/src/tests/HDFFileTest.cpp
+++ b/src/tests/HDFFileTest.cpp
@@ -1,0 +1,38 @@
+#include "../HDFFile.h"
+#include <gtest/gtest.h>
+#include <h5cpp/hdf5.hpp>
+
+TEST(HDFFileTest, givenCommandContainsVectorAttrItIsWrittenToFile) {
+  using namespace hdf5;
+
+  FileWriter::HDFFile TestFile;
+  TestFile.h5file =
+      file::create("test-vector-attribute.h5", file::AccessFlags::TRUNCATE);
+
+  std::string CommandWithVectorAttr = R""({
+    "nexus_structure": {
+      "children": [
+        {
+          "type": "dataset",
+          "name": "dataset_with_vector_attr",
+          "values": 42.24,
+          "attributes": {"vector":[1, 2, 3]}
+        }
+      ]
+    }
+  })"";
+
+  std::vector<FileWriter::StreamHDFInfo> EmptyStreamHDFInfo;
+  TestFile.init(CommandWithVectorAttr, EmptyStreamHDFInfo);
+
+  auto dataset =
+      node::get_dataset(TestFile.root_group, "dataset_with_vector_attr");
+
+  ASSERT_TRUE(dataset.attributes.exists("vector"));
+  auto vector_attr = dataset.attributes["vector"];
+  std::vector<int> vector_attr_values;
+  vector_attr.read(vector_attr_values);
+  ASSERT_EQ(vector_attr_values[0], 1);
+  ASSERT_EQ(vector_attr_values[1], 2);
+  ASSERT_EQ(vector_attr_values[2], 3);
+}

--- a/src/tests/HDFFileTest.cpp
+++ b/src/tests/HDFFileTest.cpp
@@ -3,15 +3,13 @@
 #include <h5cpp/hdf5.hpp>
 
 FileWriter::HDFFile createInMemoryTestFile(const std::string &Filename) {
-  auto fapl = H5Pcreate(H5P_FILE_ACCESS);
-  // _core uses the in-memory file driver
-  H5Pset_fapl_core(fapl, 100 * 1024, H5P_DEFAULT);
-
-  auto file_id = H5Fcreate(Filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, fapl);
-  H5Pclose(fapl);
+  hdf5::property::FileAccessList fapl;
+  fapl.driver(hdf5::file::MemoryDriver());
 
   FileWriter::HDFFile TestFile;
-  TestFile.h5file = hdf5::file::File(hdf5::ObjectHandle(file_id));
+  TestFile.h5file = hdf5::file::create(
+          Filename, hdf5::file::AccessFlags::TRUNCATE,
+          hdf5::property::FileCreationList(), fapl);
 
   return TestFile;
 }


### PR DESCRIPTION
Closes #74 

Adds support for attributes with an array of values.
Adds support for specifying attribute type.
Adds documentation in `docs/attributes.md` - [see for more details](https://github.com/ess-dmsc/kafka-to-nexus/blob/cc664a2314aef443d2559278ab25f8ac7366829c/docs/attributes.md).
Supported by additional unit tests.

Changes should be in LLVM style.