### PR TITLE
Re-enable the macos build node

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -207,8 +207,7 @@ node {
     }
   }
 
-  // macos is currently not available on the build servers
-  // builders['macOS'] = get_macos_pipeline()
+  builders['macOS'] = get_macos_pipeline()
 
   // System tests currently fail, probably because of build server maintenance window, with:
   // E               docker.errors.BuildError: The command '/bin/sh -c cd kafka_to_nexus &&


### PR DESCRIPTION
### Description of work

Enable macos target on build server after build node is available again.
