### PR TITLE
React only on commands addressed to service

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ Available options include:
   ],
   "hdf-output-prefix": "./absolute/or/relative/path/to/hdf/output/directory",
   [OPTIONAL]"kafka" : {
-	"any-rdkafka-option": "value"
+  "any-rdkafka-option": "value"
   },
   [OPTIONAL]"streamer" : {
-	"ms-before-start" : 1000
+  "ms-before-start" : 1000
   },
   [OPTIONAL]"stream-master" : {
-	"topic-write-interval" : 1000
+  "topic-write-interval" : 1000
   },
   "service_id": "this_is_filewriter_instance_HOST_PID_EXAMPLENAME"
 }
@@ -215,9 +215,9 @@ Further documentation:
 
 ```json
 {
-	"cmd": "FileWriter_stop",
-	"job_id": "job-unique-identifier",
-	"stop_time" : <[OPTIONAL] timestamp-in-milliseconds>,
+  "cmd": "FileWriter_stop",
+  "job_id": "job-unique-identifier",
+  "stop_time" : <[OPTIONAL] timestamp-in-milliseconds>,
   "service_id": "[OPTIONAL] the_name_of_the_instance_which_should_interpret_this_command"
 }
 ```
@@ -466,7 +466,7 @@ sources to be implemented) and consumes a message in the specified topic. Some f
 * initial timestamp is specified using ``set_start_time``
 * connection to the Kafka broker is nonblocking. If the broker address is invalid returns an error
 * Kafka::Config and streamer options can be optionally configured using ``kafka`` and ``streamer`` fields in the configuration file. ``kafka`` can contain any option that RdKafka accepts. `streamer` accetps:
-	- `ms-before-start` milliseconds before the `start_time` to start writing from
+  - `ms-before-start` milliseconds before the `start_time` to start writing from
     - `consumer-timeout-ms` the maximum time in milliseconds the consumer waits
       before return with error status
     - `metadata-retry` maxim number of retries to connect to specifies broker

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 ### Running kafka-to-nexus
 
 ```
-./kafka-to-nexus -h
+./kafka-to-nexus --help
 ```
 
 For example:
@@ -52,7 +52,8 @@ Available options include:
   },
   [OPTIONAL]"stream-master" : {
 	"topic-write-interval" : 1000
-  }
+  },
+  "service_id": "this_is_filewriter_instance_HOST_PID_EXAMPLENAME"
 }
 ```
 
@@ -62,6 +63,9 @@ Available options include:
 - `kafka` Kafka configuration for consumers in Streamer
 - `streamer` Configuration option for the Streamer
 - `stream-master` Configuration option for the StreamMaster
+- `service_id` If multiple instances listen on the same Kafka command topic,
+  the `service_id` let's the filewriter filter the commands to interpret.
+
 
 ### Send command to kafka-to-nexus
 
@@ -190,17 +194,21 @@ Further documentation:
     "file_name": "some.h5"
   },
   "cmd": "FileWriter_new",
-  "job_id" : "unique-identifier",
-  "broker" : "localhost:9092",
-  [OPTIONAL]"start_time" : <timestamp in milliseconds>,
-  [OPTIONAL]"stop_time" : <timestamp in milliseconds>,
+  "job_id": "unique-identifier",
+  "broker": "localhost:9092",
+  "start_time": <[OPTIONAL] timestamp in milliseconds>,
+  "stop_time": <[OPTIONAL] timestamp in milliseconds>,
+  "service_id": "[OPTIONAL] the_name_of_the_instance_which_should_interpret_this_command"
 }
 ```
 
 #### Command to exit the file writer:
 
 ```json
-{"cmd": "FileWriter_exit"}
+{
+  "cmd": "FileWriter_exit",
+  "service_id": "[OPTIONAL] the_name_of_the_instance_which_should_interpret_this_command"
+}
 ```
 
 #### Command to stop a single file:
