### PR TITLE
Query offsets_for_times using specified partitions

### DIFF
--- a/src/KafkaW/Consumer.h
+++ b/src/KafkaW/Consumer.h
@@ -21,8 +21,8 @@ public:
   void addTopic(std::string Topic, const std::chrono::milliseconds &StartTime =
                                        std::chrono::milliseconds{0});
   void dumpCurrentSubscription();
-  void dumpMetadata();
   bool topicPresent(const std::string &Topic);
+  int32_t queryNumberOfPartitions(const std::string &TopicName);
   PollStatus poll();
   std::function<void(rd_kafka_topic_partition_list_t *plist)>
       on_rebalance_assign;


### PR DESCRIPTION
Note, based on `fix-start-time` branch.

This works for me. The debug log I added in these changes shows the correct offset being found for the partition.

The problem was that `offsets_for_times` must be called for specific partitions, not for topics with `RD_KAFKA_PARTITION_UA` set. The changes here do a metadata query to find out what partitions exist for the given topic and creates a `TopicPartition` for each of them.