### PR TITLE
Fix of issue #265

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,10 +153,6 @@ set(tgt "kafka_to_nexus__objects")
 add_library(${tgt} STATIC
   ${kafka_to_nexus_SRC}
   ${kafka_to_nexus_INC}
-  $<TARGET_OBJECTS:template_module>
-  $<TARGET_OBJECTS:ev42_module>
-  $<TARGET_OBJECTS:f142_module>
-  $<TARGET_OBJECTS:senv_module>
 )
 target_link_libraries(${tgt} ${libraries_common} fmt::fmt)
 
@@ -178,7 +174,11 @@ target_link_libraries(${tgt} kafka_to_nexus__objects)
 
 set(tgt "kafka-to-nexus")
 set(sources
-        kafka-to-nexus.cpp
+  kafka-to-nexus.cpp
+  $<TARGET_OBJECTS:template_module>
+  $<TARGET_OBJECTS:ev42_module>
+  $<TARGET_OBJECTS:f142_module>
+  $<TARGET_OBJECTS:senv_module>
 )
 add_executable(${tgt} ${sources})
 add_dependencies(${tgt} flatbuffers_generate)

--- a/src/schemas/ModuleFunction.cmake
+++ b/src/schemas/ModuleFunction.cmake
@@ -1,7 +1,8 @@
 #=============================================================================
 # Generate file-writer module
 # Note that you will still need to manually include the code in the
-# 'kafka_to_nexus__objects' target (see src/CMakeLists.txt for examples).
+# 'kafka-to-nexus' target as well as the 'UnitTests' target
+# (see src/CMakeLists.txt for examples).
 #=============================================================================
 function(create_module module_name)
   add_library(${module_name} OBJECT

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -39,7 +39,14 @@ add_executable(UnitTests EXCLUDE_FROM_ALL ${UnitTests_SRC} ${UnitTests_INC})
 add_dependencies(UnitTests flatbuffers_generate)
 target_compile_definitions(UnitTests PRIVATE ${compile_defs_common})
 target_include_directories(UnitTests PRIVATE ${path_include_common} ${Trompeloeil_INCLUDE_DIR})
-target_link_libraries(UnitTests kafka_to_nexus__objects ${GTEST_BOTH_LIBRARIES})
+target_link_libraries(UnitTests 
+  kafka_to_nexus__objects
+  ${GTEST_BOTH_LIBRARIES}
+  $<TARGET_OBJECTS:template_module>
+  $<TARGET_OBJECTS:ev42_module>
+  $<TARGET_OBJECTS:f142_module>
+  $<TARGET_OBJECTS:senv_module>
+)
 
 get_filename_component(TEST_DATA_PATH "data/" ABSOLUTE)
 target_compile_definitions(UnitTests PRIVATE TEST_DATA_PATH="${TEST_DATA_PATH}")


### PR DESCRIPTION
### Description of work

The issue was that C++ does not guarantee that static variables are instantiated unless they are used in a function and because the registrars were not used in any functions, they were not instantiated. This is a fix that appears to work though the fix is not guaranteed by the C++ standard.

### Issue

Closes #265.

### Acceptance Criteria

This should be tested in an integration test but I am confident that it will work.

### Unit Tests

N/A

### Other

N/A
---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).