### PR TITLE
Fix writing event_time_offset dataset in ev42 writer module

### DIFF
--- a/src/schemas/ev42/ev42_rw.cpp
+++ b/src/schemas/ev42/ev42_rw.cpp
@@ -186,13 +186,6 @@ HDFWriterModule::WriteResult HDFWriterModule::write(Msg const &msg) {
     return HDFWriterModule::WriteResult::ERROR_IO();
   }
   auto fbuf = get_fbuf(msg.data());
-  bool use_the_process_id_for_debug_purposes = true;
-  if (use_the_process_id_for_debug_purposes) {
-    auto p = fbuf->time_of_flight()->data();
-    for (size_t i1 = 0; i1 < fbuf->time_of_flight()->size(); ++i1) {
-      ((uint32_t *)(p))[i1] = getpid_wrapper();
-    }
-  }
   auto w1ret = this->ds_event_time_offset->append_data_1d(
       fbuf->time_of_flight()->data(), fbuf->time_of_flight()->size());
   auto w2ret = this->ds_event_id->append_data_1d(fbuf->detector_id()->data(),


### PR DESCRIPTION
### Description of work

There was some temporary development/debugging code left active, which meant that every value in the dataset was set to the process id. I've removed the offending code. This writer module really needs unit tests, I've created ticket #230 for this.

### Issue

Closes #229

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
