### PR TITLE
Fix missing topic issue

### DIFF
--- a/src/KafkaW/Consumer.cpp
+++ b/src/KafkaW/Consumer.cpp
@@ -170,15 +170,15 @@ void Consumer::addTopic(std::string Topic,
 }
 
 bool Consumer::topicPresent(const std::string &TopicName) {
-  const rd_kafka_metadata_t *Metadata;
-  auto MetadataResult = rd_kafka_metadata(RdKafka, 1, nullptr, &Metadata, 1000);
-
-  if (MetadataResult != RD_KAFKA_RESP_ERR_NO_ERROR) {
-    LOG(Sev::Error, "could not create metadata");
-    return false;
-  }
+  const rd_kafka_metadata_t *Metadata{nullptr};
+  rd_kafka_metadata(RdKafka, 1, nullptr, &Metadata, 1000);
 
   bool IsPresent = false;
+  if (!Metadata) {
+    LOG(Sev::Error, "could not create metadata");
+    return IsPresent;
+  }
+
   for (int topic = 0; topic < Metadata->topic_cnt; ++topic) {
     if (Metadata->topics[topic].topic == TopicName) {
       IsPresent = true;

--- a/src/Streamer.cpp
+++ b/src/Streamer.cpp
@@ -44,6 +44,8 @@ FileWriter::Streamer::connect(std::string TopicName) {
     }
     // Error if the topic cannot be found in the metadata
     if (!Consumer->topicPresent(TopicName)) {
+      LOG(Sev::Error, "Topic {} not in broker, remove corresponding stream",
+          TopicName);
       return StreamerError::TOPIC_PARTITION_ERROR();
     }
   } catch (std::exception &Error) {
@@ -51,7 +53,7 @@ FileWriter::Streamer::connect(std::string TopicName) {
     return StreamerError::CONFIGURATION_ERROR();
   }
 
-  return (RunStatus = StreamerError::WRITING());
+  return StreamerError::WRITING();
 }
 
 FileWriter::Streamer::StreamerError FileWriter::Streamer::closeStream() {
@@ -81,7 +83,7 @@ FileWriter::Streamer::write(FileWriter::DemuxTopic &MessageProcessor) {
   // make sure that the connection is ok
   // attention: connect() handles exceptions
   if (!RunStatus.connectionOK()) {
-    return ProcessMessageResult::ERR();
+    throw std::runtime_error(Err2Str(RunStatus));
   }
 
   // consume message and make sure that's ok


### PR DESCRIPTION
### Description of work

This PR fixes an issue which shows when a topic is not present in the broker. In this case the filewriter throws an error and removes the stream associated with the topic.

### Issue

Closes #183

### Other

It is questionable if the filewriter should remove the stream or keep trying connecting. Here we assume that all the topics have to be created in the broker during some configuration stage (whatever _configuration stage_ could mean) _before_ the write command is issued.

---

## Code Review (To be filled in by the reviewer only)

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
