### PR TITLE
Fix long integer bug

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ tests.cxx
 roundtrip.cxx
 HDFFile.cxx
 HDFFileAttributesTest.cpp
+HDFFileTestHelper.cpp
 helper.cxx
 json.cxx
 uri.cxx
@@ -18,7 +19,10 @@ MainOpt_tests.cxx
 streamer_options.cxx
 $<TARGET_OBJECTS:kafka_to_nexus__objects>
 )
-add_executable(${tgt} ${sources})
+set(includes
+HDFFileTestHelper.h
+)
+add_executable(${tgt} ${sources} ${includes})
 add_dependencies(${tgt} flatbuffers_generate)
 target_compile_definitions(${tgt} PRIVATE ${compile_defs_common})
 target_include_directories(${tgt} PRIVATE ${path_include_common})

--- a/src/tests/HDFFile.cxx
+++ b/src/tests/HDFFile.cxx
@@ -1262,14 +1262,14 @@ TEST_F(T_CommandHandler, createStaticDatasetWithLongIntegerValue) {
 
   std::string CommandWithLongInt = R""({
       "children": [
-      {
-        "name": "features",
-        "values": 10138143369737381149,
-        "type": "dataset",
-        "dataset": {
-          "type": "uint64"
-      }
-    }
+        {
+          "name": "features",
+          "values": 10138143369737381149,
+          "type": "dataset",
+          "dataset": {
+            "type": "uint64"
+          }
+        }
       ]
     })"";
   std::vector<FileWriter::StreamHDFInfo> EmptyStreamHDFInfo;

--- a/src/tests/HDFFile.cxx
+++ b/src/tests/HDFFile.cxx
@@ -1257,8 +1257,8 @@ TEST_F(T_CommandHandler, dataset_static_1d_string_variable) {
 }
 
 template <typename T>
-void testType(FileWriter::HDFFile &TestFile,
-              const std::pair<std::string, T> NameAndValue) {
+void verifyWrittenDatatype(FileWriter::HDFFile &TestFile,
+                           const std::pair<std::string, T> NameAndValue) {
   auto Dataset =
       hdf5::node::get_dataset(TestFile.root_group, "/" + NameAndValue.first);
   auto OutputValue = NameAndValue.second;
@@ -1290,8 +1290,8 @@ TEST_F(T_CommandHandler, createStaticDatasetOfEachIntType) {
   std::vector<FileWriter::StreamHDFInfo> EmptyStreamHDFInfo;
   TestFile.init(CommandStream.str(), EmptyStreamHDFInfo);
 
-  testType(TestFile, TestUint32);
-  testType(TestFile, TestUint64);
-  testType(TestFile, TestInt32);
-  testType(TestFile, TestInt64);
+  verifyWrittenDatatype(TestFile, TestUint32);
+  verifyWrittenDatatype(TestFile, TestUint64);
+  verifyWrittenDatatype(TestFile, TestInt32);
+  verifyWrittenDatatype(TestFile, TestInt64);
 }

--- a/src/tests/HDFFile.cxx
+++ b/src/tests/HDFFile.cxx
@@ -638,52 +638,52 @@ public:
         children.PushBack(g1, a);
       }
 
-      auto json_stream =
-          [&a, &main_opt](string source, string topic, string module,
-                          bool run_parallel) -> Value {
-            Value g1;
-            g1.SetObject();
-            g1.AddMember("type", "group", a);
-            g1.AddMember("name", Value(source.c_str(), a), a);
-            Value attr;
-            attr.SetObject();
-            attr.AddMember("NX_class", "NXinstrument", a);
-            g1.AddMember("attributes", attr, a);
-            Value ch;
-            ch.SetArray();
-            {
-              auto &children = ch;
-              Document ds1(&a);
-              ds1.Parse(R""({
-            "type": "stream",
-            "attributes": {
-              "this_will_be_a_double": 0.125,
-              "this_will_be_a_int64": 123
-            }
-          })"");
-              Value stream;
-              stream.SetObject();
-              if (auto main_nexus = get_object(main_opt.config_file, "nexus")) {
-                Value nx;
-                nx.CopyFrom(*main_nexus.v, a);
-                stream.AddMember("nexus", std::move(nx), a);
-              }
-              stream.AddMember("topic", Value(topic.c_str(), a), a);
-              stream.AddMember("source", Value(source.c_str(), a), a);
-              stream.AddMember("writer_module", Value(module.c_str(), a), a);
-              stream.AddMember("type", Value("uint32", a), a);
-              stream.AddMember(
-                  "n_mpi_workers",
-                  std::move(Value().CopyFrom(
-                      main_opt.config_file["unit_test"]["n_mpi_workers"], a)),
-                  a);
-              stream.AddMember("run_parallel", Value(run_parallel), a);
-              ds1.AddMember("stream", stream, a);
-              children.PushBack(ds1, a);
-            }
-            g1.AddMember("children", ch, a);
-            return g1;
-          };
+      auto json_stream = [&a, &main_opt](string source, string topic,
+                                         string module,
+                                         bool run_parallel) -> Value {
+        Value g1;
+        g1.SetObject();
+        g1.AddMember("type", "group", a);
+        g1.AddMember("name", Value(source.c_str(), a), a);
+        Value attr;
+        attr.SetObject();
+        attr.AddMember("NX_class", "NXinstrument", a);
+        g1.AddMember("attributes", attr, a);
+        Value ch;
+        ch.SetArray();
+        {
+          auto &children = ch;
+          Document ds1(&a);
+          ds1.Parse(R""({
+        "type": "stream",
+        "attributes": {
+          "this_will_be_a_double": 0.125,
+          "this_will_be_a_int64": 123
+        }
+      })"");
+          Value stream;
+          stream.SetObject();
+          if (auto main_nexus = get_object(main_opt.config_file, "nexus")) {
+            Value nx;
+            nx.CopyFrom(*main_nexus.v, a);
+            stream.AddMember("nexus", std::move(nx), a);
+          }
+          stream.AddMember("topic", Value(topic.c_str(), a), a);
+          stream.AddMember("source", Value(source.c_str(), a), a);
+          stream.AddMember("writer_module", Value(module.c_str(), a), a);
+          stream.AddMember("type", Value("uint32", a), a);
+          stream.AddMember(
+              "n_mpi_workers",
+              std::move(Value().CopyFrom(
+                  main_opt.config_file["unit_test"]["n_mpi_workers"], a)),
+              a);
+          stream.AddMember("run_parallel", Value(run_parallel), a);
+          ds1.AddMember("stream", stream, a);
+          children.PushBack(ds1, a);
+        }
+        g1.AddMember("children", ch, a);
+        return g1;
+      };
 
       for (auto &source : sources) {
         children.PushBack(json_stream(source.source, source.topic, "ev42",
@@ -1282,7 +1282,8 @@ TEST_F(T_CommandHandler, createStaticDatasetOfEachIntType) {
 
   std::stringstream CommandStream;
   CommandStream << R""({"children": [)"" << createCommandForDataset(TestUint32)
-                << ",\n" << createCommandForDataset(TestUint64) << ",\n"
+                << ",\n"
+                << createCommandForDataset(TestUint64) << ",\n"
                 << createCommandForDataset(TestInt32) << ",\n"
                 << createCommandForDataset(TestInt64) << "]}";
 

--- a/src/tests/HDFFile.cxx
+++ b/src/tests/HDFFile.cxx
@@ -655,12 +655,12 @@ public:
           auto &children = ch;
           Document ds1(&a);
           ds1.Parse(R""({
-        "type": "stream",
-        "attributes": {
-          "this_will_be_a_double": 0.125,
-          "this_will_be_a_int64": 123
-        }
-      })"");
+            "type": "stream",
+            "attributes": {
+              "this_will_be_a_double": 0.125,
+              "this_will_be_a_int64": 123
+            }
+          })"");
           Value stream;
           stream.SetObject();
           if (auto main_nexus = get_object(main_opt.config_file, "nexus")) {

--- a/src/tests/HDFFile.cxx
+++ b/src/tests/HDFFile.cxx
@@ -1257,8 +1257,10 @@ TEST_F(T_CommandHandler, dataset_static_1d_string_variable) {
 }
 
 template <typename T>
-void testType(FileWriter::HDFFile &TestFile, const std::pair<std::string, T> NameAndValue) {
-  auto Dataset = hdf5::node::get_dataset(TestFile.root_group, "/" + NameAndValue.first);
+void testType(FileWriter::HDFFile &TestFile,
+              const std::pair<std::string, T> NameAndValue) {
+  auto Dataset =
+      hdf5::node::get_dataset(TestFile.root_group, "/" + NameAndValue.first);
   auto OutputValue = NameAndValue.second;
   Dataset.read(OutputValue);
   ASSERT_EQ(OutputValue, NameAndValue.second);
@@ -1266,23 +1268,23 @@ void testType(FileWriter::HDFFile &TestFile, const std::pair<std::string, T> Nam
 
 TEST_F(T_CommandHandler, createStaticDatasetOfEachIntType) {
   using namespace hdf5;
+  using HDFFileTestHelper::createCommandForDataset;
 
   auto TestFile =
       HDFFileTestHelper::createInMemoryTestFile("test-dataset-int-types.nxs");
 
   const std::pair<std::string, uint32_t> TestUint32 = {"uint32", 37381149};
-  const std::pair<std::string, uint64_t> TestUint64 = {"uint64", 10138143369737381149U};
+  const std::pair<std::string, uint64_t> TestUint64 = {"uint64",
+                                                       10138143369737381149U};
   const std::pair<std::string, int32_t> TestInt32 = {"int32", -7381149};
-  const std::pair<std::string, int64_t> TestInt64 = {"int64", -138143369737381149};
+  const std::pair<std::string, int64_t> TestInt64 = {"int64",
+                                                     -138143369737381149};
 
   std::stringstream CommandStream;
-  CommandStream
-      << R""({"children": [)""
-      << HDFFileTestHelper::createCommandForDataset(TestUint32) << ",\n"
-      << HDFFileTestHelper::createCommandForDataset(TestUint64) << ",\n"
-      << HDFFileTestHelper::createCommandForDataset(TestInt32) << ",\n"
-      << HDFFileTestHelper::createCommandForDataset(TestInt64)
-      << "]}";
+  CommandStream << R""({"children": [)"" << createCommandForDataset(TestUint32)
+                << ",\n" << createCommandForDataset(TestUint64) << ",\n"
+                << createCommandForDataset(TestInt32) << ",\n"
+                << createCommandForDataset(TestInt64) << "]}";
 
   std::vector<FileWriter::StreamHDFInfo> EmptyStreamHDFInfo;
   TestFile.init(CommandStream.str(), EmptyStreamHDFInfo);

--- a/src/tests/HDFFileAttributesTest.cpp
+++ b/src/tests/HDFFileAttributesTest.cpp
@@ -1,24 +1,14 @@
 #include "../HDFFile.h"
+#include "HDFFileTestHelper.h"
 #include <gtest/gtest.h>
 #include <h5cpp/hdf5.hpp>
-
-FileWriter::HDFFile createInMemoryTestFile(const std::string &Filename) {
-  hdf5::property::FileAccessList fapl;
-  fapl.driver(hdf5::file::MemoryDriver());
-
-  FileWriter::HDFFile TestFile;
-  TestFile.h5file =
-      hdf5::file::create(Filename, hdf5::file::AccessFlags::TRUNCATE,
-                         hdf5::property::FileCreationList(), fapl);
-
-  return TestFile;
-}
 
 TEST(HDFFileAttributesTest,
      whenCommandContainsNumericalAttributeItIsWrittenToFile) {
   using namespace hdf5;
 
-  auto TestFile = createInMemoryTestFile("test-numerical-attribute.nxs");
+  auto TestFile =
+      HDFFileTestHelper::createInMemoryTestFile("test-numerical-attribute.nxs");
 
   std::string CommandWithNumericalAttr = R""({
       "children": [
@@ -47,7 +37,8 @@ TEST(HDFFileAttributesTest,
      whenCommandContainsScalarStringAttributeItIsWrittenToFile) {
   using namespace hdf5;
 
-  auto TestFile = createInMemoryTestFile("test-scalar-string-attribute.nxs");
+  auto TestFile = HDFFileTestHelper::createInMemoryTestFile(
+      "test-scalar-string-attribute.nxs");
 
   std::string CommandWithScalarStringAttr = R""({
       "children": [
@@ -76,7 +67,8 @@ TEST(HDFFileAttributesTest,
      whenCommandContainsArrayOfAttributesTheyAreWrittenToFile) {
   using namespace hdf5;
 
-  auto TestFile = createInMemoryTestFile("test-array-of-attributes.nxs");
+  auto TestFile =
+      HDFFileTestHelper::createInMemoryTestFile("test-array-of-attributes.nxs");
 
   std::string CommandWithArrayOfAttrs = R""({
     "children": [
@@ -119,7 +111,8 @@ TEST(HDFFileAttributesTest,
      whenCommandContainsAttrOfSpecifiedTypeItIsWrittenToFile) {
   using namespace hdf5;
 
-  auto TestFile = createInMemoryTestFile("test-typed-attribute.nxs");
+  auto TestFile =
+      HDFFileTestHelper::createInMemoryTestFile("test-typed-attribute.nxs");
 
   std::string CommandWithTypedAttrs = R""({
     "children": [
@@ -150,7 +143,8 @@ TEST(HDFFileAttributesTest,
 TEST(HDFFileAttributesTest, whenCommandContainsArrayAttrItIsWrittenToFile) {
   using namespace hdf5;
 
-  auto TestFile = createInMemoryTestFile("test-array-attribute.nxs");
+  auto TestFile =
+      HDFFileTestHelper::createInMemoryTestFile("test-array-attribute.nxs");
 
   std::string CommandWithArrayAttr = R""({
     "children": [

--- a/src/tests/HDFFileTestHelper.cpp
+++ b/src/tests/HDFFileTestHelper.cpp
@@ -1,0 +1,16 @@
+#include "HDFFileTestHelper.h"
+
+namespace HDFFileTestHelper {
+
+FileWriter::HDFFile createInMemoryTestFile(const std::string &Filename) {
+  hdf5::property::FileAccessList fapl;
+  fapl.driver(hdf5::file::MemoryDriver());
+
+  FileWriter::HDFFile TestFile;
+  TestFile.h5file =
+      hdf5::file::create(Filename, hdf5::file::AccessFlags::TRUNCATE,
+                         hdf5::property::FileCreationList(), fapl);
+
+  return TestFile;
+}
+}

--- a/src/tests/HDFFileTestHelper.h
+++ b/src/tests/HDFFileTestHelper.h
@@ -6,4 +6,27 @@
 namespace HDFFileTestHelper {
 
 FileWriter::HDFFile createInMemoryTestFile(const std::string &Filename);
+
+template <typename T>
+std::string
+createCommandForDataset(const std::pair<std::string, T> NameAndValue) {
+  using namespace fmt::literals;
+
+  std::string Command = R"(  <
+    "name": "{name}",
+    "values": {value},
+    "type": "dataset",
+    "dataset": <
+      "type": "{type_string}"
+    >
+  >)";
+
+  Command = fmt::format(Command, "name"_a = NameAndValue.first,
+                        "value"_a = NameAndValue.second,
+                        "type_string"_a = NameAndValue.first);
+  std::replace(Command.begin(), Command.end(), '<', '{');
+  std::replace(Command.begin(), Command.end(), '>', '}');
+
+  return Command;
+}
 }

--- a/src/tests/HDFFileTestHelper.h
+++ b/src/tests/HDFFileTestHelper.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "../HDFFile.h"
+#include <h5cpp/hdf5.hpp>
+
+namespace HDFFileTestHelper {
+
+FileWriter::HDFFile createInMemoryTestFile(const std::string &Filename);
+}


### PR DESCRIPTION
Fixes #133 

Fixes a bug with getting long integers from the json command. This stopped `features` datasets being written for the example ESS NeXus files.

Added test for writing each of the four integer types.