### PR TITLE
Simplify HDFWriterModule init_hdf interface

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -154,10 +154,10 @@ set(kafka_to_nexus_INC
   date/tz_private.h
   date/tz.h
   date/tzblobs.h
-  schemas/ev42/ev42_synth.h
-  schemas/f142/f142_synth.h
-  schemas/f142/f142_rw.h
   schemas/ev42/ev42_rw.h
+  schemas/ev42/ev42_synth.h
+  schemas/f142/f142_rw.h
+  schemas/f142/f142_synth.h
   CLIOptions.h
 )
 

--- a/src/CommandHandler.cxx
+++ b/src/CommandHandler.cxx
@@ -173,8 +173,8 @@ static std::vector<StreamSettings> extractStreamInformationFromJson(
     if (AttributesDocument.IsObject()) {
       AttributesPtr = &AttributesDocument;
     }
-    HDFWriterModule->init_hdf(RootGroup, stream.hdf_parent_name, AttributesPtr,
-                              cq);
+    auto StreamGroup = hdf5::node::get_group(RootGroup, stream.hdf_parent_name);
+    HDFWriterModule->init_hdf(StreamGroup, ".", AttributesPtr, cq);
     HDFWriterModule->close();
     HDFWriterModule.reset();
   }
@@ -304,9 +304,9 @@ void CommandHandler::addStreamSourceToWriterModule(
       HDFWriterModule->parse_config(ConfigStream, nullptr);
       try {
         auto RootGroup = Task->hdf_file.h5file.root();
-        auto Err = HDFWriterModule->reopen(
-            RootGroup, StreamSettings.StreamHDFInfoObj.hdf_parent_name, nullptr,
-            nullptr);
+        auto StreamGroup = hdf5::node::get_group(
+            RootGroup, StreamSettings.StreamHDFInfoObj.hdf_parent_name);
+        auto Err = HDFWriterModule->reopen(StreamGroup, ".", nullptr, nullptr);
         if (Err.is_ERR()) {
           LOG(Sev::Error, "can not reopen HDF file for stream {}",
               StreamSettings.StreamHDFInfoObj.hdf_parent_name);

--- a/src/CommandHandler.cxx
+++ b/src/CommandHandler.cxx
@@ -164,7 +164,6 @@ static std::vector<StreamSettings> extractStreamInformationFromJson(
     auto ConfigStreamRapidjson =
         stringToRapidjsonOrThrow(ConfigStreamInner.dump());
     HDFWriterModule->parse_config(ConfigStreamRapidjson, nullptr);
-    CollectiveQueue *cq = nullptr;
     rapidjson::Document AttributesDocument;
     if (auto x = find<json>("attributes", ConfigStream)) {
       AttributesDocument = stringToRapidjsonOrThrow(x.inner().dump());
@@ -174,7 +173,7 @@ static std::vector<StreamSettings> extractStreamInformationFromJson(
       AttributesPtr = &AttributesDocument;
     }
     auto StreamGroup = hdf5::node::get_group(RootGroup, stream.hdf_parent_name);
-    HDFWriterModule->init_hdf(StreamGroup, ".", AttributesPtr, cq);
+    HDFWriterModule->init_hdf({StreamGroup}, AttributesPtr);
     HDFWriterModule->close();
     HDFWriterModule.reset();
   }
@@ -306,7 +305,7 @@ void CommandHandler::addStreamSourceToWriterModule(
         auto RootGroup = Task->hdf_file.h5file.root();
         auto StreamGroup = hdf5::node::get_group(
             RootGroup, StreamSettings.StreamHDFInfoObj.hdf_parent_name);
-        auto Err = HDFWriterModule->reopen(StreamGroup, ".", nullptr, nullptr);
+        auto Err = HDFWriterModule->reopen({StreamGroup});
         if (Err.is_ERR()) {
           LOG(Sev::Error, "can not reopen HDF file for stream {}",
               StreamSettings.StreamHDFInfoObj.hdf_parent_name);

--- a/src/HDFWriterModule.h
+++ b/src/HDFWriterModule.h
@@ -151,12 +151,13 @@ public:
   /// stream to allow the `HDFWriterModule` to create any structures in the HDF
   /// file.
   ///
-  /// \param hdf_file The HDF file handle.
-  /// \param hdf_parent_name Path to the group into which this HDFWriterModule
-  /// should put its data.
+  /// \param HDFParent The HDF group instance relative to which \p HDFGroupPath
+  /// is specified.
+  /// \param HDFGroupPath Path to the group, specified relative to \p
+  /// HDFParent, into which this HDFWriterModule should write its data.
   /// \return The result.
-  virtual InitResult init_hdf(hdf5::node::Group &hdf_parent,
-                              std::string hdf_parent_name,
+  virtual InitResult init_hdf(hdf5::node::Group &HDFParent,
+                              std::string HDFGroupPath,
                               rapidjson::Value const *attributes,
                               CollectiveQueue *cq) = 0;
 

--- a/src/HDFWriterModule.h
+++ b/src/HDFWriterModule.h
@@ -118,6 +118,14 @@ private:
 };
 } // namespace HDFWriterModule_detail
 
+/// Group together parameters as used in `HDFWriterModule::init_hdf` and
+/// `HDFWriterModule::reopen` for future extensibility.
+struct HDFWriterModuleInitParameters {
+  HDFWriterModuleInitParameters(hdf5::node::Group &HDFGroup_)
+      : HDFGroup(HDFGroup_) {}
+  hdf5::node::Group &HDFGroup;
+};
+
 /// Writes a given flatbuffer to HDF.
 ///
 /// Base class for the writer modules which are responsible for actually
@@ -145,25 +153,26 @@ public:
   virtual void parse_config(rapidjson::Value const &config_stream,
                             rapidjson::Value const *config_module) = 0;
 
-  /// Initialise the HDF file.
+  /// Initialize the HDF file.
   ///
   /// Called before any data has arrived with the json configuration of this
   /// stream to allow the `HDFWriterModule` to create any structures in the HDF
   /// file.
   ///
-  /// \param HDFParent The HDF group instance relative to which \p HDFGroupPath
-  /// is specified.
-  /// \param HDFGroupPath Path to the group, specified relative to \p
-  /// HDFParent, into which this HDFWriterModule should write its data.
+  /// \param HDFGroup The HDF group instance into which this HDFWriterModule
+  /// should write its data.
+  /// \param HDFAttributes Additional attributes which the HDFWriterModule
+  /// should write to the file.
   /// \return The result.
-  virtual InitResult init_hdf(hdf5::node::Group &HDFParent,
-                              std::string HDFGroupPath,
-                              rapidjson::Value const *attributes,
-                              CollectiveQueue *cq) = 0;
+  virtual InitResult init_hdf(HDFWriterModuleInitParameters InitParameters,
+                              rapidjson::Value const *HDFAttributes) = 0;
 
-  virtual InitResult reopen(hdf5::node::Group hdf_file,
-                            std::string hdf_parent_name, CollectiveQueue *cq,
-                            HDFIDStore *hdf_store) = 0;
+  /// Reopen the HDF objects which are used by this HDFWriterModule.
+  ///
+  /// \param HDFGroup The HDF group instance into which this HDFWriterModule
+  /// should write its data.
+  /// \return The result.
+  virtual InitResult reopen(HDFWriterModuleInitParameters InitParameters) = 0;
 
   /// Process the message in some way, for example write to the HDF file.
   ///

--- a/src/HDFWriterModule.h
+++ b/src/HDFWriterModule.h
@@ -153,14 +153,14 @@ public:
   virtual void parse_config(rapidjson::Value const &config_stream,
                             rapidjson::Value const *config_module) = 0;
 
-  /// Initialize the HDF file.
+  /// Initialise the HDF file.
   ///
   /// Called before any data has arrived with the json configuration of this
   /// stream to allow the `HDFWriterModule` to create any structures in the HDF
   /// file.
   ///
-  /// \param HDFGroup The HDF group instance into which this HDFWriterModule
-  /// should write its data.
+  /// \param InitParameters Contains most importantly the \p HDFGroup into
+  /// which this HDFWriterModule should write its data.
   /// \param HDFAttributes Additional attributes which the HDFWriterModule
   /// should write to the file.
   /// \return The result.
@@ -169,8 +169,8 @@ public:
 
   /// Reopen the HDF objects which are used by this HDFWriterModule.
   ///
-  /// \param HDFGroup The HDF group instance into which this HDFWriterModule
-  /// should write its data.
+  /// \param InitParameters Contains most importantly the \p HDFGroup into
+  /// which this HDFWriterModule should write its data.
   /// \return The result.
   virtual InitResult reopen(HDFWriterModuleInitParameters InitParameters) = 0;
 

--- a/src/schemas/ev42/ev42_rw.cxx
+++ b/src/schemas/ev42/ev42_rw.cxx
@@ -72,23 +72,25 @@ void HDFWriterModule::parse_config(rapidjson::Value const &config_stream,
   }
 }
 
-HDFWriterModule::InitResult HDFWriterModule::init_hdf(
-    hdf5::node::Group &hdf_parent, std::string hdf_parent_name,
-    rapidjson::Value const *attributes, CollectiveQueue *cq) {
+HDFWriterModule::InitResult
+HDFWriterModule::init_hdf(HDFWriterModuleInitParameters InitParameters,
+                          rapidjson::Value const *attributes) {
+  auto &HDFGroup = InitParameters.HDFGroup;
+  // Keep these for now, experimenting with those on another branch.
+  CollectiveQueue *cq = nullptr;
   try {
-    auto hdf_group = hdf5::node::get_group(hdf_parent, hdf_parent_name);
     this->ds_event_time_offset = h5::h5d_chunked_1d<uint32_t>::create(
-        hdf_group, "event_time_offset", chunk_bytes, cq);
+        HDFGroup, "event_time_offset", chunk_bytes, cq);
     this->ds_event_id = h5::h5d_chunked_1d<uint32_t>::create(
-        hdf_group, "event_id", chunk_bytes, cq);
+        HDFGroup, "event_id", chunk_bytes, cq);
     this->ds_event_time_zero = h5::h5d_chunked_1d<uint64_t>::create(
-        hdf_group, "event_time_zero", chunk_bytes, cq);
+        HDFGroup, "event_time_zero", chunk_bytes, cq);
     this->ds_event_index = h5::h5d_chunked_1d<uint32_t>::create(
-        hdf_group, "event_index", chunk_bytes, cq);
+        HDFGroup, "event_index", chunk_bytes, cq);
     this->ds_cue_index = h5::h5d_chunked_1d<uint32_t>::create(
-        hdf_group, "cue_index", chunk_bytes, cq);
+        HDFGroup, "cue_index", chunk_bytes, cq);
     this->ds_cue_timestamp_zero = h5::h5d_chunked_1d<uint64_t>::create(
-        hdf_group, "cue_timestamp_zero", chunk_bytes, cq);
+        HDFGroup, "cue_timestamp_zero", chunk_bytes, cq);
 
     if (!ds_event_time_offset || !ds_event_id || !ds_event_time_zero ||
         !ds_event_index || !ds_cue_index || !ds_cue_timestamp_zero) {
@@ -100,36 +102,33 @@ HDFWriterModule::InitResult HDFWriterModule::init_hdf(
       ds_cue_timestamp_zero.reset();
     }
     if (attributes) {
-      HDFFile::write_attributes(hdf_group, attributes);
+      HDFFile::write_attributes(HDFGroup, attributes);
     }
   } catch (std::exception &e) {
     auto message = hdf5::error::print_nested(e);
-    LOG(Sev::Error,
-        "ERROR ev42 could not init hdf_parent: {}  name: {}  trace: {}",
-        static_cast<std::string>(hdf_parent.link().path()), hdf_parent_name,
-        message);
+    LOG(Sev::Error, "ERROR ev42 could not init hdf_parent: {}  trace: {}",
+        static_cast<std::string>(HDFGroup.link().path()), message);
   }
   return HDFWriterModule::InitResult::OK();
 }
 
 HDFWriterModule::InitResult
