### PR TITLE
Removing NumMetadataRetry from cli11 and streamer options

### DIFF
--- a/src/CLIOptions.cpp
+++ b/src/CLIOptions.cpp
@@ -142,9 +142,6 @@ void setCLIOptions(CLI::App &App, MainOpt &MainOptions) {
   addMillisecondOption(App, "--streamer-stop-time",
                        MainOptions.StreamerConfiguration.StopTimestamp,
                        "Streamer option - stop timestamp (milliseconds)", true);
-  App.add_option("--streamer-metadata-retry",
-                 MainOptions.StreamerConfiguration.NumMetadataRetry,
-                 "Streamer option - ", true);
   addMillisecondOption(
       App, "--stream-master-topic-write-interval",
       MainOptions.topic_write_duration,

--- a/src/StreamerOptions.h
+++ b/src/StreamerOptions.h
@@ -26,7 +26,6 @@ struct StreamerOptions {
   std::chrono::milliseconds StopTimestamp{0};
   std::chrono::milliseconds BeforeStartTime{1000};
   std::chrono::milliseconds AfterStopTime{1000};
-  int NumMetadataRetry{5};
 };
 
 } // namespace FileWriter


### PR DESCRIPTION
### Description of work

It's not ever used so I removed the option from cli11opt and removed it from the `StreamerOptions` struct. 

### Issue

Closes #289 

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
