### PR TITLE
Remove system tests output file in test finaliser

### DIFF
--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -75,6 +75,14 @@ def run_containers(cmd, options):
 
 
 def build_and_run(options, request):
+    try:
+        print("Removing file", flush=True)
+        os.remove(os.path.join(os.path.join(os.getcwd(), "output-files"), "output_file.nxs"))
+        print("Removed file", flush=True)
+    except OSError:
+        print("No file found, continuing..")
+        pass
+
     build_filewriter_image()
     project = project_from_options(os.path.dirname(__file__), options)
     cmd = TopLevelCommand(project)
@@ -88,9 +96,6 @@ def build_and_run(options, request):
         options["--timeout"] = 30
         cmd.down(options)
         print("containers stopped", flush=True)
-        print("Removing file", flush=True)
-        os.remove(os.path.join(os.path.join(os.getcwd(), "output-files"), "output_file.nxs"))
-        print("Removed file", flush=True)
 
     # Using a finalizer rather than yield in the fixture means
     # that the containers will be brought down even if tests fail

--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -88,6 +88,9 @@ def build_and_run(options, request):
         options["--timeout"] = 30
         cmd.down(options)
         print("containers stopped", flush=True)
+        print("Removing file", flush=True)
+        os.remove(os.path.join(os.path.join(os.getcwd(), "output-files"), "output_file.nxs"))
+        print("Removed file", flush=True)
 
     # Using a finalizer rather than yield in the fixture means
     # that the containers will be brought down even if tests fail

--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -76,11 +76,11 @@ def run_containers(cmd, options):
 
 def build_and_run(options, request):
     try:
-        print("Removing file", flush=True)
+        print("Removing previous NeXus file", flush=True)
         os.remove(os.path.join(os.path.join(os.getcwd(), "output-files"), "output_file.nxs"))
-        print("Removed file", flush=True)
+        print("Removed previous NeXus file", flush=True)
     except OSError:
-        print("No file found, continuing..")
+        print("No previous NeXus file found, continuing..")
         pass
 
     build_filewriter_image()

--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -81,7 +81,6 @@ def build_and_run(options, request):
         print("Removed previous NeXus file", flush=True)
     except OSError:
         print("No previous NeXus file found, continuing..")
-        pass
 
     build_filewriter_image()
     project = project_from_options(os.path.dirname(__file__), options)


### PR DESCRIPTION
### Description of work

Removes the nexus file outputted by the system tests even if a test fails. This makes it easier to run system tests as you don't have to remove the file afterwards. 

### Issue

Closes #282 

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
