### PR TITLE
Set num of artefacts to keep in Jenkins to 10

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,6 +28,18 @@ def Object container_name(image_key) {
     return "${base_container_name}-${image_key}"
 }
 
+// Set number of old builds to keep.
+properties([[
+    $class: 'BuildDiscarderProperty',
+    strategy: [
+        $class: 'LogRotator',
+        artifactDaysToKeepStr: '',
+        artifactNumToKeepStr: '10',
+        daysToKeepStr: '',
+        numToKeepStr: ''
+    ]
+]]);
+
 def failure_function(exception_obj, failureMessage) {
     def toEmails = [[$class: 'DevelopersRecipientProvider']]
     emailext body: '${DEFAULT_CONTENT}\n\"' + failureMessage + '\"\n\nCheck console output at $BUILD_URL to view the results.', recipientProviders: toEmails, subject: '${DEFAULT_SUBJECT}'


### PR DESCRIPTION
### Description of work

Limit number of artefacts to be kept by Jenkins to 10.

### Acceptance Criteria

Jenkins should keep the 10 last sets of artefacts for recent builds. The build itself should not change.

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).