### PR TITLE
Remove non-consumer setting from consumer configuration

### DIFF
--- a/src/Streamer.cpp
+++ b/src/Streamer.cpp
@@ -20,7 +20,6 @@ FileWriter::Streamer::Streamer(const std::string &Broker,
   }
 
   Options.Settings.ConfigurationStrings["group.id"] = TopicName;
-  Options.Settings.ConfigurationStrings["auto.create.topics.enable"] = "false";
   Options.Settings.Address = Broker;
 
   IsConnected =


### PR DESCRIPTION
### Description of work

Removed a broker-side setting from the consumer configuration. It was causing an error to be logged (see #226).
Valid configuration settings can be seen at https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md

### Issue

Closes #226

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