-HDFWriterModule::reopen(hdf5::node::Group hdf_parent,
-                        std::string hdf_parent_name, CollectiveQueue *cq,
-                        HDFIDStore *hdf_store) {
-  auto hdf_group = hdf5::node::get_group(hdf_parent, hdf_parent_name);
-
+HDFWriterModule::reopen(HDFWriterModuleInitParameters InitParameters) {
+  auto &HDFGroup = InitParameters.HDFGroup;
+  // Keep these for now, experimenting with those on another branch.
+  HDFIDStore *hdf_store = nullptr;
   this->ds_event_time_offset = h5::h5d_chunked_1d<uint32_t>::open(
-      hdf_group, "event_time_offset", cq, hdf_store);
+      HDFGroup, "event_time_offset", cq, hdf_store);
   this->ds_event_id =
-      h5::h5d_chunked_1d<uint32_t>::open(hdf_group, "event_id", cq, hdf_store);
+      h5::h5d_chunked_1d<uint32_t>::open(HDFGroup, "event_id", cq, hdf_store);
   this->ds_event_time_zero = h5::h5d_chunked_1d<uint64_t>::open(
-      hdf_group, "event_time_zero", cq, hdf_store);
+      HDFGroup, "event_time_zero", cq, hdf_store);
   this->ds_event_index = h5::h5d_chunked_1d<uint32_t>::open(
-      hdf_group, "event_index", cq, hdf_store);
+      HDFGroup, "event_index", cq, hdf_store);
   this->ds_cue_index =
