### PR TITLE
Warnings as errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project("kafka-to-nexus")
 
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};${PROJECT_SOURCE_DIR}/cmake")
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Werror")
+
 if(CMAKE_COMPILER_IS_GNUCXX AND COV)
   include(CodeCoverage)
   setup_target_for_coverage(coverage UnitTests coverage)

--- a/src/Streamer.cpp
+++ b/src/Streamer.cpp
@@ -103,7 +103,7 @@ FileWriter::Streamer::write(FileWriter::DemuxTopic &MessageProcessor) {
   }
 
   // convert from KafkaW to Msg
-  Msg Message(Msg::fromKafkaW(std::move(Poll.isMsg())));
+  Msg Message(Msg::fromKafkaW(Poll.isMsg()));
   if (Message.type == MsgType::Invalid) {
     return ProcessMessageResult::ERR();
   }


### PR DESCRIPTION
### Description of work

Adds `-Wall` and `-Werror` compiler flags to treat warnings as errors, this will stop us from reintroducing warnings. A single warning was being thrown by clang on OS X, so I also fixed that.

### Issue

Closes #199

### Acceptance Criteria

Passing on Jenkins. If there are warnings Jenkins will now report failure.

### Unit Tests

N/A

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
