### PR TITLE
 Commit offsets before subscribing to fix start time functionality

### DIFF
--- a/src/KafkaW/Consumer.cpp
+++ b/src/KafkaW/Consumer.cpp
@@ -182,8 +182,8 @@ void Consumer::commitOffsets() const {
   auto CommitErr = rd_kafka_commit(RdKafka, PartitionList, false);
   KERR(RdKafka, CommitErr);
   if (CommitErr) {
-      LOG(Sev::Error, "Could not commit offsets in Consumer");
-    }
+    LOG(Sev::Error, "Could not commit offsets in Consumer");
+  }
 }
 
 int32_t Consumer::queryNumberOfPartitions(const std::string &TopicName) {

--- a/src/KafkaW/Consumer.cpp
+++ b/src/KafkaW/Consumer.cpp
@@ -166,12 +166,24 @@ void Consumer::addTopic(std::string Topic,
     }
   }
 
+  if (StartTime.count() > 0) {
+    commitOffsets();
+  }
+
   int err = rd_kafka_subscribe(RdKafka, PartitionList);
   KERR(RdKafka, err);
   if (err) {
     LOG(Sev::Error, "could not subscribe");
     throw std::runtime_error("can not subscribe");
   }
+}
+
+void Consumer::commitOffsets() const {
+  auto CommitErr = rd_kafka_commit(RdKafka, PartitionList, false);
+  KERR(RdKafka, CommitErr);
+  if (CommitErr) {
+      LOG(Sev::Error, "Could not commit offsets in Consumer");
+    }
 }
 
 int32_t Consumer::queryNumberOfPartitions(const std::string &TopicName) {

--- a/src/KafkaW/Consumer.h
+++ b/src/KafkaW/Consumer.h
@@ -43,5 +43,7 @@ private:
                            void *opaque);
   rd_kafka_topic_partition_list_t *PartitionList = nullptr;
   int id = 0;
+
+  void commitOffsets() const;
 };
 } // namespace KafkaW


### PR DESCRIPTION
### Description of work

Start time functionality is broken by an immediate partition rebalance after subscribe is called, which resets the offsets. The fix is to commit the offsets before calling subscribe.

### Issue

Closes #239

### Acceptance Criteria

Test using data from NeXus-Streamer.

### Unit Tests

N/A, change is in Kafka interface.

---

## Code Review (To be filled in by the reviewer only)

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
