### PR TITLE
Add more information to exceptions, catch exception in command handler

### DIFF
--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -487,7 +487,7 @@ void CommandHandler::tryToHandle(std::string const &Command) {
   }
 }
 
-void CommandHandler::handle(Msg const &Msg) {
+void CommandHandler::tryToHandle(Msg const &Msg) {
   tryToHandle({(char *)Msg.data(), Msg.size()});
 }
 

--- a/src/CommandHandler.h
+++ b/src/CommandHandler.h
@@ -35,7 +35,7 @@ public:
   /// Passes content of the message to the command handler.
   ///
   /// \param Msg The message.
-  void handle(Msg const &msg);
+  void tryToHandle(Msg const &msg);
 
   /// Parses the given command and passes it on to a more specific handler.
   ///

--- a/src/HDFFile.cpp
+++ b/src/HDFFile.cpp
@@ -47,7 +47,8 @@ static void append_value(nlohmann::json const *Value, std::vector<DT> &Buffer) {
   } else if (Value->is_number_float()) {
     Buffer.push_back(Value->get<double>());
   } else {
-    LOG(Sev::Error, "Unhandled type in HDFFile::append_value()")
+    std::throw_with_nested(std::runtime_error(fmt::format(
+        "Expect a numeric value but got: {}", Value->dump().substr(0, 256))));
   }
 }
 
