### PR TITLE
System tests: container output to file then artifacting on jenkins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -y && \
     apt-get clean all && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip install conan
+RUN pip install conan==1.8.2
 # Force conan to create .conan directory and profile
 RUN conan profile new default
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -292,6 +292,7 @@ def get_system_tests_pipeline() {
             scl enable rh-python35 -- python -m pytest -s --junitxml=./SystemTestsOutput.xml .
             """
             junit "system-tests/SystemTestsOutput.xml"
+            archiveArtifacts "logs/*.log"
           }  // stage
         } finally {
           stage ("System tests: Clean Up") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -292,7 +292,7 @@ def get_system_tests_pipeline() {
             scl enable rh-python35 -- python -m pytest -s --junitxml=./SystemTestsOutput.xml .
             """
             junit "system-tests/SystemTestsOutput.xml"
-            archiveArtifacts "logs/*.log"
+            archiveArtifacts "system-tests/logs/*.log"
           }  // stage
         } finally {
           stage ("System tests: Clean Up") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -207,18 +207,11 @@ node {
     }
   }
 
-  // macos is currently not available on the build servers
-  // builders['macOS'] = get_macos_pipeline()
+  builders['macOS'] = get_macos_pipeline()
 
-  // System tests currently fail, probably because of build server maintenance window, with:
-  // E               docker.errors.BuildError: The command '/bin/sh -c cd kafka_to_nexus &&
-  // conan install --build=outdated ../kafka_to_nexus_src/conan/conanfile.txt'
-  // returned a non-zero code: 1
-  //
-  // ../../../../.local/lib/python3.5/site-packages/docker/models/images.py:266: BuildError
-  //if ( env.CHANGE_ID ) {
-  //    builders['system tests'] = get_system_tests_pipeline()
-  //}
+  if ( env.CHANGE_ID ) {
+      builders['system tests'] = get_system_tests_pipeline()
+  }
 
   try {
     parallel builders

--- a/src/CLIOptions.cpp
+++ b/src/CLIOptions.cpp
@@ -101,6 +101,8 @@ void setCLIOptions(CLI::App &App, MainOpt &MainOptions) {
                  "commands");
   App.add_flag("--logpid-sleep", MainOptions.logpid_sleep);
   App.add_flag("--use-signal-handler", MainOptions.use_signal_handler);
+  App.add_option("--log-file", MainOptions.LogFilename,
+                 "Specify file to log to");
   App.add_option("--teamid", MainOptions.teamid);
   App.add_option("--service-id", MainOptions.service_id,
                  "Identifier string for this filewriter instance. Otherwise by "

--- a/src/MainOpt.cpp
+++ b/src/MainOpt.cpp
@@ -50,4 +50,8 @@ void setupLoggerFromOptions(MainOpt const &opt) {
   if (!opt.graylog_logger_address.empty()) {
     fwd_graylog_logger_enable(opt.graylog_logger_address);
   }
+
+  if (!opt.LogFilename.empty()) {
+    use_log_file(opt.LogFilename);
+  }
 }

--- a/src/MainOpt.h
+++ b/src/MainOpt.h
@@ -32,6 +32,8 @@ struct MainOpt {
   std::string kafka_gelf;
   /// Can optionally use the `graylog_logger` library to log to this address.
   std::string graylog_logger_address;
+  /// Used for logging to file
+  std::string LogFilename;
   /// The commands file given by the `--commands-json` option.
   nlohmann::json CommandsJson = nlohmann::json::object();
   /// The commands filename given by the `--commands-json` option.

--- a/system-tests/config-files/file_writer_config.ini
+++ b/system-tests/config-files/file_writer_config.ini
@@ -3,3 +3,4 @@ command-uri="//localhost:9092/TEST_writerCommand"
 status-uri= "//localhost:9092/TEST_writerStatus"
 status-master-interval=2000
 verbosity=7
+log-file=/filewriter_logs/filewriter_tests.log

--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -89,7 +89,6 @@ def build_and_run(options, request):
     run_containers(cmd, options)
 
     def fin():
-        cmd.logs(options)
         # Stop the containers then remove them and their volumes (--volumes option)
         print("containers stopping", flush=True)
         options["--timeout"] = 30

--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -103,6 +103,15 @@ def build_and_run(options, request):
     # from to get all data which was published
     return start_time
 
+@pytest.fixture(scope="session", autouse=True)
+def remove_logs_from_previous_run(request):
+    print("Removing previous log files", flush=True)
+    dir_name = os.path.join(os.getcwd(), "logs")
+    dirlist = os.listdir(dir_name)
+    for filename in dirlist:
+        if filename.endswith(".log"):
+            os.remove(os.path.join(dir_name, filename))
+    print("Removed previous log files", flush=True)
 
 @pytest.fixture(scope="module")
 def docker_compose(request):

--- a/system-tests/docker-compose.yml
+++ b/system-tests/docker-compose.yml
@@ -41,3 +41,4 @@ services:
     volumes:
     - ./config-files/file_writer_config.ini:/file_writer_config.ini
     - ./output-files/:/output-files/
+    - ./logs/:/filewriter_logs/

--- a/system-tests/logs/.gitkeep
+++ b/system-tests/logs/.gitkeep
@@ -1,0 +1,1 @@
+This file retains this otherwise empty directory in git so that it can be used as a file output directory in the docker-compose script.


### PR DESCRIPTION
### Description of work

The filewriter container now logs to a file instead of stdout. 

These files are then artifacted on jenkins so can be read by a user rather than just to the container output

### Issue

Closes #280 

### Acceptance Criteria

I have modified `CLIOpt.cpp` and `MainOpt.h` to include a missing option for using a log file, the functionality already existed in `logger.h` so didn't need to add the actual logic of using a log file to write to. 

### Unit Tests

None modified

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
