### PR TITLE
Change default UseHDFSWMR value to false

### DIFF
--- a/src/FileWriterTask.h
+++ b/src/FileWriterTask.h
@@ -41,7 +41,7 @@ public:
   std::string hdf_filename;
   std::string filename_full;
   HDFFile hdf_file;
-  bool UseHDFSWMR = true;
+  bool UseHDFSWMR = false;
 
 private:
   std::vector<DemuxTopic> _demuxers;


### PR DESCRIPTION
### Description of work

This sets the default back to not using SWMR, as there is a problem with the current implementation which is blocking other important tickets, see #217 .

No change to the documentation was necessary, it already implies that this is the default.

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
