### PR TITLE
215 run status error after stop message

### DIFF
--- a/src/Errors.cpp
+++ b/src/Errors.cpp
@@ -122,6 +122,8 @@ const std::string FileWriter::Status::Err2Str(const StreamMasterError &Error) {
   switch (Error.Value) {
   case 1000:
     return "No Error";
+  case 4:
+    return "Stream Can Be Removed";
   case 3:
     return "Streamers Empty";
   case 2:

--- a/src/send-command.cpp
+++ b/src/send-command.cpp
@@ -39,8 +39,7 @@ std::string make_command(const std::string &broker, const uint64_t &teamid) {
 std::string make_command_exit(const std::string &broker,
                               const uint64_t &teamid) {
   auto Command = json::parse(R""({
-    "cmd": "FileWriter_exit",
-    ]
+    "cmd": "FileWriter_exit"
   })"");
   Command["teamid"] = teamid;
   return Command.dump();


### PR DESCRIPTION
### Description of work

This PR adds fixes the log 'Unknown error code' that appears when a file is closed. The log message is now 'Stream Can Be Removed'.
Furthermore the PR fixes a minor bug in ``send-command``.

### Issue

Closes #215

### Acceptance Criteria

Please make sure that the log is correct.

### Other

The *exit* command that ``send-command`` generates is not a valid JSON. The parser complains about the ``]``, which is removed with this PR.
---

## Code Review (To be filled in by the reviewer only)

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
