### PR TITLE
Restore streamer.cpp in tests

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -25,22 +25,7 @@ set(UnitTests_INC
 HDFFileTestHelper.h
 )
 
-add_executable(UnitTests EXCLUDE_FROM_ALL ${UnitTests_SRC} ${UnitTests_INC})
-
-
-add_dependencies(UnitTests flatbuffers_generate)
-target_compile_definitions(UnitTests PRIVATE ${compile_defs_common})
-target_include_directories(UnitTests PRIVATE ${path_include_common})
-target_link_libraries(UnitTests ${GTEST_BOTH_LIBRARIES} ${libraries_common})
-
-get_filename_component(TEST_DATA_PATH "data/" ABSOLUTE)
-target_compile_definitions(UnitTests PRIVATE TEST_DATA_PATH="${TEST_DATA_PATH}")
-
-enable_testing()
-add_test(AllTests UnitTests)
-
-#-------------- Integration tests --------------
-
+# replace librdkafka with fake in order to test the Streamer
 set(libraries_testing ${libraries_common})
 if(NOT ${FAKE_RDKAFKA} STREQUAL "")
   message(STATUS "Build with fake librdkafka: " ${FAKE_RDKAFKA})
@@ -49,10 +34,25 @@ if(NOT ${FAKE_RDKAFKA} STREQUAL "")
     ${FAKE_RDKAFKA}/lib/librdkafka-fake.a
      ${FAKE_RDKAFKA}/lib/librdkafka-fake-utils.a
     )
-  list(APPEND sources
-    streamer.cxx
-    )
+  list(APPEND path_include_common ${FAKE_RDKAFKA} )
+  list(APPEND UnitTests_SRC streamer.cpp)
 endif()
+
+add_executable(UnitTests EXCLUDE_FROM_ALL ${UnitTests_SRC} ${UnitTests_INC})
+
+
+add_dependencies(UnitTests flatbuffers_generate)
+target_compile_definitions(UnitTests PRIVATE ${compile_defs_common})
+target_include_directories(UnitTests PRIVATE ${path_include_common})
+target_link_libraries(UnitTests ${GTEST_BOTH_LIBRARIES} ${libraries_testing})
+
+get_filename_component(TEST_DATA_PATH "data/" ABSOLUTE)
+target_compile_definitions(UnitTests PRIVATE TEST_DATA_PATH="${TEST_DATA_PATH}")
+
+enable_testing()
+add_test(AllTests UnitTests)
+
+#-------------- Integration tests --------------
 
 set(IntegrationTest_SRC
   roundtrip.cpp
@@ -70,4 +70,3 @@ target_compile_definitions(IntegrationTest PRIVATE TEST_DATA_PATH="${TEST_DATA_P
 target_compile_definitions(IntegrationTest PRIVATE ${compile_defs_common})
 target_include_directories(IntegrationTest PRIVATE ${path_include_common} ${FAKE_RDKAFKA})
 target_link_libraries(IntegrationTest ${GTEST_BOTH_LIBRARIES} ${libraries_testing})
-


### PR DESCRIPTION
### Description of work

Restore the tests for the Streamer class. See [README->Running tests](https://github.com/ess-dmsc/kafka-to-nexus#running-tests).

### Issue

Not an issue, ticket [DM-399](https://jira.esss.lu.se/browse/DM-399)

### Unit Tests

Tests handling of the following failures (and successes):
- missing constructor arguments
- configuration creation
- missing topic
- connection to the broker
- consumer timeouts

### Other

Here we want to test the Streamer response to network calls. In order to do that we need to fake the rdkafka library: such an implementation can be found in [ess-dmsc/librdkafka-fake](https://github.com/ess-dmsc/librdkafka-fake). Of course I'm open to alternatives.

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
