### PR TITLE
Remove MainOpt constructor and add init

### DIFF
--- a/src/MainOpt.cpp
+++ b/src/MainOpt.cpp
@@ -6,7 +6,11 @@
 
 using uri::URI;
 
-MainOpt::MainOpt() {
+// For reasons unknown, the presence of the constructor caused the integration
+// test to fail, with the NeXus file being created, but no data written to it.
+// While the cause of this problem is not discovered and fixed, use the
+// following init function.
+void MainOpt::init() {
   service_id = fmt::format("kafka-to-nexus--host:{}--pid:{}",
                            gethostname_wrapper(), getpid_wrapper());
 }

--- a/src/MainOpt.h
+++ b/src/MainOpt.h
@@ -78,7 +78,9 @@ struct MainOpt {
   // Max interval (in std::chrono::milliseconds) to spend writing each topic
   // before switch to the next
   std::chrono::milliseconds topic_write_duration;
-  MainOpt();
+  // The constructor was removed because of the issue with the integration test
+  // (see cpp file for more details).
+  void init();
 };
 
 void setup_logger_from_options(MainOpt const &opt);

--- a/src/kafka-to-nexus.cpp
+++ b/src/kafka-to-nexus.cpp
@@ -28,6 +28,7 @@ int main(int argc, char **argv) {
       "Writes NeXus files in a format specified with a json template.\n"
       "Writer modules can be used to populate the file from Kafka topics.\n"};
   auto Options = std::unique_ptr<MainOpt>(new MainOpt());
+  Options->init();
   setCLIOptions(App, *Options);
 
   CLI11_PARSE(App, argc, argv);

--- a/src/tests/HDFFile.cpp
+++ b/src/tests/HDFFile.cpp
@@ -24,7 +24,11 @@ using std::chrono::milliseconds;
 using std::chrono::steady_clock;
 using nlohmann::json;
 
-MainOpt getTestOptions() { return MainOpt(); }
+MainOpt getTestOptions() {
+  MainOpt mo;
+  mo.init();
+  return mo;
+}
 
 void merge_config_into_main_opt(MainOpt &main_opt, string JSONString) {
   main_opt.ConfigJSON.merge_patch(json::parse(JSONString));

--- a/src/tests/HDFFile.cpp
+++ b/src/tests/HDFFile.cpp
@@ -25,9 +25,9 @@ using std::chrono::steady_clock;
 using nlohmann::json;
 
 MainOpt getTestOptions() {
-  MainOpt mo;
-  mo.init();
-  return mo;
+  MainOpt TestOptions;
+  TestOptions.init();
+  return TestOptions;
 }
 
 void merge_config_into_main_opt(MainOpt &main_opt, string JSONString) {

--- a/src/tests/MainOptTest.cpp
+++ b/src/tests/MainOptTest.cpp
@@ -20,6 +20,7 @@ TEST(MainOpt, parse_hdf_output_prefix_from_command_line) {
 
   CLI::App App{""};
   auto Options = std::unique_ptr<MainOpt>(new MainOpt());
+  Options->init();
   setCLIOptions(App, *Options);
   App.parse(static_cast<int>(argv.size()), argv.data());
 
@@ -38,6 +39,7 @@ TEST(MainOpt, parse_hdf_output_prefix_from_json_file) {
 
   CLI::App App{""};
   auto Options = std::unique_ptr<MainOpt>(new MainOpt());
+  Options->init();
   setCLIOptions(App, *Options);
   App.parse(static_cast<int>(argv.size()), argv.data());
   Options->parse_config_file();


### PR DESCRIPTION
The presence of the constructor causes the file writer not to write data
to file in the integration test (the command is received, as the NeXus
file is created with the correct structure). Just commenting out the
contents of the constructor makes no difference. As a temporary
solution, an init function was added to initialise the variable that was
being initialised in the constructor. If the cause of the problem is
discovered and fixed, the constructor can be reintroduced.

### Description of work

See commit text above.

### Issue

Closes JIRA DM-927

### Acceptance Criteria

The build succeeds, unit tests pass and the integration test passes.

### Unit Tests

_src/tests/HDFFile.cpp_ and _src/tests/MainOptTest.cpp_ have been modified to call the new `init` function after the `MainOpt` struct is created.

### Other

For the sake of elegance and resource management, the new `init` should be replaced by the constructor after the problem is understood and fixed.

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).