### PR TITLE
Dm983 timestamp as start time

### DIFF
--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -253,9 +253,12 @@ void CommandHandler::handleNew(std::string const &Command) {
 
   addStreamSourceToWriterModule(StreamSettingsList, Task);
 
+  // If start time not specified use command message timestamp
   std::chrono::milliseconds Time = findTime(Doc, "start_time");
   if (Time.count() > 0) {
     Config.StreamerConfiguration.StartTimestamp = Time;
+  } else {
+    Config.StreamerConfiguration.StartTimestamp = KafkaMsgTimestamp;
   }
   LOG(Sev::Info, "Start time: {}",
       Config.StreamerConfiguration.StartTimestamp.count());

--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -46,9 +46,7 @@ std::chrono::milliseconds findTime(nlohmann::json const &Doc,
 static int g_N_HANDLED = 0;
 
 CommandHandler::CommandHandler(MainOpt &Config_, MasterI *MasterPtr_)
-    : Config(Config_), MasterPtr(MasterPtr_),
-      KafkaMsgTimestamp(std::chrono::duration_cast<std::chrono::milliseconds>(
-          std::chrono::system_clock::now().time_since_epoch())) {}
+    : Config(Config_), MasterPtr(MasterPtr_) {}
 
 /// Holder for the stream settings.
 struct StreamSettings {
@@ -483,6 +481,7 @@ void CommandHandler::tryToHandle(std::string const &Command,
               .count());
     }
 
+    // <<<<<<< 700b7a6bc5fd158b6f69576c21dff1198517de2f
   } catch (json::parse_error const &E) {
     LOG(Sev::Error, "parse_error: {}  Command: {}", E.what(), Command);
   } catch (json::out_of_range const &E) {
@@ -491,6 +490,16 @@ void CommandHandler::tryToHandle(std::string const &Command,
     LOG(Sev::Error, "type_error: {}  Command: ", E.what(), Command);
   } catch (std::runtime_error const &E) {
 
+    // =======
+    //   } catch (nlohmann::detail::parse_error &e) {
+    //     LOG(Sev::Error, "parse_error: {}  Command: {}", e.what(), Command);
+    //   } catch (nlohmann::detail::out_of_range &e) {
+    //     LOG(Sev::Error, "out_of_range: {}  Command: ", e.what(), Command);
+    //   } catch (nlohmann::detail::type_error &e) {
+    //     LOG(Sev::Error, "type_error: {}  Command: ", e.what(), Command);
+    //   } catch (std::runtime_error &e) {
+    // >>>>>>> Do not use class member for message timestamp but propagate in
+    // methods
     // Originates from h5cpp:
     if (std::string(E.what()).find(
             "Cannot obtain ObjectId from an invalid file instance!") == 0) {

--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -255,7 +255,6 @@ void CommandHandler::handleNew(std::string const &Command,
 
   addStreamSourceToWriterModule(StreamSettingsList, Task);
 
-  // Must be done before StreamMaster instantiation.
   // If start time not specified use command message timestamp
   std::chrono::milliseconds Time = findTime(Doc, "start_time");
   if (Time.count() > 0) {

--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -32,8 +32,8 @@ static void throwMissingKey(std::string const &Key,
 }
 
 std::chrono::milliseconds findTime(nlohmann::json const &Doc,
-                                   std::string const &TimeName) {
-  if (auto x = find<uint64_t>(TimeName, Doc)) {
+                                   std::string const &Key) {
+  if (auto x = find<uint64_t>(Key, Doc)) {
     std::chrono::milliseconds Time(x.inner());
     if (Time.count() != 0) {
       return Time;
@@ -381,7 +381,7 @@ void CommandHandler::handleStreamMasterStop(std::string const &Command) {
   if (MasterPtr) {
     auto &StreamMaster = MasterPtr->getStreamMasterForJobID(JobID);
     if (StreamMaster) {
-      if (StopTime.count() != 0) {
+      if (StopTime.count() > 0) {
         LOG(Sev::Info,
             "Received request to gracefully stop file with id : {} at {} ms",
             JobID, StopTime.count());
@@ -481,7 +481,6 @@ void CommandHandler::tryToHandle(std::string const &Command,
               .count());
     }
 
-    // <<<<<<< 700b7a6bc5fd158b6f69576c21dff1198517de2f
   } catch (json::parse_error const &E) {
     LOG(Sev::Error, "parse_error: {}  Command: {}", E.what(), Command);
   } catch (json::out_of_range const &E) {
@@ -489,18 +488,6 @@ void CommandHandler::tryToHandle(std::string const &Command,
   } catch (json::type_error const &E) {
     LOG(Sev::Error, "type_error: {}  Command: ", E.what(), Command);
   } catch (std::runtime_error const &E) {
-
-    // =======
-    //   } catch (nlohmann::detail::parse_error &e) {
-    //     LOG(Sev::Error, "parse_error: {}  Command: {}", e.what(), Command);
-    //   } catch (nlohmann::detail::out_of_range &e) {
-    //     LOG(Sev::Error, "out_of_range: {}  Command: ", e.what(), Command);
-    //   } catch (nlohmann::detail::type_error &e) {
-    //     LOG(Sev::Error, "type_error: {}  Command: ", e.what(), Command);
-    //   } catch (std::runtime_error &e) {
-    // >>>>>>> Do not use class member for message timestamp but propagate in
-    // methods
-    // Originates from h5cpp:
     if (std::string(E.what()).find(
             "Cannot obtain ObjectId from an invalid file instance!") == 0) {
       LOG(Sev::Warning, "Exception while creating HDF output file, maybe "

--- a/src/CommandHandler.h
+++ b/src/CommandHandler.h
@@ -70,6 +70,7 @@ private:
   MainOpt &Config;
   MasterI *MasterPtr = nullptr;
   std::vector<std::unique_ptr<FileWriterTask>> FileWriterTasks;
+  std::chrono::milliseconds KafkaMsgTimestamp;
 };
 
 std::string findBroker(std::string const &);

--- a/src/CommandHandler.h
+++ b/src/CommandHandler.h
@@ -35,7 +35,7 @@ public:
   /// Passes content of the message to the command handler.
   ///
   /// \param Msg The message.
-  void handle(Msg const &msg);
+  void handle(Msg const &msg, int64_t MsgTimestamp = -1);
 
   /// Parses the given command and passes it on to a more specific handler.
   ///
@@ -67,6 +67,7 @@ private:
   MainOpt &Config;
   MasterI *MasterPtr = nullptr;
   std::vector<std::unique_ptr<FileWriterTask>> FileWriterTasks;
+  std::chrono::milliseconds KafkaMsgTimestamp;
 };
 
 std::string findBroker(std::string const &);

--- a/src/CommandHandler.h
+++ b/src/CommandHandler.h
@@ -73,7 +73,16 @@ private:
 };
 
 std::string findBroker(std::string const &);
+//------------------------------------------------------------------------------
+/// @brief      Extract the time in milliseconds associated with the key Key in
+/// the document.
+///
+/// @param      Doc   The JSON document
+/// @param      Key   The time identifier keyword
+///
+/// @return     The value, in milliseconds
+///
 std::chrono::milliseconds findTime(nlohmann::json const &Doc,
-                                   std::string const &TimeName);
+                                   std::string const &Key);
 
 } // namespace FileWriter

--- a/src/CommandHandler.h
+++ b/src/CommandHandler.h
@@ -70,7 +70,6 @@ private:
   MainOpt &Config;
   MasterI *MasterPtr = nullptr;
   std::vector<std::unique_ptr<FileWriterTask>> FileWriterTasks;
-  std::chrono::milliseconds KafkaMsgTimestamp;
 };
 
 std::string findBroker(std::string const &);

--- a/src/CommandHandler.h
+++ b/src/CommandHandler.h
@@ -73,15 +73,14 @@ private:
 };
 
 std::string findBroker(std::string const &);
-//------------------------------------------------------------------------------
-/// @brief      Extract the time in milliseconds associated with the key Key in
+  
+/// \brief Extract the time in milliseconds associated with the key Key in
 /// the document.
 ///
-/// @param      Doc   The JSON document
-/// @param      Key   The time identifier keyword
+/// \param Doc The JSON document.
+/// \param Key The time identifier keyword.
 ///
-/// @return     The value, in milliseconds
-///
+/// \return The value in milliseconds.
 std::chrono::milliseconds findTime(nlohmann::json const &Doc,
                                    std::string const &Key);
 

--- a/src/CommandHandler.h
+++ b/src/CommandHandler.h
@@ -35,6 +35,7 @@ public:
   /// Passes content of the message to the command handler.
   ///
   /// \param Msg The message.
+  /// \param MsgTimestamp The rd_kafka_message_timestamp when available
   void handle(Msg const &msg, int64_t MsgTimestamp = -1);
 
   /// Parses the given command and passes it on to a more specific handler.
@@ -71,5 +72,7 @@ private:
 };
 
 std::string findBroker(std::string const &);
+std::chrono::milliseconds findTime(nlohmann::json const &Doc,
+                                   std::string const &TimeName);
 
 } // namespace FileWriter

--- a/src/CommandHandler.h
+++ b/src/CommandHandler.h
@@ -19,7 +19,8 @@ public:
   /// Given a JSON string, create a new file writer task.
   ///
   /// \param Command The command for configuring the new task.
-  void handleNew(std::string const &Command);
+  void handleNew(std::string const &Command,
+                 const std::chrono::milliseconds MsgTimestamp);
 
   /// Stop the whole file writer application.
   void handleExit();
@@ -36,13 +37,14 @@ public:
   ///
   /// \param Msg The message.
   /// \param MsgTimestamp The rd_kafka_message_timestamp when available
-  void handle(Msg const &msg, int64_t MsgTimestamp = -1);
+  void handle(Msg const &msg, const int64_t MsgTimestamp = -1);
 
   /// Parses the given command and passes it on to a more specific handler.
   ///
   /// \param Command The command to parse.
-  void handle(std::string const &command);
-  void tryToHandle(std::string const &Command);
+  void handle(std::string const &command,
+              const std::chrono::milliseconds MsgTimestamp);
+  void tryToHandle(std::string const &Command, const int64_t MsgTimestamp = -1);
 
   size_t getNumberOfFileWriterTasks() const;
   std::unique_ptr<FileWriterTask> &getFileWriterTaskByJobID(std::string JobID);
@@ -68,7 +70,6 @@ private:
   MainOpt &Config;
   MasterI *MasterPtr = nullptr;
   std::vector<std::unique_ptr<FileWriterTask>> FileWriterTasks;
-  std::chrono::milliseconds KafkaMsgTimestamp;
 };
 
 std::string findBroker(std::string const &);

--- a/src/KafkaW/Msg.cpp
+++ b/src/KafkaW/Msg.cpp
@@ -15,4 +15,26 @@ std::pair<rd_kafka_timestamp_type_t, int64_t> Msg::timestamp() {
   return TS;
 }
 
+// <<<<<<< 700b7a6bc5fd158b6f69576c21dff1198517de2f
 } // namespace KafkaW
+// =======
+// int32_t Msg::partition() { return ((rd_kafka_message_t *)MsgPtr)->partition;
+// }
+
+// int64_t Msg::offset() { return ((rd_kafka_message_t *)MsgPtr)->offset; }
+
+// std::pair<rd_kafka_timestamp_type_t, int64_t> Msg::timestamp() {
+//   std::pair<rd_kafka_timestamp_type_t, int64_t> TS;
+//   TS.second =
+//       rd_kafka_message_timestamp((rd_kafka_message_t *)MsgPtr, &TS.first);
+//   return TS;
+// }
+
+// void *Msg::releaseMsgPtr() {
+//   void *ptr = MsgPtr;
+//   MsgPtr = nullptr;
+//   return ptr;
+// }
+// }
+// >>>>>>> Do not use class member for message timestamp but propagate in
+// methods

--- a/src/KafkaW/Msg.cpp
+++ b/src/KafkaW/Msg.cpp
@@ -1,4 +1,5 @@
 #include "Msg.h"
+#include <librdkafka/rdkafka.h>
 
 namespace KafkaW {
 
@@ -7,4 +8,11 @@ Msg::~Msg() {
     OnDelete();
   }
 }
+
+int64_t Msg::timestamp() {
+  rd_kafka_timestamp_type_t TSType;
+  // Ignore info about timestamp type
+  return rd_kafka_message_timestamp((rd_kafka_message_t *)DataPointer, &TSType);
+}
+
 } // namespace KafkaW

--- a/src/KafkaW/Msg.cpp
+++ b/src/KafkaW/Msg.cpp
@@ -1,5 +1,4 @@
 #include "Msg.h"
-#include <librdkafka/rdkafka.h>
 
 namespace KafkaW {
 
@@ -9,10 +8,11 @@ Msg::~Msg() {
   }
 }
 
-int64_t Msg::timestamp() {
-  rd_kafka_timestamp_type_t TSType;
-  // Ignore info about timestamp type
-  return rd_kafka_message_timestamp((rd_kafka_message_t *)DataPointer, &TSType);
+std::pair<rd_kafka_timestamp_type_t, int64_t> Msg::timestamp() {
+  std::pair<rd_kafka_timestamp_type_t, int64_t> TS;
+  TS.second =
+      rd_kafka_message_timestamp((rd_kafka_message_t *)DataPointer, &TS.first);
+  return TS;
 }
 
 } // namespace KafkaW

--- a/src/KafkaW/Msg.h
+++ b/src/KafkaW/Msg.h
@@ -23,6 +23,7 @@ public:
   std::uint8_t const *data() const { return DataPointer; };
   size_t size() const { return DataSize; };
   std::uint64_t getMessageOffset() const { return MessageOffset; };
+  std::int64_t timestamp();
 
 private:
   unsigned char const *DataPointer{nullptr};

--- a/src/KafkaW/Msg.h
+++ b/src/KafkaW/Msg.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
+#include <librdkafka/rdkafka.h>
 
 namespace KafkaW {
 // Want to expose this typedef also for users of this namespace
@@ -23,7 +24,7 @@ public:
   std::uint8_t const *data() const { return DataPointer; };
   size_t size() const { return DataSize; };
   std::uint64_t getMessageOffset() const { return MessageOffset; };
-  std::int64_t timestamp();
+  std::pair<rd_kafka_timestamp_type_t, int64_t> timestamp();
 
 private:
   unsigned char const *DataPointer{nullptr};

--- a/src/KafkaW/Msg.h
+++ b/src/KafkaW/Msg.h
@@ -2,8 +2,14 @@
 
 #include <cstdint>
 #include <cstdlib>
+// <<<<<<< 700b7a6bc5fd158b6f69576c21dff1198517de2f
 #include <functional>
 #include <librdkafka/rdkafka.h>
+// =======
+// #include <librdkafka/rdkafka.h>
+// #include <map>
+// >>>>>>> Do not use class member for message timestamp but propagate in
+// methods
 
 namespace KafkaW {
 // Want to expose this typedef also for users of this namespace
@@ -21,6 +27,7 @@ public:
       : DataPointer(Pointer), DataSize(Size), OnDelete(std::move(DataDeleter)),
         MessageOffset(Offset) {}
   ~Msg();
+  // <<<<<<< 700b7a6bc5fd158b6f69576c21dff1198517de2f
   std::uint8_t const *data() const { return DataPointer; };
   size_t size() const { return DataSize; };
   std::uint64_t getMessageOffset() const { return MessageOffset; };
@@ -31,5 +38,16 @@ private:
   size_t DataSize{0};
   std::function<void()> OnDelete;
   std::int64_t MessageOffset{0};
+  // =======
+  //   uchar *data();
+  //   size_t size();
+  //   void *MsgPtr = nullptr;
+  //   char const *topicName();
+  //   int64_t offset();
+  //   int32_t partition();
+  //   std::pair<rd_kafka_timestamp_type_t, int64_t> timestamp();
+  //   void *releaseMsgPtr();
+  // >>>>>>> Do not use class member for message timestamp but propagate in
+  // methods
 };
 } // namespace KafkaW

--- a/src/Master.cpp
+++ b/src/Master.cpp
@@ -30,8 +30,19 @@ Master::Master(MainOpt &MainOpt_)
 
 void Master::handle_command_message(std::unique_ptr<KafkaW::Msg> &&msg) {
   CommandHandler command_handler(getMainOpt(), this);
-  command_handler.handle(Msg::owned((char const *)msg->data(), msg->size()),
-                         msg->timestamp());
+  auto MessageTimestamp = msg->timestamp();
+  if (MessageTimestamp.first != RD_KAFKA_TIMESTAMP_NOT_AVAILABLE) {
+    command_handler.handle(Msg::owned((char const *)msg->data(), msg->size()),
+                           MessageTimestamp.second);
+    return;
+  }
+  command_handler.handle(
+      Msg::owned((char const *)msg->data(), msg->size())
+      //,
+      // std::chrono::duration_cast<std::chrono::milliseconds>(
+      //     std::chrono::system_clock::now().time_since_epoch())
+      //     .count()
+      );
 }
 
 void Master::handle_command(std::string const &command) {

--- a/src/Master.cpp
+++ b/src/Master.cpp
@@ -30,7 +30,8 @@ Master::Master(MainOpt &MainOpt_)
 
 void Master::handle_command_message(std::unique_ptr<KafkaW::Msg> &&msg) {
   CommandHandler command_handler(getMainOpt(), this);
-  command_handler.handle(Msg::owned((char const *)msg->data(), msg->size()));
+  command_handler.handle(Msg::owned((char const *)msg->data(), msg->size()),
+                         msg->timestamp());
 }
 
 void Master::handle_command(std::string const &command) {

--- a/src/tests/CommandHandlerTests.cpp
+++ b/src/tests/CommandHandlerTests.cpp
@@ -16,6 +16,40 @@ protected:
   }
 };
 
+TEST_F(CommandHandler_Testing, MissingTimeInHandleNewCommand) {
+  std::ifstream CommandFile(std::string(TEST_DATA_PATH) +
+                            "/msg-cmd-new-01.json");
+  nlohmann::json Command;
+  CommandFile >> Command;
+  EXPECT_EQ(findTime(Command, "start_time").count(), -1);
+  EXPECT_EQ(findTime(Command, "stop_time").count(), -1);
+}
+
+TEST_F(CommandHandler_Testing, FindTimeHandleNewCommand) {
+  std::ifstream CommandFile(std::string(TEST_DATA_PATH) +
+                            "/msg-cmd-new-00.json");
+  nlohmann::json Command;
+  CommandFile >> Command;
+  EXPECT_EQ(findTime(Command, "start_time").count(), 123456789);
+  EXPECT_EQ(findTime(Command, "stop_time").count(), 123456790);
+}
+
+TEST_F(CommandHandler_Testing, MissingTimeHandleStopCommand) {
+  std::ifstream CommandFile(std::string(TEST_DATA_PATH) +
+                            "/msg-conf-stop.json");
+  nlohmann::json Command;
+  CommandFile >> Command;
+  EXPECT_EQ(findTime(Command, "stop_time").count(), -1);
+}
+
+TEST_F(CommandHandler_Testing, FindTimeHandleStopCommand) {
+  std::ifstream CommandFile(std::string(TEST_DATA_PATH) +
+                            "/msg-conf-stop-01.json");
+  nlohmann::json Command;
+  CommandFile >> Command;
+  EXPECT_EQ(findTime(Command, "stop_time").count(), 987654321);
+}
+
 TEST_F(CommandHandler_Testing, CatchExceptionOnAttemptToOverwriteFile) {
   std::ofstream ofs;
   ofs.open("tmp-dummy-hdf");

--- a/src/tests/CommandHandlerTests.cpp
+++ b/src/tests/CommandHandlerTests.cpp
@@ -34,14 +34,14 @@ TEST_F(CommandHandler_Testing, FindTimeHandleNewCommand) {
   EXPECT_EQ(findTime(Command, "stop_time").count(), 123456790);
 }
 
-TEST(CommandHandler_Testing, MissingTimeHandleStopCommand) {
+TEST_F(CommandHandler_Testing, MissingTimeHandleStopCommand) {
   std::string CommandString(
       R"""({"cmd":"FileWriter_stop"})""");
   nlohmann::json Command = nlohmann::json::parse(CommandString);
   EXPECT_EQ(findTime(Command, "stop_time").count(), -1);
 }
 
-TEST(CommandHandler_Testing, FindTimeHandleStopCommand) {
+TEST_F(CommandHandler_Testing, FindTimeHandleStopCommand) {
   std::string CommandString(
       R"""({"cmd":"FileWriter_stop","stop_time":987654321})""");
   nlohmann::json Command = nlohmann::json::parse(CommandString);

--- a/src/tests/CommandHandlerTests.cpp
+++ b/src/tests/CommandHandlerTests.cpp
@@ -34,19 +34,17 @@ TEST_F(CommandHandler_Testing, FindTimeHandleNewCommand) {
   EXPECT_EQ(findTime(Command, "stop_time").count(), 123456790);
 }
 
-TEST_F(CommandHandler_Testing, MissingTimeHandleStopCommand) {
-  std::ifstream CommandFile(std::string(TEST_DATA_PATH) +
-                            "/msg-conf-stop.json");
-  nlohmann::json Command;
-  CommandFile >> Command;
+TEST(CommandHandler_Testing, MissingTimeHandleStopCommand) {
+  std::string CommandString(
+      R"""({"cmd":"FileWriter_stop"})""");
+  nlohmann::json Command = nlohmann::json::parse(CommandString);
   EXPECT_EQ(findTime(Command, "stop_time").count(), -1);
 }
 
-TEST_F(CommandHandler_Testing, FindTimeHandleStopCommand) {
-  std::ifstream CommandFile(std::string(TEST_DATA_PATH) +
-                            "/msg-conf-stop-01.json");
-  nlohmann::json Command;
-  CommandFile >> Command;
+TEST(CommandHandler_Testing, FindTimeHandleStopCommand) {
+  std::string CommandString(
+      R"""({"cmd":"FileWriter_stop","stop_time":987654321})""");
+  nlohmann::json Command = nlohmann::json::parse(CommandString);
   EXPECT_EQ(findTime(Command, "stop_time").count(), 987654321);
 }
 

--- a/src/tests/CommandHandlerTests.cpp
+++ b/src/tests/CommandHandlerTests.cpp
@@ -8,6 +8,7 @@
 
 using nlohmann::json;
 using namespace FileWriter;
+using CLK = std::chrono::system_clock;
 
 class CommandHandler_Testing : public testing::Test {
 protected:
@@ -16,34 +17,91 @@ protected:
   }
 };
 
-TEST_F(CommandHandler_Testing, MissingTimeInHandleNewCommand) {
-  std::ifstream CommandFile(std::string(TEST_DATA_PATH) +
-                            "/msg-cmd-new-01.json");
-  nlohmann::json Command;
-  CommandFile >> Command;
-  EXPECT_EQ(findTime(Command, "start_time").count(), -1);
-  EXPECT_EQ(findTime(Command, "stop_time").count(), -1);
+TEST_F(CommandHandler_Testing, MissingStratTimeMeanStartNow) {
+
+  unlink("a-dummy-name-00.h5");
+  std::string CommandString(R"""(
+{
+  "cmd": "FileWriter_new",
+  "file_attributes": {
+    "file_name": "a-dummy-name-00.h5"
+  },
+  "job_id": "qw3rty",
+  "broker": "localhost:202020",
+  "nexus_structure": { }
+})""");
+
+  MainOpt MainOpt;
+  CommandHandler CommandHandler(MainOpt, nullptr);
+  CommandHandler.handle(
+      FileWriter::Msg::owned(CommandString.data(), CommandString.size()));
+
+  std::chrono::milliseconds Now =
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          CLK::now().time_since_epoch());
+  // Allow 100ms tolerance
+  EXPECT_NEAR(MainOpt.StreamerConfiguration.StartTimestamp.count(), Now.count(),
+              100);
+  unlink("a-dummy-name-00.h5");
 }
 
-TEST_F(CommandHandler_Testing, FindTimeHandleNewCommand) {
-  std::ifstream CommandFile(std::string(TEST_DATA_PATH) +
-                            "/msg-cmd-new-00.json");
-  nlohmann::json Command;
-  CommandFile >> Command;
-  EXPECT_EQ(findTime(Command, "start_time").count(), 123456789);
-  EXPECT_EQ(findTime(Command, "stop_time").count(), 123456790);
+TEST_F(CommandHandler_Testing, MissingStopTimeMeanNeverStop) {
+
+  unlink("a-dummy-name-00.h5");
+  std::string CommandString(R"""(
+{
+  "cmd": "FileWriter_new",
+  "file_attributes": {
+    "file_name": "a-dummy-name-00.h5"
+  },
+  "job_id": "qw3rty",
+  "broker": "localhost:202020",
+  "nexus_structure": { }
+})""");
+
+  MainOpt MainOpt;
+  CommandHandler CommandHandler(MainOpt, nullptr);
+  CommandHandler.handle(
+      FileWriter::Msg::owned(CommandString.data(), CommandString.size()));
+
+  EXPECT_FALSE(MainOpt.StreamerConfiguration.StopTimestamp.count() > 0);
+  unlink("a-dummy-name-00.h5");
+}
+
+TEST_F(CommandHandler_Testing, UseFoundStartStopTime) {
+  unlink("a-dummy-name-01.h5");
+  std::string CommandString(R"""(
+{
+  "cmd": "FileWriter_new",
+  "file_attributes": {
+    "file_name": "a-dummy-name-01.h5"
+  },
+  "job_id": "qw3rty",
+  "broker": "localhost:202020",
+  "start_time" : 123456789,
+  "stop_time" : 123456790,
+  "nexus_structure": { }
+})""");
+
+  MainOpt MainOpt;
+  CommandHandler CommandHandler(MainOpt, nullptr);
+  CommandHandler.handle(
+      FileWriter::Msg::owned(CommandString.data(), CommandString.size()));
+  EXPECT_EQ(MainOpt.StreamerConfiguration.StartTimestamp.count(), 123456789);
+  EXPECT_EQ(MainOpt.StreamerConfiguration.StopTimestamp.count(), 123456790);
+  unlink("a-dummy-name-01.h5");
 }
 
 TEST_F(CommandHandler_Testing, MissingTimeHandleStopCommand) {
   std::string CommandString(
-      R"""({"cmd":"FileWriter_stop"})""");
+      R"""({"cmd":"FileWriter_stop","job_id": "xyzwt"})""");
   nlohmann::json Command = nlohmann::json::parse(CommandString);
   EXPECT_EQ(findTime(Command, "stop_time").count(), -1);
 }
 
 TEST_F(CommandHandler_Testing, FindTimeHandleStopCommand) {
   std::string CommandString(
-      R"""({"cmd":"FileWriter_stop","stop_time":987654321})""");
+      R"""({"cmd":"FileWriter_stop","job_id": "xyzwt","stop_time":987654321})""");
   nlohmann::json Command = nlohmann::json::parse(CommandString);
   EXPECT_EQ(findTime(Command, "stop_time").count(), 987654321);
 }

--- a/src/tests/data/msg-conf-stop-01.json
+++ b/src/tests/data/msg-conf-stop-01.json
@@ -1,0 +1,4 @@
+{
+    "cmd": "FileWriter_exit",
+    "stop_time" : 987654321
+}

--- a/src/tests/data/msg-conf-stop-01.json
+++ b/src/tests/data/msg-conf-stop-01.json
@@ -1,4 +1,0 @@
-{
-    "cmd": "FileWriter_exit",
-    "stop_time" : 987654321
-}

--- a/src/tests/data/msg-conf-stop.json
+++ b/src/tests/data/msg-conf-stop.json
@@ -1,3 +1,0 @@
-{
-    "cmd": "FileWriter_exit"
-}


### PR DESCRIPTION
### Description of work

This PR closes [ticket 983](https://jira.esss.lu.se/browse/DM-983). If the timestamp is not specified in the command uses the timestamp of the Kafka message.
``KafkaW::Msg`` has now a new time() method that returns the timestamp of the message.

### Acceptance Criteria

- Events must  be written from and until the specified times
- If no time is specified start time must be the Kafka message timestamp
- If the Kafka message timestamp is empty start time must be the time at with the message has been received
- If no stop time is specified the file must be closed as the message arrives

### Unit Tests

- Make sure that start and stop command use the values defined in the command

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).