### PR TITLE
Add file with build information

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -188,14 +188,6 @@ def docker_archive(image_key) {
     try {
         def custom_sh = images[image_key]['sh']
         def archive_output = "${project}-${image_key}.tar.gz"
-
-        git_commit = sh(
-            script: """docker exec ${container_name(image_key)} ${custom_sh} -c \"
-                    cd ${project} && git rev-parse HEAD
-                \"""",
-            returnStdout: true
-        ).trim()
-
         def archive_script = """
                     cd build && \
                     rm -rf ${project}; mkdir ${project} && \
@@ -208,7 +200,7 @@ def docker_archive(image_key) {
                     # Create file with build information
                     touch BUILD_INFO
                     echo 'Repository: ${project}/${env.BRANCH_NAME}' >> BUILD_INFO
-                    echo 'Commit: ${git_commit}' >> BUILD_INFO
+                    echo 'Commit: ${scm_vars.GIT_COMMIT}' >> BUILD_INFO
                     echo 'Jenkins build: ${BUILD_NUMBER}' >> BUILD_INFO
                 """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${archive_script}\""

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -188,6 +188,14 @@ def docker_archive(image_key) {
     try {
         def custom_sh = images[image_key]['sh']
         def archive_output = "${project}-${image_key}.tar.gz"
+
+        git_commit = sh(
+            script: """docker exec ${container_name(image_key)} ${custom_sh} -c \"
+                    cd ${project} && git rev-parse HEAD
+                \"""",
+            returnStdout: true
+        ).trim()
+
         def archive_script = """
                     cd build && \
                     rm -rf ${project}; mkdir ${project} && \
@@ -196,10 +204,17 @@ def docker_archive(image_key) {
                     cp -r ./lib ${project}/ && \
                     cp -r ./licenses ${project}/ && \
                     tar czf ${archive_output} ${project}
+
+                    # Create file with build information
+                    touch BUILD_INFO
+                    echo 'Repository: ${project}/${env.BRANCH_NAME}' >> BUILD_INFO
+                    echo 'Commit: ${git_commit}' >> BUILD_INFO
+                    echo 'Jenkins build: ${BUILD_NUMBER}' >> BUILD_INFO
                 """
         sh "docker exec ${container_name(image_key)} ${custom_sh} -c \"${archive_script}\""
         sh "docker cp ${container_name(image_key)}:/home/jenkins/build/${archive_output} ./"
-        archiveArtifacts "${archive_output}"
+        sh "docker cp ${container_name(image_key)}:/home/jenkins/build/BUILD_INFO ./"
+        archiveArtifacts "${archive_output},BUILD_INFO"
     } catch (e) {
         failure_function(e, "Test step for (${container_name(image_key)}) failed")
     }


### PR DESCRIPTION
### Description of work

Add a BUILD_INFO artefact with project name, commit SHA and Jenkins build number. As we deploy the archive directly from Jenkins, this makes it easier to identify which version has been deployed and can be displayed in the integration test.

### Issue

N/A

### Acceptance Criteria

A new artefact containing project name, branch, Git commit SHA and Jenkins build number is archived in Jenkins.

### Unit Tests

N/a

### Other

N/A

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).