-      h5::h5d_chunked_1d<uint32_t>::open(hdf_group, "cue_index", cq, hdf_store);
+      h5::h5d_chunked_1d<uint32_t>::open(HDFGroup, "cue_index", cq, hdf_store);
   this->ds_cue_timestamp_zero = h5::h5d_chunked_1d<uint64_t>::open(
-      hdf_group, "cue_timestamp_zero", cq, hdf_store);
+      HDFGroup, "cue_timestamp_zero", cq, hdf_store);
 
   ds_event_time_offset->buffer_init(buffer_size, buffer_packet_max);
   ds_event_id->buffer_init(buffer_size, buffer_packet_max);

--- a/src/schemas/ev42/ev42_rw.h
+++ b/src/schemas/ev42/ev42_rw.h
@@ -19,14 +19,10 @@ public:
   static FileWriter::HDFWriterModule::ptr create();
   void parse_config(rapidjson::Value const &config_stream,
                     rapidjson::Value const *config_module) override;
-  InitResult init_hdf(hdf5::node::Group &hdf_parent,
-                      std::string hdf_parent_name,
-                      rapidjson::Value const *attributes,
-                      CollectiveQueue *cq) override;
-  HDFWriterModule::InitResult reopen(hdf5::node::Group hdf_parent,
-                                     std::string hdf_parent_name,
-                                     CollectiveQueue *cq,
-                                     HDFIDStore *hdf_store) override;
+  InitResult init_hdf(HDFWriterModuleInitParameters InitParameters,
+                      rapidjson::Value const *attributes) override;
+  HDFWriterModule::InitResult
+  reopen(HDFWriterModuleInitParameters InitParameters) override;
   WriteResult write(Msg const &msg) override;
   int32_t flush() override;
   int32_t close() override;