@@ -209,7 +217,8 @@ Further documentation:
 {
 	"cmd": "FileWriter_stop",
 	"job_id": "job-unique-identifier",
-	"[OPTIONAL]stop_time" : "timestamp-in-milliseconds"
+	"stop_time" : <[OPTIONAL] timestamp-in-milliseconds>,
+  "service_id": "[OPTIONAL] the_name_of_the_instance_which_should_interpret_this_command"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Available options include:
 - `streamer` Configuration option for the Streamer
 - `stream-master` Configuration option for the StreamMaster
 - `service_id` If multiple instances listen on the same Kafka command topic,
-  the `service_id` let's the filewriter filter the commands to interpret.
+  the `service_id` lets the filewriter filter the commands to interpret.
 
 
 ### Send command to kafka-to-nexus

--- a/src/CLIOptions.cpp
+++ b/src/CLIOptions.cpp
@@ -71,4 +71,7 @@ void setCLIOptions(CLI::App &App, MainOpt &MainOptions) {
   App.add_flag("--logpid-sleep", MainOptions.logpid_sleep);
   App.add_flag("--use-signal-handler", MainOptions.use_signal_handler);
   App.add_option("--teamid", MainOptions.teamid);
+  App.add_option("--service_id", MainOptions.service_id,
+                 "Identifier string for this filewriter instance. Otherwise by "
+                 "default a string containing hostname and process id.");
 }

--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -395,6 +395,19 @@ void CommandHandler::handle(std::string const &Command) {
     LOG(Sev::Error, "Can not parse json command: {}", Command);
     return;
   }
+
+  if (auto x = find<std::string>("service_id", Doc)) {
+    if (x.inner() != Config.service_id) {
+      return;
+    }
+  } else {
+    // Currently, we interpret commands which have no service_id.
+    // In the future, we may want to ignore all commands which are not
+    // specifically addressed to us (breaking change).
+    // In that case, just uncomment the following return:
+    // return;
+  }
+
   uint64_t TeamId = 0;
   uint64_t CommandTeamId = 0;
   if (MasterPtr) {

--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -398,6 +398,8 @@ void CommandHandler::handle(std::string const &Command) {
 
   if (auto x = find<std::string>("service_id", Doc)) {
     if (x.inner() != Config.service_id) {
+      LOG(Sev::Debug, "Ignoring command addressed to service_id: {}",
+          x.inner());
       return;
     }
   } else {

--- a/src/MainOpt.cpp
+++ b/src/MainOpt.cpp
@@ -9,6 +9,11 @@
 
 using uri::URI;
 
+MainOpt::MainOpt() {
+  service_id = fmt::format("kafka-to-nexus--host:{}--pid:{}",
+                           gethostname_wrapper(), getpid_wrapper());
+}
+
 int MainOpt::parse_config_file() {
   if (config_filename.empty()) {
     LOG(Sev::Notice, "given config filename is empty");
@@ -74,6 +79,9 @@ int MainOpt::parse_config_json(std::string json) {
   }
   if (auto o = get_bool(&d, "source_do_process_message")) {
     source_do_process_message = o.v;
+  }
+  if (auto o = get_string(&d, "service_id")) {
+    service_id = o.v;
   }
 
   return 0;

--- a/src/MainOpt.cpp
+++ b/src/MainOpt.cpp
@@ -88,6 +88,7 @@ int MainOpt::parse_config_json(std::string json) {
 }
 
 void setup_logger_from_options(MainOpt const &opt) {
+  g_ServiceID = opt.service_id;
   if (!opt.kafka_gelf.empty()) {
     URI uri(opt.kafka_gelf);
     log_kafka_gelf_start(uri.host, uri.topic);

--- a/src/MainOpt.h
+++ b/src/MainOpt.h
@@ -26,6 +26,11 @@ struct MainOpt {
   bool help = false;
   bool gtest = false;
   bool use_signal_handler = true;
+  /// Each running filewriter should be identifiable by some id.
+  /// This service_id is announced in the status updates.
+  /// It is by default a combination of hostname and process id.
+  /// Can be set via command line or configuration file.
+  std::string service_id;
   /// Kafka options, they get parsed from the configuration file and passed on
   /// to the StreamMaster.
   std::map<std::string, std::string> kafka;
@@ -73,6 +78,7 @@ struct MainOpt {
   // Max interval (in std::chrono::milliseconds) to spend writing each topic
   // before switch to the next
   std::chrono::milliseconds topic_write_duration;
+  MainOpt();
 };
 
 void setup_logger_from_options(MainOpt const &opt);

--- a/src/Master.cpp
+++ b/src/Master.cpp
@@ -106,6 +106,7 @@ void Master::statistics() {
   rapidjson::Document js_status;
   auto &a = js_status.GetAllocator();
   js_status.SetObject();
+  js_status.AddMember("service_id", Value(config.service_id.c_str(), a), a);
   js_status.AddMember("type", StringRef("filewriter_status_master"), a);
   Value js_files;
   js_files.SetObject();

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -16,6 +16,18 @@ void sleep_ms(size_t ms) {
 
 uint64_t getpid_wrapper() { return getpid(); }
 
+/// Wrapper, because it may need some Windows implementation in the future.
+std::string gethostname_wrapper() {
+  std::vector<char> Buffer;
+  Buffer.resize(1024);
+  int Result = gethostname(Buffer.data(), Buffer.size());
+  Buffer.back() = '\0';
+  if (Result != 0) {
+    return "";
+  }
+  return Buffer.data();
+}
+
 std::vector<char> gulp(std::string fname) {
   std::vector<char> ret;
   std::ifstream ifs(fname, std::ios::binary | std::ios::ate);

--- a/src/helper.h
+++ b/src/helper.h
@@ -11,6 +11,8 @@ void sleep_ms(size_t ms);
 
 uint64_t getpid_wrapper();
 
+std::string gethostname_wrapper();
+
 // note: this implementation does not disable this overload for array types
 template <typename T, typename... TX>
 std::unique_ptr<T> make_unique(TX &&... tx) {

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -17,6 +17,7 @@
 #endif
 
 int log_level = 3;
+std::string g_ServiceID;
 
 // adhoc namespace because it would now collide with ::Logger defined
 // in gralog_logger
@@ -114,7 +115,8 @@ void Logger::dwlog_inner(int level, char const *file, int line,
     npre = 0;
   }
   auto f1 = file + npre;
-  auto lmsg = fmt::format("{}:{} [{}]:  {}\n", f1, line, level, s1);
+  auto lmsg = fmt::format("{}:{} [{}] [ServiceID:{}]:  {}\n", f1, line, level,
+                          g_ServiceID, s1);
   fwrite(lmsg.c_str(), 1, lmsg.size(), log_file);
   if (level < 7 && do_run_kafka.load()) {
     // If we will use logging to Kafka in the future, refactor a bit to reduce
@@ -128,6 +130,9 @@ void Logger::dwlog_inner(int level, char const *file, int line,
     d.AddMember("level", Value(level), a);
     d.AddMember("_FILE", Value(file, a), a);
     d.AddMember("_LINE", Value(line), a);
+    if (!g_ServiceID.empty()) {
+      d.AddMember("ServiceID", Value(g_ServiceID.c_str(), a), a);
+    }
     StringBuffer buf1;
     Writer<StringBuffer> wr(buf1);
     d.Accept(wr);

--- a/src/logger.h
+++ b/src/logger.h
@@ -17,6 +17,8 @@
 
 extern int log_level;
 
+extern std::string g_ServiceID;
+
 // These severity level correspond to the RFC3164 (syslog) severity levels
 enum class Sev : int {
   Emergency = 0, // Do not use, reserved for system errors


### PR DESCRIPTION
### Description of work

- On incoming filewriter command, check if it contains a `service_id`.
- If not, we currently accept the command for compatibility. Behavior can be changed in the future in one line.
- If yes, we check if it matches the `service_id` of the running instance before we accept the command.
- The `service_id` can be given to the filewriter via CLI option or configuration file.

### Issue

Closes https://jira.esss.lu.se/browse/DM-726

### Acceptance Criteria

Filewriter should accept command only if `service_id` matches, or not given in command.
Should get an integration test.

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
