### PR TITLE
Add conan CMake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,20 +11,23 @@ if(CMAKE_COMPILER_IS_GNUCXX AND COV)
 endif()
 
 SET(CONAN_PROFILE "default" CACHE STRING "Name of conan profile to use, uses default by default")
-if(CONANBUILDINFO_ENABLE)
-  if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-    include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
-    conan_basic_setup(NO_OUTPUT_DIRS SKIP_RPATH)
-  else()
-    MESSAGE(FATAL_ERROR "CONANBUILDINFO_ENABLE is true but no file named conanbuildinfo.cmake found in build directory")
-  endif()
-elseif(NOT CONAN_DISABLE)
+SET(CONAN "AUTO" CACHE STRING "conan options AUTO (conan must be in path), MANUAL (expects conanbuildinfo.cmake in build directory) or DISABLE")
+if(${CONAN} MATCHES "AUTO")
   include(${CMAKE_MODULE_PATH}/conan.cmake)
   conan_cmake_run(CONANFILE conan/conanfile.txt
           PROFILE ${CONAN_PROFILE}
           BASIC_SETUP NO_OUTPUT_DIRS SKIP_RPATH
           BUILD_TYPE "None"
           BUILD outdated)
+elseif(${CONAN} MATCHES "MANUAL")
+  if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+    include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+    conan_basic_setup(NO_OUTPUT_DIRS SKIP_RPATH)
+  else()
+    MESSAGE(FATAL_ERROR "CONAN set to MANUAL but no file named conanbuildinfo.cmake found in build directory")
+  endif()
+elseif(NOT ${CONAN} MATCHES "DISABLE")
+  MESSAGE(FATAL_ERROR "Unrecognised option for CONAN, use AUTO, MANUAL or DISABLE")
 endif()
 
 # Yes, there exists also FindGTest.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,10 +10,18 @@ if(CMAKE_COMPILER_IS_GNUCXX AND COV)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_COVERAGE}")
 endif()
 
-if(NOT CONAN_DISABLE)
+SET(CONAN_PROFILE "default" CACHE STRING "Name of conan profile to use, uses default by default")
+if(CONANBUILDINFO_ENABLE)
+  if(EXISTS "${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+    include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+    conan_basic_setup(NO_OUTPUT_DIRS SKIP_RPATH)
+  else()
+    MESSAGE(FATAL_ERROR "CONANBUILDINFO_ENABLE is true but no file named conanbuildinfo.cmake found in build directory")
+  endif()
+elseif(NOT CONAN_DISABLE)
   include(${CMAKE_MODULE_PATH}/conan.cmake)
   conan_cmake_run(CONANFILE conan/conanfile.txt
-          PROFILE default
+          PROFILE ${CONAN_PROFILE}
           BASIC_SETUP NO_OUTPUT_DIRS SKIP_RPATH
           BUILD_TYPE "None"
           BUILD outdated)

--- a/README.md
+++ b/README.md
@@ -236,12 +236,11 @@ Tooling
 
 ### Conan
 
-For downloading and configuring dependencies there are three options:
-- By default conan is used to download and configure dependencies, this is done automatically by CMake.
-conan is required to be installed and in the `path`.
-- conan can be run manually to generate a `conanbuildinfo.cmake` file in the build directory, to use this specify the CMake parameter `CONANBUILDINFO_ENABLE=true`.
-- conan can be disabled by specifying the CMake parameter `CONAN_DISABLE=true`. CMake will try to find system installed libraries or paths can be specified manually.
-
+For downloading and configuring dependencies there are three options which can be set using the `CONAN` CMake parameter with one of the following values:
+- `AUTO` - (default) conan is used to download and configure dependencies, this is done automatically by CMake.
+conan is required to be installed and in the `path`. A non-default conan profile can be specified by setting `CONAN_PROFILE`.
+- `MANUAL` - conan can be run manually to generate a `conanbuildinfo.cmake` file in the build directory.
+- `DISABLE` - conan is disabled. CMake will try to find system installed libraries or paths can be specified manually.
 
 
 If using conan, the following remote repositories are required to be configured:

--- a/README.md
+++ b/README.md
@@ -234,9 +234,17 @@ Tooling
 - C++ compiler with c++11 support
 - Doxygen if you would like to make docs
 
-### Conan repositories
+### Conan
 
-The following remote repositories are required to be configured:
+For downloading and configuring dependencies there are three options:
+- By default conan is used to download and configure dependencies, this is done automatically by CMake.
+conan is required to be installed and in the `path`.
+- conan can be run manually to generate a `conanbuildinfo.cmake` file in the build directory, to use this specify the CMake parameter `CONANBUILDINFO_ENABLE=true`.
+- conan can be disabled by specifying the CMake parameter `CONAN_DISABLE=true`. CMake will try to find system installed libraries or paths can be specified manually.
+
+
+
+If using conan, the following remote repositories are required to be configured:
 
 - https://api.bintray.com/conan/ess-dmsc/conan
 - https://api.bintray.com/conan/conan-community/conan


### PR DESCRIPTION
Closes #134

Creates the following options for using conan:
- By default conan is used to download and configure dependencies, this is done automatically by CMake.
conan is required to be installed and in the `path`.
- conan can be run manually to generate a `conanbuildinfo.cmake` file in the build directory, to use this specify the CMake parameter `CONANBUILDINFO_ENABLE=true`.
- conan can be disabled by specifying the CMake parameter `CONAN_DISABLE=true`. CMake will try to find system installed libraries or paths can be specified manually.

These options are documented in the README.