--- a/src/schemas/f142/f142_rw.cxx
+++ b/src/schemas/f142/f142_rw.cxx
@@ -421,9 +421,6 @@ HDFWriterModule::InitResult HDFWriterModule::init_hdf(
     hdf5::node::Group &hdf_parent, std::string hdf_parent_name,
     rapidjson::Value const *attributes, CollectiveQueue *cq) {
   try {
-    // LOG(Sev::Error, "hdf_parent: {}   hdf_parent_name: {}",
-    // static_cast<std::string>(hdf_parent.link().path()), hdf_parent_name);
-    // exit(1);
     auto hdf_group = hdf5::node::get_group(hdf_parent, hdf_parent_name);
 
     std::string s("value");

--- a/src/schemas/f142/f142_rw.h
+++ b/src/schemas/f142/f142_rw.h
@@ -59,16 +59,12 @@ class FlatbufferReader : public FileWriter::FlatbufferReader {
 class HDFWriterModule : public FileWriter::HDFWriterModule {
 public:
   static FileWriter::HDFWriterModule::ptr create();
-  InitResult init_hdf(hdf5::node::Group &hdf_parent,
-                      std::string hdf_parent_name,
-                      rapidjson::Value const *attributes,
-                      CollectiveQueue *cq) override;
+  InitResult init_hdf(HDFWriterModuleInitParameters InitParameters,
+                      rapidjson::Value const *attributes) override;
   void parse_config(rapidjson::Value const &config_stream,
                     rapidjson::Value const *config_module) override;
-  HDFWriterModule::InitResult reopen(hdf5::node::Group hdf_file,
-                                     std::string hdf_parent_name,
-                                     CollectiveQueue *cq,
-                                     HDFIDStore *hdf_store) override;
+  HDFWriterModule::InitResult
+  reopen(HDFWriterModuleInitParameters InitParameters) override;
   void enable_cq(CollectiveQueue *cq, HDFIDStore *hdf_store,
                  int mpi_rank) override;
   WriteResult write(Msg const &msg) override;


### PR DESCRIPTION
In `HDFWriterModule`

- remove the separate `hdf_parent` and `hdf_parent_name` and replace by `HDFGroup`, carried by the `HDFWriterModuleInitParameters`.
- LLVM-stylify a few things which got touched on the way