### PR TITLE
217 fix swmr option

### DIFF
--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -209,6 +209,10 @@ void CommandHandler::handleNew(std::string const &Command) {
     return;
   }
 
+  if (auto x = find<bool>("use_hdf_swmr", Doc)) {
+    Task->UseHDFSWMR = x.inner();
+  }
+
   // When FileWriterTask::hdf_init() returns, `stream_hdf_info` will contain
   // the list of streams which have been found in the `nexus_structure`.
   std::vector<StreamHDFInfo> StreamHDFInfoList;
@@ -221,10 +225,6 @@ void CommandHandler::handleNew(std::string const &Command) {
   } else {
     logMissingKey("nexus_structure", Doc.dump());
     return;
-  }
-
-  if (auto x = find<bool>("use_hdf_swmr", Doc)) {
-    Task->UseHDFSWMR = x.inner();
   }
 
   std::vector<StreamSettings> StreamSettingsList =

--- a/src/HDFFile.cpp
+++ b/src/HDFFile.cpp
@@ -785,6 +785,7 @@ void HDFFile::init(std::string filename, nlohmann::json const &nexus_structure,
           hdf5::file::create(filename, hdf5::file::AccessFlags::TRUNCATE |
                                            hdf5::file::AccessFlags::SWMR_WRITE,
                              fcpl, fapl);
+      isSWMREnabled_ = true;
     } else {
       h5file = hdf5::file::create(filename, hdf5::file::AccessFlags::EXCLUSIVE,
                                   fcpl, fapl);
@@ -893,5 +894,7 @@ void HDFFile::SWMRFlush() {
     SWMRFlushLast = Now;
   }
 }
+
+bool HDFFile::isSWMREnabled() const { return isSWMREnabled_; }
 
 } // namespace FileWriter

--- a/src/HDFFile.h
+++ b/src/HDFFile.h
@@ -51,6 +51,8 @@ public:
   /// file.
   void SWMRFlush();
 
+  bool isSWMREnabled() const;
+
   hdf5::file::File h5file;
   hdf5::node::Group root_group;
 
@@ -125,6 +127,8 @@ private:
                                        hdf5::node::Node &Node,
                                        std::string const &Name,
                                        nlohmann::json const *Values);
+
+  bool isSWMREnabled_ = false;
 
   using CLOCK = std::chrono::steady_clock;
   std::chrono::milliseconds SWMRFlushInterval{10000};


### PR DESCRIPTION
### Description of work

- Add test for opening file in non-SWMR and SWMR mode
- Fix the non-SWMR case

### Issue

Closes #217

### Acceptance Criteria

- Filewriter should respect the `{ "use_hdf_swmr": false }` in the `FileWriter_new` command.

### Unit Tests

`CommandHandlertests.cpp`: `OpenFileInNonSWMRMode`, `OpenFileInSWMRMode`
