### PR TITLE
Fix start time

### DIFF
--- a/src/KafkaW/Consumer.cpp
+++ b/src/KafkaW/Consumer.cpp
@@ -153,14 +153,14 @@ void Consumer::addTopic(std::string Topic,
   LOG(Sev::Info, "Consumer::add_topic  {}", Topic);
   int Partition = RD_KAFKA_PARTITION_UA;
 
-  if (StartTime.count() > 0) {
-    LOG(Sev::Info, "Consumer::StartTime  {}", StartTime.count());
-    rd_kafka_offsets_for_times(RdKafka, PartitionList, 1000);
-    rd_kafka_topic_partition_list_add(PartitionList, Topic.c_str(), Partition)
-        ->offset = StartTime.count();
+  rd_kafka_topic_partition_list_add(PartitionList, Topic.c_str(), Partition);
+  for (int i = 0; i < PartitionList->cnt; ++i) {
+    if (StartTime.count() > 0) {
+      PartitionList->elems[i].offset = StartTime.count();
+      rd_kafka_offsets_for_times(RdKafka, PartitionList, 1000);
+    }
   }
 
-  rd_kafka_topic_partition_list_add(PartitionList, Topic.c_str(), Partition);
   int err = rd_kafka_subscribe(RdKafka, PartitionList);
   KERR(RdKafka, err);
   if (err) {


### PR DESCRIPTION
### Description of work

With ``KafkaW`` used as ``librdkafka`` wrapper in the ``Streamer`` the *start_time* functionality was broken. This PR  fixes the issue. If a *start_time* is provided ``rd_kafka_offsets_for_times`` is called on all the partitions to retrieve the first message not older than *start_time*.

### Issue

Closes #233 

### Acceptance Criteria

The following function have been added/modified

- ``Consumer::queryNumberOfPartitions``
- ``Consumer::addTopic``

### Other

---

## Code Review (To be filled in by the reviewer only)

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