@@ -105,18 +106,23 @@ static void writeAttrNumeric(hdf5::node::Node &Node, const std::string &Name,
   if (Value->is_array()) {
     Length = Value->size();
   }
-  auto ValueData = populate_blob<T>(Value, Length);
   try {
-    if (Value->is_array()) {
-      write_attribute(Node, Name, ValueData);
-    } else {
-      write_attribute(Node, Name, ValueData[0]);
+    auto ValueData = populate_blob<T>(Value, Length);
+    try {
+      if (Value->is_array()) {
+        write_attribute(Node, Name, ValueData);
+      } else {
+        write_attribute(Node, Name, ValueData[0]);
+      }
+    } catch (std::exception const &E) {
+      std::throw_with_nested(std::runtime_error(
+          fmt::format("Failed write for numeric attribute {} in {}: {}", Name,
+                      std::string(Node.link().path()), E.what())));
     }
-  } catch (std::exception &e) {
-    std::stringstream ss;
-    ss << "Failed numeric attribute write in ";
-    ss << Node.link().path() << "/" << Name;
-    std::throw_with_nested(std::runtime_error(ss.str()));
+  } catch (std::exception const &E) {
+    std::throw_with_nested(std::runtime_error(
+        fmt::format("Can not populate blob for attribute {} in {}: {}", Name,
+                    std::string(Node.link().path()), E.what())));
   }
 }
 
@@ -455,20 +461,32 @@ HDFFile::populate_fixed_strings(nlohmann::json const *Value, size_t FixedAt,
 }
 
 template <typename DT>
-static void write_ds_numeric(hdf5::node::Group &parent, std::string name,
-                             hdf5::property::DatasetCreationList &dcpl,
-                             hdf5::dataspace::Dataspace &dataspace,
-                             nlohmann::json const *vals) {
+static void write_ds_numeric(hdf5::node::Group &Node, std::string Name,
+                             hdf5::property::DatasetCreationList &DCPL,
+                             hdf5::dataspace::Dataspace &Dataspace,
+                             nlohmann::json const *Values) {
 
   try {
-    auto ds = parent.create_dataset(name, hdf5::datatype::create<DT>(),
-                                    dataspace, dcpl);
-    ds.write(populate_blob<DT>(vals, dataspace.size()));
-  } catch (std::exception &e) {
-    std::stringstream ss;
-    ss << "Failed numeric dataset write in ";
-    ss << parent.link().path() << "/" << name;
-    std::throw_with_nested(std::runtime_error(ss.str()));
+    auto ds = Node.create_dataset(Name, hdf5::datatype::create<DT>(), Dataspace,
+                                  DCPL);
+    try {
+      auto Blob = populate_blob<DT>(Values, Dataspace.size());
+      try {
+        ds.write(Blob);
+      } catch (std::exception const &E) {
+        std::throw_with_nested(std::runtime_error(
+            fmt::format("Failed write for numeric attribute {} in {}: {}", Name,
+                        std::string(Node.link().path()), E.what())));
+      }
+    } catch (std::exception const &E) {
+      std::throw_with_nested(std::runtime_error(
+          fmt::format("Failed populate_blob for numeric attribute {} in {}: {}",
+                      Name, std::string(Node.link().path()), E.what())));
+    }
+  } catch (std::exception const &E) {
+    std::throw_with_nested(std::runtime_error(
+        fmt::format("Failed write for numeric attribute {} in {}: {}", Name,
+                    std::string(Node.link().path()), E.what())));
   }
 }
 

--- a/src/Master.cpp
+++ b/src/Master.cpp
@@ -30,7 +30,8 @@ Master::Master(MainOpt &MainOpt_)
 
 void Master::handle_command_message(std::unique_ptr<KafkaW::Msg> &&msg) {
   CommandHandler command_handler(getMainOpt(), this);
-  command_handler.handle(Msg::owned((char const *)msg->data(), msg->size()));
+  command_handler.tryToHandle(
+      Msg::owned((char const *)msg->data(), msg->size()));
 }
 
 void Master::handle_command(std::string const &command) {

--- a/src/tests/CommandHandlerTests.cpp
+++ b/src/tests/CommandHandlerTests.cpp
@@ -46,8 +46,8 @@ TEST_F(CommandHandler_Testing, CatchExceptionOnAttemptToOverwriteFile) {
     ]
   }
 })""");
-  CommandHandler.handle(
-      FileWriter::Msg::owned(CommandString.data(), CommandString.size()));
+  // Make sure that using 'tryToHandle' does not let the exception escape
+  CommandHandler.tryToHandle(CommandString);
   // Assert that this command was not accepted by the command handler:
   ASSERT_EQ(CommandHandler_Testing::FileWriterTasksSize(CommandHandler),
             static_cast<size_t>(0));
@@ -72,8 +72,7 @@ void createFileWithOptionalSWMR(bool UseSWMR) {
   auto Command = nlohmann::json::parse(CommandString);
   Command["use_hdf_swmr"] = UseSWMR;
   CommandString = Command.dump();
-  CommandHandler.handle(
-      FileWriter::Msg::owned(CommandString.data(), CommandString.size()));
+  CommandHandler.handle(CommandString);
   ASSERT_EQ(CommandHandler.getNumberOfFileWriterTasks(),
             static_cast<size_t>(1));
   auto &Task = CommandHandler.getFileWriterTaskByJobID("tmp_swmr_enable");

--- a/src/tests/HDFFile.cpp
+++ b/src/tests/HDFFile.cpp
@@ -75,7 +75,7 @@ void send_stop(FileWriter::CommandHandler &ch, json const &CommandJSON) {
   })"");
   Command["job_id"] = CommandJSON["job_id"];
   auto CommandString = Command.dump();
-  ch.handle(FileWriter::Msg::owned(CommandString.data(), CommandString.size()));
+  ch.handle(CommandString);
 }
 
 // Verify
@@ -92,8 +92,10 @@ TEST(HDFFile, Create) {
 class T_CommandHandler : public testing::Test {
 public:
   static void new_03() {
-    auto CommandString =
+    auto CommandData =
         gulp(std::string(TEST_DATA_PATH) + "/msg-cmd-new-03.json");
+    std::string CommandString(CommandData.data(),
+                              CommandData.data() + CommandData.size());
     LOG(Sev::Debug, "CommandString: {:.{}}", CommandString.data(),
         CommandString.size());
     auto Command = json::parse(CommandString);
@@ -101,8 +103,7 @@ public:
     unlink(fname.c_str());
     MainOpt main_opt;
     FileWriter::CommandHandler ch(main_opt, nullptr);
-    ch.handle(
-        FileWriter::Msg::owned(CommandString.data(), CommandString.size()));
+    ch.handle(CommandString);
   }
 
   static bool check_cue(std::vector<uint64_t> const &event_time_zero,
@@ -141,12 +142,12 @@ public:
     auto json_command = basic_command(hdf_output_filename);
     command_add_static_dataset_1d(json_command);
 
-    auto cmd = json_command.dump();
+    auto Command = json_command.dump();
     std::string fname = json_command["file_attributes"]["file_name"];
     ASSERT_GT(fname.size(), 8u);
 
     FileWriter::CommandHandler ch(main_opt, nullptr);
-    ch.handle(FileWriter::Msg::owned(cmd.data(), cmd.size()));
+    ch.handle(Command);
     ASSERT_EQ(ch.getNumberOfFileWriterTasks(), (size_t)1);
     send_stop(ch, json_command);
     ASSERT_EQ(ch.getNumberOfFileWriterTasks(), (size_t)0);
@@ -288,8 +289,7 @@ public:
     ASSERT_GT(Filename.size(), 8u);
 
     FileWriter::CommandHandler ch(main_opt, nullptr);
-    ch.handle(
-        FileWriter::Msg::owned(CommandString.data(), CommandString.size()));
+    ch.handle(CommandString);
     ASSERT_EQ(ch.getNumberOfFileWriterTasks(), (size_t)1);
     send_stop(ch, CommandJSON);
     ASSERT_EQ(ch.getNumberOfFileWriterTasks(), (size_t)0);
@@ -324,8 +324,7 @@ public:
     ASSERT_GT(Filename.size(), 8u);
 
     FileWriter::CommandHandler ch(main_opt, nullptr);
-    ch.handle(
-        FileWriter::Msg::owned(CommandString.data(), CommandString.size()));
+    ch.handle(CommandString);
     ASSERT_EQ(ch.getNumberOfFileWriterTasks(), (size_t)1);
     send_stop(ch, CommandJSON);
     ASSERT_EQ(ch.getNumberOfFileWriterTasks(), (size_t)0);
@@ -628,8 +627,7 @@ public:
       unlink(string(fname).c_str());
 
       auto CommandString = CommandJSON.dump();
-      ch.handle(
-          FileWriter::Msg::owned(CommandString.data(), CommandString.size()));
+      ch.handle(CommandString);
       ASSERT_EQ(ch.getNumberOfFileWriterTasks(), (size_t)1);
 
       auto &fwt = ch.getFileWriterTaskByJobID("test-ev42");
@@ -977,8 +975,7 @@ public:
     for (int file_i = 0; file_i < 1; ++file_i) {
       unlink(Filename.c_str());
 
-      ch.handle(FileWriter::Msg::owned((char const *)CommandString.data(),
-                                       CommandString.size()));
+      ch.handle(CommandString);
       ASSERT_EQ(ch.getNumberOfFileWriterTasks(), (size_t)1);
 
       auto &fwt = ch.getFileWriterTaskByJobID("unit_test_job_data_f142");


### PR DESCRIPTION
### Description of work

- Create better messages for `std::runtime_error`
- Use `tryToHandle` on incoming command message which logs exceptions
- Simplify unit tests by handling a command string without conversion to a `Msg`
