### PR TITLE
Convert kafkaw msg to filewriter msg

### DIFF
--- a/src/KafkaW/Consumer.h
+++ b/src/KafkaW/Consumer.h
@@ -4,7 +4,6 @@
 #include "Msg.h"
 #include "PollStatus.h"
 #include <functional>
-#include <functional>
 #include <librdkafka/rdkafka.h>
 
 namespace KafkaW {

--- a/src/KafkaW/Consumer.h
+++ b/src/KafkaW/Consumer.h
@@ -4,6 +4,7 @@
 #include "Msg.h"
 #include "PollStatus.h"
 #include <functional>
+#include <functional>
 #include <librdkafka/rdkafka.h>
 
 namespace KafkaW {

--- a/src/KafkaW/Msg.cxx
+++ b/src/KafkaW/Msg.cxx
@@ -21,4 +21,10 @@ char const *Msg::topicName() {
 int32_t Msg::partition() { return ((rd_kafka_message_t *)MsgPtr)->partition; }
 
 int64_t Msg::offset() { return ((rd_kafka_message_t *)MsgPtr)->offset; }
+
+void *Msg::releaseMsgPtr() {
+  void *ptr = MsgPtr;
+  MsgPtr = nullptr;
+  return ptr;
+}
 }

--- a/src/KafkaW/Msg.cxx
+++ b/src/KafkaW/Msg.cxx
@@ -4,7 +4,11 @@
 
 namespace KafkaW {
 
-Msg::~Msg() { rd_kafka_message_destroy((rd_kafka_message_t *)MsgPtr); }
+Msg::~Msg() {
+  if (MsgPtr) {
+    rd_kafka_message_destroy((rd_kafka_message_t *)MsgPtr);
+  }
+}
 
 uchar *Msg::data() { return (uchar *)((rd_kafka_message_t *)MsgPtr)->payload; }
 

--- a/src/KafkaW/Msg.h
+++ b/src/KafkaW/Msg.h
@@ -12,7 +12,7 @@ public:
   ~Msg();
   uchar *data();
   size_t size();
-  void *MsgPtr;
+  void *MsgPtr = nullptr;
   char const *topicName();
   int64_t offset();
   int32_t partition();

--- a/src/KafkaW/Msg.h
+++ b/src/KafkaW/Msg.h
@@ -16,5 +16,6 @@ public:
   char const *topicName();
   int64_t offset();
   int32_t partition();
+  void *releaseMsgPtr();
 };
 }

--- a/src/KafkaW/PollStatus.cxx
+++ b/src/KafkaW/PollStatus.cxx
@@ -69,6 +69,7 @@ std::unique_ptr<Msg> PollStatus::isMsg() {
   if (state == 1) {
     std::unique_ptr<Msg> ret((Msg *)data);
     data = nullptr;
+    state = -3;
     return ret;
   }
   return nullptr;

--- a/src/KafkaW/PollStatus.cxx
+++ b/src/KafkaW/PollStatus.cxx
@@ -4,12 +4,6 @@ namespace KafkaW {
 
 PollStatus::~PollStatus() { reset(); }
 
-PollStatus PollStatus::Okkk() {
-  PollStatus ret;
-  ret.state = PollStatusContent::Msg;
-  return ret;
-}
-
 PollStatus PollStatus::Err() {
   PollStatus ret;
   ret.state = PollStatusContent::Err;

--- a/src/KafkaW/PollStatus.cxx
+++ b/src/KafkaW/PollStatus.cxx
@@ -4,33 +4,33 @@ namespace KafkaW {
 
 PollStatus::~PollStatus() { reset(); }
 
-PollStatus PollStatus::Ok() {
+PollStatus PollStatus::Okkk() {
   PollStatus ret;
-  ret.state = 0;
+  ret.state = PollStatusContent::Msg;
   return ret;
 }
 
 PollStatus PollStatus::Err() {
   PollStatus ret;
-  ret.state = -1;
+  ret.state = PollStatusContent::Err;
   return ret;
 }
 
 PollStatus PollStatus::EOP() {
   PollStatus ret;
-  ret.state = -2;
+  ret.state = PollStatusContent::EOP;
   return ret;
 }
 
 PollStatus PollStatus::Empty() {
   PollStatus ret;
-  ret.state = -3;
+  ret.state = PollStatusContent::Empty;
   return ret;
 }
 
 PollStatus PollStatus::newWithMsg(std::unique_ptr<Msg> Msg) {
   PollStatus ret;
-  ret.state = 1;
+  ret.state = PollStatusContent::Msg;
   ret.data = Msg.release();
   return ret;
 }
@@ -46,30 +46,30 @@ PollStatus &PollStatus::operator=(PollStatus &&x) {
 }
 
 void PollStatus::reset() {
-  if (state == 1) {
+  if (state == PollStatusContent::Msg) {
     if (auto x = (Msg *)data) {
       delete x;
     }
   }
-  state = -1;
+  state = PollStatusContent::Empty;
   data = nullptr;
 }
 
 PollStatus::PollStatus() {}
 
-bool PollStatus::isOk() { return state == 0; }
+bool PollStatus::isOk() { return state == PollStatusContent::Msg; }
 
-bool PollStatus::isErr() { return state == -1; }
+bool PollStatus::isErr() { return state == PollStatusContent::Err; }
 
-bool PollStatus::isEOP() { return state == -2; }
+bool PollStatus::isEOP() { return state == PollStatusContent::EOP; }
 
-bool PollStatus::isEmpty() { return state == -3; }
+bool PollStatus::isEmpty() { return state == PollStatusContent::Empty; }
 
 std::unique_ptr<Msg> PollStatus::isMsg() {
-  if (state == 1) {
+  if (state == PollStatusContent::Msg) {
     std::unique_ptr<Msg> ret((Msg *)data);
     data = nullptr;
-    state = -3;
+    state = PollStatusContent::Empty;
     return ret;
   }
   return nullptr;

--- a/src/KafkaW/PollStatus.h
+++ b/src/KafkaW/PollStatus.h
@@ -5,9 +5,16 @@
 
 namespace KafkaW {
 
+enum class PollStatusContent {
+  Msg,
+  Err,
+  EOP,
+  Empty,
+};
+
 class PollStatus {
 public:
-  static PollStatus Ok();
+  static PollStatus Okkk();
   static PollStatus Err();
   static PollStatus EOP();
   static PollStatus Empty();
@@ -24,7 +31,7 @@ public:
   std::unique_ptr<Msg> isMsg();
 
 private:
-  int state = -1;
+  PollStatusContent state = PollStatusContent::Err;
   void *data = nullptr;
 };
 }

--- a/src/KafkaW/PollStatus.h
+++ b/src/KafkaW/PollStatus.h
@@ -14,7 +14,6 @@ enum class PollStatusContent {
 
 class PollStatus {
 public:
-  static PollStatus Okkk();
   static PollStatus Err();
   static PollStatus EOP();
   static PollStatus Empty();

--- a/src/Msg.h
+++ b/src/Msg.h
@@ -81,7 +81,7 @@ public:
     Msg msg;
     msg.type = MsgType::RdKafkaCPtr;
     msg.var.rdkafka_msg_c_ptr =
-        static_cast<rd_kafka_message_t *>(KafkaWMsg->MsgPtr);
+        static_cast<rd_kafka_message_t *>(KafkaWMsg->releaseMsgPtr());
     msg._size = msg.var.rdkafka_msg_c_ptr->len;
     return msg;
   }

--- a/src/Msg.h
+++ b/src/Msg.h
@@ -79,7 +79,7 @@ public:
     return msg;
   }
 
-  static Msg fromKafkaW(std::unique_ptr<KafkaW::Msg> KafkaWMsg) {
+  static Msg fromKafkaW(std::unique_ptr<KafkaW::Msg> &&KafkaWMsg) {
     Msg msg;
     msg.type = MsgType::KafkaW;
     msg.var.kafkaw_msg = KafkaWMsg.release();

--- a/src/Msg.h
+++ b/src/Msg.h
@@ -18,7 +18,7 @@ enum class MsgType : int {
   Owned = 0,
   RdKafka = 1,
   Shared = 2,
-  RdKafkaCPtr = 3,
+  KafkaW = 3,
   Cheap = 22,
 };
 
@@ -43,7 +43,6 @@ public:
       p1 = (char *)jm->alloc(len * sizeof(char));
       if (not jm->check_in_range(p1)) {
         LOG(Sev::Error, "try again...");
-        // exit(1);
       } else
         break;
     }
@@ -59,15 +58,18 @@ public:
   }
 
   static Msg cheap(Msg const &msg, std::shared_ptr<Alloc> &jm) {
-    if (msg.type != MsgType::Shared) {
-      throw "msg.type != MsgType::Shared";
-    }
     Msg ret;
+    if (msg.type != MsgType::Shared) {
+      LOG(Sev::Critical, "msg.type != MsgType::Shared");
+      return ret;
+    }
     ret.type = MsgType::Cheap;
     ret.var.cheap = msg.var.shared;
     ret._size = msg._size;
     return ret;
   }
+
+  /// Can be removed when we use the KafkaW wrapper everywhere.
 
   static Msg rdkafka(std::unique_ptr<RdKafka::Message> &&rdkafka_msg) {
     Msg msg;
@@ -79,10 +81,9 @@ public:
 
   static Msg fromKafkaW(std::unique_ptr<KafkaW::Msg> KafkaWMsg) {
     Msg msg;
-    msg.type = MsgType::RdKafkaCPtr;
-    msg.var.rdkafka_msg_c_ptr =
-        static_cast<rd_kafka_message_t *>(KafkaWMsg->releaseMsgPtr());
-    msg._size = msg.var.rdkafka_msg_c_ptr->len;
+    msg.type = MsgType::KafkaW;
+    msg.var.kafkaw_msg = KafkaWMsg.release();
+    msg._size = 0;
     return msg;
   }
 
@@ -107,9 +108,9 @@ public:
   inline char const *data() const {
     switch (type) {
     case MsgType::RdKafka:
-      return (char const *)var.rdkafka_msg->payload();
-    case MsgType::RdKafkaCPtr:
-      return (char const *)var.rdkafka_msg_c_ptr->payload;
+      return static_cast<char const *>(var.rdkafka_msg->payload());
+    case MsgType::KafkaW:
+      return reinterpret_cast<char const *>(var.kafkaw_msg->data());
     case MsgType::Owned:
       return var.owned;
     case MsgType::Shared:
@@ -118,7 +119,6 @@ public:
       return var.cheap;
     default:
       LOG(Sev::Error, "error at type: {}", static_cast<int>(type));
-      exit(1);
     }
     return "";
   }
@@ -127,8 +127,8 @@ public:
     switch (type) {
     case MsgType::RdKafka:
       return var.rdkafka_msg->len();
-    case MsgType::RdKafkaCPtr:
-      return var.rdkafka_msg_c_ptr->len;
+    case MsgType::KafkaW:
+      return var.kafkaw_msg->size();
     case MsgType::Owned:
       return _size;
     case MsgType::Shared:
@@ -137,7 +137,6 @@ public:
       return _size;
     default:
       LOG(Sev::Error, "error at type: {}", static_cast<int>(type));
-      exit(1);
     }
     return 0;
   }
@@ -145,7 +144,7 @@ public:
   MsgType type = MsgType::Invalid;
   union Var {
     RdKafka::Message *rdkafka_msg;
-    rd_kafka_message_t *rdkafka_msg_c_ptr;
+    KafkaW::Msg *kafkaw_msg;
     char const *owned;
     char const *shared;
     char const *cheap;
@@ -155,18 +154,15 @@ public:
   inline ~Msg() {
     switch (type) {
     case MsgType::RdKafka:
-      // var.rdkafka_msg.~unique_ptr<RdKafka::Message>();
       delete var.rdkafka_msg;
       break;
-    case MsgType::RdKafkaCPtr:
-      rd_kafka_message_destroy(var.rdkafka_msg_c_ptr);
+    case MsgType::KafkaW:
+      delete var.kafkaw_msg;
       break;
     case MsgType::Owned:
-      // var.owned.~V0();
       delete var.owned;
       break;
     case MsgType::Shared:
-      // var.shared.~shared_ptr<std::vector<char>>();
       delete var.shared;
       break;
     case MsgType::Cheap:
@@ -175,7 +171,6 @@ public:
       break;
     default:
       LOG(Sev::Error, "unhandled type: {}", static_cast<int>(type));
-      exit(1);
     }
   }
 };


### PR DESCRIPTION
Add interoperability between `FileWriter::Msg` and `KafkaW::Msg` types so that `KafkaW::Msg` can be used by `Streamer`.