### PR TITLE
Adding missing cli options

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The file writer can be configured via `--config-file <ini>` which should contain
   service_id=this_is_filewriter_instance_HOST_PID_EXAMPLENAME
   streamer-ms-before-start=123456
   kafka-config-ints=consumer.timeout.ms 501 fetch.message.max.bytes 1234
+  kafka-config-strings=
 ```
 Note that the kafka options are key value pairs and the filewriter can be given multiple by appending the key value pair to the end of the command line option. 
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ The file writer can be configured via `--config-file <ini>` which should contain
   hdf-output-prefix=./absolute/or/relative/path/to/hdf/output/directory
   service_id=this_is_filewriter_instance_HOST_PID_EXAMPLENAME
   streamer-ms-before-start=123456
+  kafka-config-ints=consumer.timeout.ms 501 fetch.message.max.bytes 1234
 ```
-
+Note that the kafka options are key value pairs and the filewriter can be given multiple by appending the key value pair to the end of the command line option. 
 
 ### Send command to kafka-to-nexus
 

--- a/src/CLIOptions.cpp
+++ b/src/CLIOptions.cpp
@@ -144,7 +144,7 @@ void setCLIOptions(CLI::App &App, MainOpt &MainOptions) {
                        "Streamer option - stop timestamp (milliseconds)", true);
   App.add_option("--streamer-metadata-retry",
                  MainOptions.StreamerConfiguration.NumMetadataRetry,
-                 "Streamer option - consumer timeout (milliseconds)", true);
+                 "Streamer option - ", true);
   addMillisecondOption(
       App, "--stream-master-topic-write-interval",
       MainOptions.topic_write_duration,

--- a/src/CLIOptions.cpp
+++ b/src/CLIOptions.cpp
@@ -132,22 +132,29 @@ void setCLIOptions(CLI::App &App, MainOpt &MainOptions) {
                        MainOptions.StreamerConfiguration.BeforeStartTime,
                        "Streamer option - milliseconds before start time",
                        true);
-  addMillisecondOption(App, "--streamer-ms-after-start",
+  addMillisecondOption(App, "--streamer-ms-after-stop",
                        MainOptions.StreamerConfiguration.AfterStopTime,
                        "Streamer option - milliseconds after stop time", true);
+  addMillisecondOption(App, "--streamer-start-time",
+                       MainOptions.StreamerConfiguration.StartTimestamp,
+                       "Streamer option - start timestamp (milliseconds)",
+                       true);
+  addMillisecondOption(App, "--streamer-stop-time",
+                       MainOptions.StreamerConfiguration.StopTimestamp,
+                       "Streamer option - stop timestamp (milliseconds)", true);
   App.add_option("--streamer-metadata-retry",
                  MainOptions.StreamerConfiguration.NumMetadataRetry,
-                 "Streamer option - ", true);
+                 "Streamer option - consumer timeout (milliseconds)", true);
   addMillisecondOption(
       App, "--stream-master-topic-write-interval",
       MainOptions.topic_write_duration,
       "Stream-master option - topic write interval (milliseconds)");
   addKafkaOption(
-      App, "-S",
+      App, "-S,--kafka-config-string",
       MainOptions.StreamerConfiguration.Settings.ConfigurationStrings,
       "LibRDKafka option (String value)");
   addKafkaOption(
-      App, "-I",
+      App, "-I,--kafka-config-int",
       MainOptions.StreamerConfiguration.Settings.ConfigurationIntegers,
       "LibRDKafka option (Integer value)");
   App.set_config("-c,--config-file", "", "Read configuration from an ini file");

--- a/src/CLIOptions.cpp
+++ b/src/CLIOptions.cpp
@@ -82,7 +82,7 @@ CLI::Option *addKafkaOption(CLI::App &App, std::string const &Name,
     for (size_t i = 0; i < Results.size() / 2; i++) {
       try {
         ConfigMap[Results.at(i * 2)] = std::stol(Results.at(i * 2 + 1));
-      } catch (std::invalid_argument e) {
+      } catch (std::invalid_argument &e) {
         throw std::runtime_error(
             fmt::format("Argument {} is not an int", Results.at(i * 2)));
       }
@@ -150,11 +150,11 @@ void setCLIOptions(CLI::App &App, MainOpt &MainOptions) {
       MainOptions.topic_write_duration,
       "Stream-master option - topic write interval (milliseconds)");
   addKafkaOption(
-      App, "-S,--kafka-config-string",
+      App, "-S,--kafka-config-strings",
       MainOptions.StreamerConfiguration.Settings.ConfigurationStrings,
       "LibRDKafka option (String value)");
   addKafkaOption(
-      App, "-I,--kafka-config-int",
+      App, "-I,--kafka-config-ints",
       MainOptions.StreamerConfiguration.Settings.ConfigurationIntegers,
       "LibRDKafka option (Integer value)");
   App.set_config("-c,--config-file", "", "Read configuration from an ini file");


### PR DESCRIPTION
### Description of work

Adding: 
Stop timestamp option (`--streamer-stop-time`)
Start timestamp option (`--streamer-start-time`)
Kafka option documentation 

### Issue

Closes #287 

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
