### PR TITLE
Log message instead of program termination when structure cannot be written to nexus file

### DIFF
--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -90,7 +90,7 @@ static StreamSettings extractStreamInformationFromJsonForSource(
   StreamSettings.StreamHDFInfoObj = StreamHDFInfo;
 
   json ConfigStream;
-  ConfigStream = json::parse(StreamHDFInfo.config_stream);
+  ConfigStream = json::parse(StreamHDFInfo.ConfigStream);
 
   json ConfigStreamInner;
   if (auto StreamMaybe = find<json>("stream", ConfigStream)) {
@@ -147,7 +147,7 @@ static StreamSettings extractStreamInformationFromJsonForSource(
         "Can not create a HDFWriterModule for '{}'", StreamSettings.Module));
   }
 
-  auto RootGroup = Task->hdf_file.h5file.root();
+  auto RootGroup = Task->hdf_file.H5File.root();
   try {
     HDFWriterModule->parse_config(ConfigStreamInner.dump(), "{}");
   } catch (std::exception const &E) {
@@ -161,7 +161,7 @@ static StreamSettings extractStreamInformationFromJsonForSource(
     Attributes = x.inner();
   }
   auto StreamGroup =
-      hdf5::node::get_group(RootGroup, StreamHDFInfo.hdf_parent_name);
+      hdf5::node::get_group(RootGroup, StreamHDFInfo.HDFParentName);
   HDFWriterModule->init_hdf({StreamGroup}, Attributes.dump());
   HDFWriterModule->close();
   HDFWriterModule.reset();
@@ -179,12 +179,12 @@ static std::vector<StreamSettings> extractStreamInformationFromJson(
       StreamSettingsList.push_back(
           extractStreamInformationFromJsonForSource(Task, StreamHDFInfo));
     } catch (json::parse_error const &E) {
-      LOG(Sev::Warning, "Invalid json: {}", StreamHDFInfo.config_stream);
+      LOG(Sev::Warning, "Invalid json: {}", StreamHDFInfo.ConfigStream);
       continue;
     } catch (std::runtime_error const &E) {
       LOG(Sev::Warning,
           "Exception while initializing writer module  what: {}  json: {}",
-          E.what(), StreamHDFInfo.config_stream);
+          E.what(), StreamHDFInfo.ConfigStream);
       continue;
     }
   }
@@ -333,13 +333,13 @@ void CommandHandler::addStreamSourceToWriterModule(
         // Reopen the previously created HDF dataset.
         HDFWriterModule->parse_config(StreamSettings.ConfigStreamJson, "{}");
         try {
-          auto RootGroup = Task->hdf_file.h5file.root();
+          auto RootGroup = Task->hdf_file.H5File.root();
           auto StreamGroup = hdf5::node::get_group(
-              RootGroup, StreamSettings.StreamHDFInfoObj.hdf_parent_name);
+              RootGroup, StreamSettings.StreamHDFInfoObj.HDFParentName);
           auto Err = HDFWriterModule->reopen({StreamGroup});
           if (Err.is_ERR()) {
             LOG(Sev::Error, "can not reopen HDF file for stream {}",
-                StreamSettings.StreamHDFInfoObj.hdf_parent_name);
+                StreamSettings.StreamHDFInfoObj.HDFParentName);
             continue;
           }
         } catch (std::runtime_error const &e) {

--- a/src/HDFFile.cpp
+++ b/src/HDFFile.cpp
@@ -290,8 +290,8 @@ void HDFFile::writeAttrOfSpecifiedType(std::string const &DType,
       } else {
         std::string const StringValue = Values->get<std::string>();
         auto StringType = hdf5::datatype::String::fixed(StringValue.size());
-        auto StringAttr = Node.attributes.create(Name, StringType,
-                                                 hdf5::dataspace::Scalar());
+        auto StringAttr =
+            Node.attributes.create(Name, StringType, hdf5::dataspace::Scalar());
         StringAttr.write(StringValue, StringType);
       }
     }
@@ -452,8 +452,8 @@ static void writeNumericDataset(
     hdf5::dataspace::Dataspace &Dataspace, const nlohmann::json *Values) {
 
   try {
-    auto Dataset = Node.create_dataset(Name, hdf5::datatype::create<DT>(), Dataspace,
-                                  DatasetCreationPropertyList);
+    auto Dataset = Node.create_dataset(Name, hdf5::datatype::create<DT>(),
+                                       Dataspace, DatasetCreationPropertyList);
     try {
       auto Blob = populateBlob<DT>(Values, Dataspace.size());
       try {
@@ -485,9 +485,10 @@ void HDFFile::WriteStringDataset(
     DataType.encoding(hdf5::datatype::CharacterEncoding::UTF8);
     DataType.padding(hdf5::datatype::StringPad::NULLTERM);
 
-    auto Dataset = Parent.create_dataset(Name, DataType, Dataspace, DatasetCreationList);
-    Dataset.write(populateStrings(Values, Dataspace.size()), DataType, Dataspace,
-             Dataspace, hdf5::property::DatasetTransferList());
+    auto Dataset =
+        Parent.create_dataset(Name, DataType, Dataspace, DatasetCreationList);
+    Dataset.write(populateStrings(Values, Dataspace.size()), DataType,
+                  Dataspace, Dataspace, hdf5::property::DatasetTransferList());
   } catch (const std::exception &e) {
     std::stringstream ss;
     ss << "Failed to write variable-size string dataset ";
@@ -507,11 +508,13 @@ void HDFFile::writeFixedSizeStringDataset(
     DataType.encoding(hdf5::datatype::CharacterEncoding::UTF8);
     DataType.padding(hdf5::datatype::StringPad::NULLTERM);
 
-    auto Dataset = Parent.create_dataset(Name, DataType, Dataspace, DatasetCreationList);
+    auto Dataset =
+        Parent.create_dataset(Name, DataType, Dataspace, DatasetCreationList);
 
     DataType.padding(hdf5::datatype::StringPad::NULLPAD);
-    Dataset.write(populateFixedStrings(Values, ElementSize, Dataspace.size()), DataType,
-             Dataspace, Dataspace, hdf5::property::DatasetTransferList());
+    Dataset.write(populateFixedStrings(Values, ElementSize, Dataspace.size()),
+                  DataType, Dataspace, Dataspace,
+                  hdf5::property::DatasetTransferList());
 
   } catch (const std::exception &e) {
     std::stringstream ss;
@@ -731,7 +734,8 @@ void HDFFile::createHDFStructures(
       Path.pop_back();
     }
   } catch (const std::exception &e) {
-    LOG(Sev::Error, "Failed to create structure  parent={} level={}", std::string(Parent.link().path()), Level)
+    LOG(Sev::Error, "Failed to create structure  parent={} level={}",
+        std::string(Parent.link().path()), Level)
   }
 }
 

--- a/src/HDFFile.cpp
+++ b/src/HDFFile.cpp
@@ -731,6 +731,7 @@ void HDFFile::createHDFStructures(
       Path.pop_back();
     }
   } catch (const std::exception &e) {
+    // Don't throw here as the file should continue writing
     LOG(Sev::Error, "Failed to create structure  parent={} level={}",
         std::string(Parent.link().path()), Level)
   }

--- a/src/HDFFile.cpp
+++ b/src/HDFFile.cpp
@@ -90,9 +90,6 @@ static std::vector<DT> populateBlob(const nlohmann::json *Value,
   }
 
   if (static_cast<hssize_t>(Buffer.size()) != GoalSize) {
-    LOG(Sev::Warning,
-        "Failed to populate numeric blob \n size mismatch {} != {}",
-        Buffer.size(), GoalSize);
     std::stringstream ss;
     ss << "Failed to populate numeric blob ";
     ss << " size mismatch " << Buffer.size() << "!=" << GoalSize;

--- a/src/HDFFile.cpp
+++ b/src/HDFFile.cpp
@@ -23,23 +23,23 @@ using nlohmann::json;
 using json_out_of_range = nlohmann::detail::out_of_range;
 
 template <typename T>
-static void write_attribute(hdf5::node::Node &node, const std::string &name,
-                            T value) {
+static void writeAttribute(hdf5::node::Node &Node, const std::string &Name,
+                           T Value) {
   hdf5::property::AttributeCreationList acpl;
   acpl.character_encoding(hdf5::datatype::CharacterEncoding::UTF8);
-  node.attributes.create<T>(name, acpl).write(value);
+  Node.attributes.create<T>(Name, acpl).write(Value);
 }
 
 template <typename T>
-static void write_attribute(hdf5::node::Node &node, const std::string &name,
-                            std::vector<T> values) {
+static void writeAttribute(hdf5::node::Node &Node, const std::string &Name,
+                           std::vector<T> Values) {
   hdf5::property::AttributeCreationList acpl;
   acpl.character_encoding(hdf5::datatype::CharacterEncoding::UTF8);
-  node.attributes.create<T>(name, {values.size()}, acpl).write(values);
+  Node.attributes.create<T>(Name, {Values.size()}, acpl).write(Values);
 }
 
 template <typename DT>
-static void append_value(nlohmann::json const *Value, std::vector<DT> &Buffer) {
+static void appendValue(const nlohmann::json *Value, std::vector<DT> &Buffer) {
   if (Value->is_number_integer()) {
     Buffer.push_back(Value->get<int64_t>());
   } else if (Value->is_number_unsigned()) {
@@ -53,8 +53,8 @@ static void append_value(nlohmann::json const *Value, std::vector<DT> &Buffer) {
 }
 
 template <typename DT>
-static std::vector<DT> populate_blob(nlohmann::json const *Value,
-                                     hssize_t goal_size) {
+static std::vector<DT> populateBlob(const nlohmann::json *Value,
+                                    hssize_t GoalSize) {
   std::vector<DT> Buffer;
   if (Value->is_array()) {
     std::stack<json const *> as;
@@ -81,18 +81,21 @@ static std::vector<DT> populate_blob(nlohmann::json const *Value,
         ai.push(0);
         an.push(v.size());
       } else {
-        append_value(&v, Buffer);
+        appendValue(&v, Buffer);
         ai.top()++;
       }
     }
   } else {
-    append_value(Value, Buffer);
+    appendValue(Value, Buffer);
   }
 
-  if (static_cast<hssize_t>(Buffer.size()) != goal_size) {
+  if (static_cast<hssize_t>(Buffer.size()) != GoalSize) {
+    LOG(Sev::Warning,
+        "Failed to populate numeric blob \n size mismatch {} != {}",
+        Buffer.size(), GoalSize);
     std::stringstream ss;
     ss << "Failed to populate numeric blob ";
-    ss << " size mismatch " << Buffer.size() << "!=" << goal_size;
+    ss << " size mismatch " << Buffer.size() << "!=" << GoalSize;
     std::throw_with_nested(std::runtime_error(ss.str()));
   }
 
@@ -101,25 +104,25 @@ static std::vector<DT> populate_blob(nlohmann::json const *Value,
 
 template <typename T>
 static void writeAttrNumeric(hdf5::node::Node &Node, const std::string &Name,
-                             nlohmann::json const *Value) {
+                             const nlohmann::json *Value) {
   hssize_t Length = 1;
   if (Value->is_array()) {
     Length = Value->size();
   }
   try {
-    auto ValueData = populate_blob<T>(Value, Length);
+    auto ValueData = populateBlob<T>(Value, Length);
     try {
       if (Value->is_array()) {
-        write_attribute(Node, Name, ValueData);
+        writeAttribute(Node, Name, ValueData);
       } else {
-        write_attribute(Node, Name, ValueData[0]);
+        writeAttribute(Node, Name, ValueData[0]);
       }
-    } catch (std::exception const &E) {
+    } catch (const std::exception &E) {
       std::throw_with_nested(std::runtime_error(
           fmt::format("Failed write for numeric attribute {} in {}: {}", Name,
                       std::string(Node.link().path()), E.what())));
     }
-  } catch (std::exception const &E) {
+  } catch (const std::exception &E) {
     std::throw_with_nested(std::runtime_error(
         fmt::format("Can not populate blob for attribute {} in {}: {}", Name,
                     std::string(Node.link().path()), E.what())));
@@ -136,7 +139,7 @@ HDFFile::HDFFile() {
 #endif
 }
 
-herr_t visitor_show_name(hid_t oid, char const *name, H5O_info_t const *oi,
+herr_t visitor_show_name(hid_t oid, const char *name, const H5O_info_t *oi,
                          void *op_data) {
   LOG(Sev::Error, "obj refs: {:2}  name: {}", oi->rc, name);
   return 0;
@@ -153,66 +156,48 @@ HDFFile::~HDFFile() {
   }
 }
 
-void HDFFile::write_hdf_ds_scalar_string(hdf5::node::Group &parent,
-                                         std::string name, std::string s1) {
-
-  auto strfix = hdf5::datatype::String::variable();
-  strfix.encoding(hdf5::datatype::CharacterEncoding::UTF8);
-
-  auto dsp = hdf5::dataspace::Scalar();
-  auto ds = parent.create_dataset(name, strfix, dsp);
-  ds.write(s1, strfix, dsp, dsp);
-}
-
-void HDFFile::write_attribute_str(hdf5::node::Node &node, std::string name,
-                                  std::string value) {
+void HDFFile::writeStringAttribute(hdf5::node::Node &Node,
+                                   const std::string &Name,
+                                   const std::string &Value) {
   auto string_type = hdf5::datatype::String::variable();
   string_type.encoding(hdf5::datatype::CharacterEncoding::UTF8);
-  hdf5::property::AttributeCreationList acpl;
-  acpl.character_encoding(hdf5::datatype::CharacterEncoding::UTF8);
+  hdf5::property::AttributeCreationList AttributeCreationPropertyList;
+  AttributeCreationPropertyList.character_encoding(
+      hdf5::datatype::CharacterEncoding::UTF8);
 
-  auto at = node.attributes.create(name, string_type, hdf5::dataspace::Scalar(),
-                                   acpl);
-  at.write(value, string_type);
+  auto at = Node.attributes.create(Name, string_type, hdf5::dataspace::Scalar(),
+                                   AttributeCreationPropertyList);
+  at.write(Value, string_type);
 }
 
 template <typename T>
-void HDFFile::write_hdf_ds_iso8601(hdf5::node::Group &parent,
-                                   const std::string &name, T &ts) {
+static void writeHDFISO8601Attribute(hdf5::node::Node &Node,
+                                     const std::string &Name, T &TimeStamp) {
   using namespace date;
   using namespace std::chrono;
-  auto s2 = format("%Y-%m-%dT%H:%M:%S%z", ts);
-  HDFFile::write_hdf_ds_scalar_string(parent, name, s2);
+  auto s2 = format("%Y-%m-%dT%H:%M:%S%z", TimeStamp);
+  HDFFile::writeStringAttribute(Node, Name, s2);
 }
 
-template <typename T>
-static void write_hdf_attribute_iso8601(hdf5::node::Node &node,
-                                        std::string name, T &ts) {
+void HDFFile::writeHDFISO8601AttributeCurrentTime(hdf5::node::Node &Node,
+                                                  const std::string &Name) {
   using namespace date;
   using namespace std::chrono;
-  auto s2 = format("%Y-%m-%dT%H:%M:%S%z", ts);
-  HDFFile::write_attribute_str(node, name, s2);
-}
-
-void HDFFile::write_hdf_iso8601_now(hdf5::node::Node &node,
-                                    const std::string &name) {
-  using namespace date;
-  using namespace std::chrono;
-  const time_zone *current_time_zone;
+  const time_zone *CurrentTimeZone;
   try {
-    current_time_zone = current_zone();
-  } catch (std::runtime_error const &e) {
+    CurrentTimeZone = current_zone();
+  } catch (const std::runtime_error &e) {
     LOG(Sev::Warning, "ERROR failed to detect time zone for use in ISO8601 "
                       "timestamp in HDF file")
-    current_time_zone = locate_zone("UTC");
+    CurrentTimeZone = locate_zone("UTC");
   }
-  auto now = make_zoned(current_time_zone,
+  auto now = make_zoned(CurrentTimeZone,
                         floor<std::chrono::milliseconds>(system_clock::now()));
-  write_hdf_attribute_iso8601(node, name, now);
+  writeHDFISO8601Attribute(Node, Name, now);
 }
 
-void HDFFile::write_attributes(hdf5::node::Node &Node,
-                               nlohmann::json const *Value) {
+void HDFFile::writeAttributes(hdf5::node::Node &Node,
+                              const nlohmann::json *Value) {
   if (Value->is_array()) {
     writeArrayOfAttributes(Node, Value);
   } else if (Value->is_object()) {
@@ -225,11 +210,11 @@ void HDFFile::write_attributes(hdf5::node::Node &Node,
 /// \param Node : node to write attributes on
 /// \param JsonValue : json value array of attribute objects
 void HDFFile::writeArrayOfAttributes(hdf5::node::Node &Node,
-                                     nlohmann::json const *Value) {
-  if (!Value->is_array()) {
+                                     const nlohmann::json *Values) {
+  if (!Values->is_array()) {
     return;
   }
-  for (auto const &Attribute : *Value) {
+  for (auto const &Attribute : *Values) {
     if (Attribute.is_object()) {
       string Name;
       if (auto NameMaybe = find<std::string>("name", Attribute)) {
@@ -262,8 +247,8 @@ void HDFFile::writeArrayOfAttributes(hdf5::node::Node &Node,
 /// \param Values : the attribute values
 void HDFFile::writeAttrOfSpecifiedType(std::string const &DType,
                                        hdf5::node::Node &Node,
-                                       std::string const &Name,
-                                       nlohmann::json const *Values) {
+                                       const std::string &Name,
+                                       const nlohmann::json *Values) {
   try {
     if (DType == "uint8") {
       writeAttrNumeric<uint8_t>(Node, Name, Values);
@@ -297,20 +282,20 @@ void HDFFile::writeAttrOfSpecifiedType(std::string const &DType,
     }
     if (DType == "string") {
       if (Values->is_array()) {
-        auto ValueArray = populate_strings(Values, Values->size());
+        auto ValueArray = populateStrings(Values, Values->size());
         auto StringAttr =
             Node.attributes.create(Name, hdf5::datatype::create<std::string>(),
                                    hdf5::dataspace::Simple{{Values->size()}});
         StringAttr.write(ValueArray);
       } else {
         std::string const StringValue = Values->get<std::string>();
-        auto string_type = hdf5::datatype::String::fixed(StringValue.size());
-        auto StringAttr = Node.attributes.create(Name, string_type,
+        auto StringType = hdf5::datatype::String::fixed(StringValue.size());
+        auto StringAttr = Node.attributes.create(Name, StringType,
                                                  hdf5::dataspace::Scalar());
-        StringAttr.write(StringValue, string_type);
+        StringAttr.write(StringValue, StringType);
       }
     }
-  } catch (std::exception &e) {
+  } catch (const std::exception &e) {
     std::stringstream ss;
     ss << "Failed attribute write in ";
     ss << Node.link().path() << "/" << Name;
@@ -323,8 +308,8 @@ void HDFFile::writeAttrOfSpecifiedType(std::string const &DType,
 /// \param node : node to write attributes on
 /// \param jsv : json value object of attributes
 void HDFFile::writeObjectOfAttributes(hdf5::node::Node &Node,
-                                      nlohmann::json const *Value) {
-  for (auto It = Value->begin(); It != Value->end(); ++It) {
+                                      const nlohmann::json *Values) {
+  for (auto It = Values->begin(); It != Values->end(); ++It) {
     auto const Name = It.key();
     writeScalarAttribute(Node, Name, &It.value());
   }
@@ -333,42 +318,42 @@ void HDFFile::writeObjectOfAttributes(hdf5::node::Node &Node,
 /// Write a scalar attribute when the type is to be inferred
 /// \param Node : Group or dataset to write attribute to
 /// \param Name : Name of the attribute
-/// \param AttrValue : Json value containing the attribute value
+/// \param Values : Json value containing the attribute value
 void HDFFile::writeScalarAttribute(hdf5::node::Node &Node,
                                    const std::string &Name,
-                                   nlohmann::json const *AttrValue) {
-  if (AttrValue->is_string()) {
-    write_attribute_str(Node, Name, AttrValue->get<std::string>());
-  } else if (AttrValue->is_number_integer()) {
-    write_attribute(Node, Name, AttrValue->get<int64_t>());
-  } else if (AttrValue->is_number_unsigned()) {
-    write_attribute(Node, Name, AttrValue->get<uint64_t>());
-  } else if (AttrValue->is_number_float()) {
-    write_attribute(Node, Name, AttrValue->get<double>());
+                                   const nlohmann::json *Values) {
+  if (Values->is_string()) {
+    writeStringAttribute(Node, Name, Values->get<std::string>());
+  } else if (Values->is_number_integer()) {
+    writeAttribute(Node, Name, Values->get<int64_t>());
+  } else if (Values->is_number_unsigned()) {
+    writeAttribute(Node, Name, Values->get<uint64_t>());
+  } else if (Values->is_number_float()) {
+    writeAttribute(Node, Name, Values->get<double>());
   }
 }
 
-void HDFFile::write_attributes_if_present(hdf5::node::Node &Node,
-                                          nlohmann::json const *Value) {
-  if (auto AttributesMaybe = find<json>("attributes", *Value)) {
+void HDFFile::writeAttributesIfPresent(hdf5::node::Node &Node,
+                                       const nlohmann::json *Values) {
+  if (auto AttributesMaybe = find<json>("attributes", *Values)) {
     auto const Attributes = AttributesMaybe.inner();
-    write_attributes(Node, &Attributes);
+    writeAttributes(Node, &Attributes);
   }
 }
 
-std::vector<std::string> HDFFile::populate_strings(nlohmann::json const *Value,
-                                                   hssize_t goal_size) {
+std::vector<std::string> HDFFile::populateStrings(const nlohmann::json *Values,
+                                                  hssize_t GoalSize) {
   std::vector<std::string> Buffer;
-  if (Value->is_string()) {
-    auto String = Value->get<std::string>();
+  if (Values->is_string()) {
+    auto String = Values->get<std::string>();
     Buffer.push_back(String);
-  } else if (Value->is_array()) {
+  } else if (Values->is_array()) {
     std::stack<json const *> as;
     std::stack<size_t> ai;
     std::stack<size_t> an;
-    as.push(Value);
+    as.push(Values);
     ai.push(0);
-    an.push(Value->size());
+    an.push(Values->size());
 
     while (!as.empty()) {
       if (as.size() > 10) {
@@ -393,10 +378,10 @@ std::vector<std::string> HDFFile::populate_strings(nlohmann::json const *Value,
     }
   }
 
-  if (static_cast<hssize_t>(Buffer.size()) != goal_size) {
+  if (static_cast<hssize_t>(Buffer.size()) != GoalSize) {
     std::stringstream ss;
     ss << "Failed to populate string(variable) blob ";
-    ss << " size mismatch " << Buffer.size() << "!=" << goal_size;
+    ss << " size mismatch " << Buffer.size() << "!=" << GoalSize;
     std::throw_with_nested(std::runtime_error(ss.str()));
   }
 
@@ -404,8 +389,8 @@ std::vector<std::string> HDFFile::populate_strings(nlohmann::json const *Value,
 }
 
 std::vector<std::string>
-HDFFile::populate_fixed_strings(nlohmann::json const *Value, size_t FixedAt,
-                                hssize_t goal_size) {
+HDFFile::populateFixedStrings(const nlohmann::json *Values, size_t FixedAt,
+                              hssize_t GoalSize) {
   if (FixedAt >= 1024 * 1024) {
     std::throw_with_nested(std::runtime_error(fmt::format(
         "Failed to allocate fixed-size string dataset, bad element size: {}",
@@ -413,17 +398,17 @@ HDFFile::populate_fixed_strings(nlohmann::json const *Value, size_t FixedAt,
   }
 
   std::vector<std::string> Buffer;
-  if (Value->is_string()) {
-    auto String = Value->get<std::string>();
+  if (Values->is_string()) {
+    auto String = Values->get<std::string>();
     String.resize(FixedAt, '\0');
     Buffer.push_back(String);
-  } else if (Value->is_array()) {
+  } else if (Values->is_array()) {
     std::stack<json const *> as;
     std::stack<size_t> ai;
     std::stack<size_t> an;
-    as.push(Value);
+    as.push(Values);
     ai.push(0);
-    an.push(Value->size());
+    an.push(Values->size());
 
     while (!as.empty()) {
       if (as.size() > 10) {
@@ -450,10 +435,10 @@ HDFFile::populate_fixed_strings(nlohmann::json const *Value, size_t FixedAt,
     }
   }
 
-  if (static_cast<hssize_t>(Buffer.size()) != goal_size) {
+  if (static_cast<hssize_t>(Buffer.size()) != GoalSize) {
     std::stringstream ss;
     ss << "Failed to populate string(fixed) blob ";
-    ss << " size mismatch " << Buffer.size() << "!=" << goal_size;
+    ss << " size mismatch " << Buffer.size() << "!=" << GoalSize;
     std::throw_with_nested(std::runtime_error(ss.str()));
   }
 
@@ -461,18 +446,18 @@ HDFFile::populate_fixed_strings(nlohmann::json const *Value, size_t FixedAt,
 }
 
 template <typename DT>
-static void write_ds_numeric(hdf5::node::Group &Node, std::string Name,
-                             hdf5::property::DatasetCreationList &DCPL,
-                             hdf5::dataspace::Dataspace &Dataspace,
-                             nlohmann::json const *Values) {
+static void writeNumericDataset(
+    hdf5::node::Group &Node, const std::string &Name,
+    hdf5::property::DatasetCreationList &DatasetCreationPropertyList,
+    hdf5::dataspace::Dataspace &Dataspace, const nlohmann::json *Values) {
 
   try {
-    auto ds = Node.create_dataset(Name, hdf5::datatype::create<DT>(), Dataspace,
-                                  DCPL);
+    auto Dataset = Node.create_dataset(Name, hdf5::datatype::create<DT>(), Dataspace,
+                                  DatasetCreationPropertyList);
     try {
-      auto Blob = populate_blob<DT>(Values, Dataspace.size());
+      auto Blob = populateBlob<DT>(Values, Dataspace.size());
       try {
-        ds.write(Blob);
+        Dataset.write(Blob);
       } catch (std::exception const &E) {
         std::throw_with_nested(std::runtime_error(
             fmt::format("Failed write for numeric attribute {} in {}: {}", Name,
@@ -490,223 +475,227 @@ static void write_ds_numeric(hdf5::node::Group &Node, std::string Name,
   }
 }
 
-void HDFFile::write_ds_string(hdf5::node::Group &parent, std::string name,
-                              hdf5::property::DatasetCreationList &dcpl,
-                              hdf5::dataspace::Dataspace &dataspace,
-                              nlohmann::json const *vals) {
+void HDFFile::WriteStringDataset(
+    hdf5::node::Group &Parent, const std::string &Name,
+    hdf5::property::DatasetCreationList &DatasetCreationList,
+    hdf5::dataspace::Dataspace &Dataspace, const nlohmann::json *Values) {
 
   try {
-    auto dt = hdf5::datatype::String::variable();
-    dt.encoding(hdf5::datatype::CharacterEncoding::UTF8);
-    dt.padding(hdf5::datatype::StringPad::NULLTERM);
+    auto DataType = hdf5::datatype::String::variable();
+    DataType.encoding(hdf5::datatype::CharacterEncoding::UTF8);
+    DataType.padding(hdf5::datatype::StringPad::NULLTERM);
 
-    auto ds = parent.create_dataset(name, dt, dataspace, dcpl);
-    ds.write(populate_strings(vals, dataspace.size()), dt, dataspace, dataspace,
-             hdf5::property::DatasetTransferList());
-  } catch (std::exception &e) {
+    auto Dataset = Parent.create_dataset(Name, DataType, Dataspace, DatasetCreationList);
+    Dataset.write(populateStrings(Values, Dataspace.size()), DataType, Dataspace,
+             Dataspace, hdf5::property::DatasetTransferList());
+  } catch (const std::exception &e) {
     std::stringstream ss;
     ss << "Failed to write variable-size string dataset ";
-    ss << parent.link().path() << "/" << name;
+    ss << Parent.link().path() << "/" << Name;
     std::throw_with_nested(std::runtime_error(ss.str()));
   }
 }
 
-void HDFFile::write_ds_string_fixed_size(
-    hdf5::node::Group &parent, std::string name,
-    hdf5::property::DatasetCreationList &dcpl,
-    hdf5::dataspace::Dataspace &dataspace, hsize_t element_size,
-    nlohmann::json const *vals) {
+void HDFFile::writeFixedSizeStringDataset(
+    hdf5::node::Group &Parent, const std::string &Name,
+    hdf5::property::DatasetCreationList &DatasetCreationList,
+    hdf5::dataspace::Dataspace &Dataspace, hsize_t ElementSize,
+    const nlohmann::json *Values) {
 
   try {
-    auto dt = hdf5::datatype::String::fixed(element_size);
-    dt.encoding(hdf5::datatype::CharacterEncoding::UTF8);
-    dt.padding(hdf5::datatype::StringPad::NULLTERM);
+    auto DataType = hdf5::datatype::String::fixed(ElementSize);
+    DataType.encoding(hdf5::datatype::CharacterEncoding::UTF8);
+    DataType.padding(hdf5::datatype::StringPad::NULLTERM);
 
-    auto ds = parent.create_dataset(name, dt, dataspace, dcpl);
+    auto Dataset = Parent.create_dataset(Name, DataType, Dataspace, DatasetCreationList);
 
-    dt.padding(hdf5::datatype::StringPad::NULLPAD);
-    ds.write(populate_fixed_strings(vals, element_size, dataspace.size()), dt,
-             dataspace, dataspace, hdf5::property::DatasetTransferList());
+    DataType.padding(hdf5::datatype::StringPad::NULLPAD);
+    Dataset.write(populateFixedStrings(Values, ElementSize, Dataspace.size()), DataType,
+             Dataspace, Dataspace, hdf5::property::DatasetTransferList());
 
-  } catch (std::exception &e) {
+  } catch (const std::exception &e) {
     std::stringstream ss;
     ss << "Failed to write fixed-size string dataset ";
-    ss << parent.link().path() << "/" << name;
+    ss << Parent.link().path() << "/" << Name;
     std::throw_with_nested(std::runtime_error(ss.str()));
   }
 }
 
-void HDFFile::write_ds_generic(std::string const &dtype,
-                               hdf5::node::Group &parent,
-                               std::string const &name,
-                               std::vector<hsize_t> const &sizes,
-                               std::vector<hsize_t> const &max,
-                               hsize_t element_size,
-                               nlohmann::json const *vals) {
+void HDFFile::writeGenericDataset(const std::string &DataType,
+                                  hdf5::node::Group &Parent,
+                                  const std::string &Name,
+                                  const std::vector<hsize_t> &Sizes,
+                                  const std::vector<hsize_t> &Max,
+                                  hsize_t ElementSize,
+                                  const nlohmann::json *Values) {
   try {
 
-    hdf5::property::DatasetCreationList dcpl;
-    hdf5::dataspace::Dataspace dataspace = hdf5::dataspace::Scalar();
-    if (!sizes.empty()) {
-      dataspace = hdf5::dataspace::Simple(sizes, max);
-      if (max[0] == H5S_UNLIMITED) {
-        dcpl.chunk(sizes);
+    hdf5::property::DatasetCreationList DatasetCreationList;
+    hdf5::dataspace::Dataspace Dataspace = hdf5::dataspace::Scalar();
+    if (!Sizes.empty()) {
+      Dataspace = hdf5::dataspace::Simple(Sizes, Max);
+      if (Max[0] == H5S_UNLIMITED) {
+        DatasetCreationList.chunk(Sizes);
       }
     }
 
-    if (dtype == "uint8") {
-      write_ds_numeric<uint8_t>(parent, name, dcpl, dataspace, vals);
+    if (DataType == "uint8") {
+      writeNumericDataset<uint8_t>(Parent, Name, DatasetCreationList, Dataspace,
+                                   Values);
     }
-    if (dtype == "uint16") {
-      write_ds_numeric<uint16_t>(parent, name, dcpl, dataspace, vals);
+    if (DataType == "uint16") {
+      writeNumericDataset<uint16_t>(Parent, Name, DatasetCreationList,
+                                    Dataspace, Values);
     }
-    if (dtype == "uint32") {
-      write_ds_numeric<uint32_t>(parent, name, dcpl, dataspace, vals);
+    if (DataType == "uint32") {
+      writeNumericDataset<uint32_t>(Parent, Name, DatasetCreationList,
+                                    Dataspace, Values);
     }
-    if (dtype == "uint64") {
-      write_ds_numeric<uint64_t>(parent, name, dcpl, dataspace, vals);
+    if (DataType == "uint64") {
+      writeNumericDataset<uint64_t>(Parent, Name, DatasetCreationList,
+                                    Dataspace, Values);
     }
-    if (dtype == "int8") {
-      write_ds_numeric<int8_t>(parent, name, dcpl, dataspace, vals);
+    if (DataType == "int8") {
+      writeNumericDataset<int8_t>(Parent, Name, DatasetCreationList, Dataspace,
+                                  Values);
     }
-    if (dtype == "int16") {
-      write_ds_numeric<int16_t>(parent, name, dcpl, dataspace, vals);
+    if (DataType == "int16") {
+      writeNumericDataset<int16_t>(Parent, Name, DatasetCreationList, Dataspace,
+                                   Values);
     }
-    if (dtype == "int32") {
-      write_ds_numeric<int32_t>(parent, name, dcpl, dataspace, vals);
+    if (DataType == "int32") {
+      writeNumericDataset<int32_t>(Parent, Name, DatasetCreationList, Dataspace,
+                                   Values);
     }
-    if (dtype == "int64") {
-      write_ds_numeric<int64_t>(parent, name, dcpl, dataspace, vals);
+    if (DataType == "int64") {
+      writeNumericDataset<int64_t>(Parent, Name, DatasetCreationList, Dataspace,
+                                   Values);
     }
-    if (dtype == "float") {
-      write_ds_numeric<float>(parent, name, dcpl, dataspace, vals);
+    if (DataType == "float") {
+      writeNumericDataset<float>(Parent, Name, DatasetCreationList, Dataspace,
+                                 Values);
     }
-    if (dtype == "double") {
-      write_ds_numeric<double>(parent, name, dcpl, dataspace, vals);
+    if (DataType == "double") {
+      writeNumericDataset<double>(Parent, Name, DatasetCreationList, Dataspace,
+                                  Values);
     }
-    if (dtype == "string") {
-      // TODO
-      // We currently not support fixed length strings, apparently some
-      // to-be-tracked issue with h5cpp at the moment.
-      if (true || element_size == H5T_VARIABLE) {
-        write_ds_string(parent, name, dcpl, dataspace, vals);
-      } else {
-        write_ds_string_fixed_size(parent, name, dcpl, dataspace, element_size,
-                                   vals);
-      }
+    if (DataType == "string") {
+      WriteStringDataset(Parent, Name, DatasetCreationList, Dataspace, Values);
     }
-  } catch (std::exception &e) {
+  } catch (const std::exception &e) {
     std::stringstream ss;
     ss << "Failed dataset write in ";
-    ss << parent.link().path() << "/" << name;
-    ss << " type='" << dtype << "'";
+    ss << Parent.link().path() << "/" << Name;
+    ss << " type='" << DataType << "'";
     ss << " size(";
-    for (auto s : sizes)
+    for (auto s : Sizes)
       ss << s << " ";
     ss << ")  max(";
-    for (auto s : max)
+    for (auto s : Max)
       ss << s << " ";
     ss << ")  ";
     std::throw_with_nested(std::runtime_error(ss.str()));
   }
 }
 
-void HDFFile::write_dataset(hdf5::node::Group &Parent,
-                            nlohmann::json const *Value) {
+void HDFFile::writeDataset(hdf5::node::Group &Parent,
+                           const nlohmann::json *Values) {
   std::string Name;
-  if (auto NameMaybe = find<std::string>("name", *Value)) {
+  if (auto NameMaybe = find<std::string>("name", *Values)) {
     Name = NameMaybe.inner();
   } else {
     return;
   }
 
   std::string DataType = "int64";
-  hsize_t element_size = H5T_VARIABLE;
+  hsize_t ElementSize = H5T_VARIABLE;
 
-  std::vector<hsize_t> sizes;
-  if (auto ds = find<json>("dataset", *Value)) {
-    auto dso = ds.inner();
-    if (auto ds_space = find<std::string>("space", dso)) {
-      if (ds_space.inner() != "simple") {
+  std::vector<hsize_t> Sizes;
+  if (auto DatasetJSONObject = find<json>("dataset", *Values)) {
+    auto DatasetInnerObject = DatasetJSONObject.inner();
+    if (auto DataSpaceObject = find<std::string>("space", DatasetInnerObject)) {
+      if (DataSpaceObject.inner() != "simple") {
         LOG(Sev::Warning, "sorry, can only handle simple data spaces");
         return;
       }
     }
 
-    if (auto ds_type = find<std::string>("type", dso)) {
-      DataType = ds_type.inner();
+    if (auto DatasetTypeObject =
+            find<std::string>("type", DatasetInnerObject)) {
+      DataType = DatasetTypeObject.inner();
     }
 
     // optional, default to scalar
-    if (auto ds_size = find<json>("size", dso)) {
-      if (ds_size.inner().is_array()) {
-        auto a = ds_size.inner();
-        for (auto const &Element : a) {
+    if (auto DatasetSizeObject = find<json>("size", DatasetInnerObject)) {
+      if (DatasetSizeObject.inner().is_array()) {
+        auto DatasetSizeInnerObject = DatasetSizeObject.inner();
+        for (auto const &Element : DatasetSizeInnerObject) {
           if (Element.is_number_integer()) {
-            sizes.push_back(Element.get<int64_t>());
+            Sizes.push_back(Element.get<int64_t>());
           } else if (Element.is_string()) {
             if (Element.get<std::string>() == "unlimited") {
-              sizes.push_back(H5S_UNLIMITED);
+              Sizes.push_back(H5S_UNLIMITED);
             }
           }
         }
       }
     }
 
-    if (auto x = find<uint64_t>("string_size", dso)) {
-      if ((x.inner() > 0) && (x.inner() != H5T_VARIABLE)) {
-        element_size = x.inner();
+    if (auto DatasetStringSizeObject =
+            find<uint64_t>("string_size", DatasetInnerObject)) {
+      if ((DatasetStringSizeObject.inner() > 0) &&
+          (DatasetStringSizeObject.inner() != H5T_VARIABLE)) {
+        ElementSize = DatasetStringSizeObject.inner();
       }
     }
   }
 
-  auto ds_values_maybe = find<json>("values", *Value);
-  if (!ds_values_maybe) {
+  auto DatasetValuesObject = find<json>("values", *Values);
+  if (!DatasetValuesObject) {
     return;
   }
-  auto ds_values = ds_values_maybe.inner();
+  auto DatasetValuesInnerObject = DatasetValuesObject.inner();
 
-  if (ds_values.is_number_float()) {
+  if (DatasetValuesInnerObject.is_number_float()) {
     DataType = "double";
   }
 
-  auto max = sizes;
-  if (!sizes.empty()) {
-    if (sizes[0] == H5S_UNLIMITED) {
-      if (ds_values.is_array()) {
-        sizes[0] = ds_values.size();
+  auto Max = Sizes;
+  if (!Sizes.empty()) {
+    if (Sizes[0] == H5S_UNLIMITED) {
+      if (DatasetValuesInnerObject.is_array()) {
+        Sizes[0] = DatasetValuesInnerObject.size();
       } else {
-        sizes[0] = 1;
+        Sizes[0] = 1;
       }
     }
   }
 
-  write_ds_generic(DataType, Parent, Name, sizes, max, element_size,
-                   &ds_values);
+  writeGenericDataset(DataType, Parent, Name, Sizes, Max, ElementSize,
+                      &DatasetValuesInnerObject);
   auto dset = hdf5::node::Dataset(Parent.nodes[Name]);
 
-  write_attributes_if_present(dset, Value);
+  writeAttributesIfPresent(dset, Values);
 }
 
-void HDFFile::create_hdf_structures(nlohmann::json const *value,
-                                    hdf5::node::Group &parent, uint16_t level,
-                                    hdf5::property::LinkCreationList lcpl,
-                                    hdf5::datatype::String hdf_type_strfix,
-                                    std::vector<StreamHDFInfo> &stream_hdf_info,
-                                    std::deque<std::string> &path) {
+void HDFFile::createHDFStructures(
+    const nlohmann::json *Value, hdf5::node::Group &Parent, uint16_t Level,
+    hdf5::property::LinkCreationList LinkCreationPropertyList,
+    hdf5::datatype::String FixedStringHDFType,
+    std::vector<StreamHDFInfo> &HDFStreamInfo, std::deque<std::string> &Path) {
 
   try {
 
     // The HDF object that we will maybe create at the current level.
     hdf5::node::Group hdf_this;
-    if (auto TypeMaybe = find<std::string>("type", *value)) {
+    if (auto TypeMaybe = find<std::string>("type", *Value)) {
       auto Type = TypeMaybe.inner();
       if (Type == "group") {
-        if (auto NameMaybe = find<std::string>("name", *value)) {
+        if (auto NameMaybe = find<std::string>("name", *Value)) {
           auto Name = NameMaybe.inner();
           try {
-            hdf_this = parent.create_group(Name, lcpl);
-            path.push_back(Name);
+            hdf_this = Parent.create_group(Name, LinkCreationPropertyList);
+            Path.push_back(Name);
           } catch (...) {
             LOG(Sev::Critical, "failed to create group  Name: {}", Name);
           }
@@ -714,47 +703,45 @@ void HDFFile::create_hdf_structures(nlohmann::json const *value,
       }
       if (Type == "stream") {
         string pathstr;
-        for (auto &x : path) {
+        for (auto &x : Path) {
           pathstr += "/" + x;
         }
 
-        stream_hdf_info.push_back(StreamHDFInfo{pathstr, value->dump()});
+        HDFStreamInfo.push_back(StreamHDFInfo{pathstr, Value->dump()});
       }
       if (Type == "dataset") {
-        write_dataset(parent, value);
+        writeDataset(Parent, Value);
       }
     }
 
     // If the current level in the HDF can act as a parent, then continue the
     // recursion with the (optional) "children" array.
     if (hdf_this.is_valid()) {
-      write_attributes_if_present(hdf_this, value);
-      if (auto ChildrenMaybe = find<json>("children", *value)) {
+      writeAttributesIfPresent(hdf_this, Value);
+      if (auto ChildrenMaybe = find<json>("children", *Value)) {
         auto Children = ChildrenMaybe.inner();
         if (Children.is_array()) {
           for (auto &Child : Children) {
-            create_hdf_structures(&Child, hdf_this, level + 1, lcpl,
-                                  hdf_type_strfix, stream_hdf_info, path);
+            createHDFStructures(&Child, hdf_this, Level + 1,
+                                LinkCreationPropertyList, FixedStringHDFType,
+                                HDFStreamInfo, Path);
           }
         }
       }
-      path.pop_back();
+      Path.pop_back();
     }
-  } catch (std::exception &e) {
-    std::stringstream ss;
-    ss << "Failed to create structure  parent=";
-    ss << parent.link().path() << "  level=" << level;
-    std::throw_with_nested(std::runtime_error(ss.str()));
+  } catch (const std::exception &e) {
+    LOG(Sev::Error, "Failed to create structure  parent={} level={}", std::string(Parent.link().path()), Level)
   }
 }
 
 /// Human readable version of the HDF5 headers that we compile against.
-std::string HDFFile::h5_version_string_headers_compile_time() {
+std::string HDFFile::H5VersionStringHeadersCompileTime() {
   return fmt::format("{}.{}.{}", H5_VERS_MAJOR, H5_VERS_MINOR, H5_VERS_RELEASE);
 }
 
 /// Human readable version of the HDF5 libraries that we run with.
-std::string HDFFile::h5_version_string_linked() {
+std::string HDFFile::h5VersionStringLinked() {
   unsigned h5_vers_major, h5_vers_minor, h5_vers_release;
   H5get_libversion(&h5_vers_major, &h5_vers_minor, &h5_vers_release);
   return fmt::format("{}.{}.{}", h5_vers_major, h5_vers_minor, h5_vers_release);
@@ -764,71 +751,71 @@ std::string HDFFile::h5_version_string_linked() {
 /// compiled with against the version of the HDF5 libraries that the
 /// kafka-to-nexus is linked against at runtime. Currently, a mismatch in the
 /// release number is logged but does not cause panic.
-void HDFFile::check_hdf_version() {
+void HDFFile::checkHDFVersion() {
   unsigned h5_vers_major, h5_vers_minor, h5_vers_release;
   H5get_libversion(&h5_vers_major, &h5_vers_minor, &h5_vers_release);
   if (h5_vers_major != H5_VERS_MAJOR) {
     LOG(Sev::Error, "HDF5 version mismatch.  compile time: {}  runtime: {}",
-        h5_version_string_headers_compile_time(), h5_version_string_linked());
+        H5VersionStringHeadersCompileTime(), h5VersionStringLinked());
     exit(1);
   }
   if (h5_vers_minor != H5_VERS_MINOR) {
     LOG(Sev::Error, "HDF5 version mismatch.  compile time: {}  runtime: {}",
-        h5_version_string_headers_compile_time(), h5_version_string_linked());
+        H5VersionStringHeadersCompileTime(), h5VersionStringLinked());
     exit(1);
   }
   if (h5_vers_release != H5_VERS_RELEASE) {
     LOG(Sev::Error, "HDF5 version mismatch.  compile time: {}  runtime: {}",
-        h5_version_string_headers_compile_time(), h5_version_string_linked());
+        H5VersionStringHeadersCompileTime(), h5VersionStringLinked());
   }
 }
 
 extern "C" char const GIT_COMMIT[];
 
-void HDFFile::init(std::string filename, nlohmann::json const &nexus_structure,
-                   nlohmann::json const &config_file,
-                   std::vector<StreamHDFInfo> &stream_hdf_info,
-                   bool UseHDFSWMR) {
-  if (std::ifstream(filename).good()) {
+void HDFFile::init(const std::string &Filename,
+                   const nlohmann::json &NexusStructure,
+                   const nlohmann::json &ConfigFile,
+                   std::vector<StreamHDFInfo> &StreamHDFInfo, bool UseHDFSWMR) {
+  if (std::ifstream(Filename).good()) {
     // File exists already
     throw std::runtime_error(
-        fmt::format("The file \"{}\" exists already.", filename));
+        fmt::format("The file \"{}\" exists already.", Filename));
   }
   try {
     hdf5::property::FileCreationList fcpl;
     hdf5::property::FileAccessList fapl;
-    set_common_props(fcpl, fapl);
+    setCommonProps(fcpl, fapl);
     if (UseHDFSWMR) {
-      h5file =
-          hdf5::file::create(filename, hdf5::file::AccessFlags::TRUNCATE |
+      H5File =
+          hdf5::file::create(Filename, hdf5::file::AccessFlags::TRUNCATE |
                                            hdf5::file::AccessFlags::SWMR_WRITE,
                              fcpl, fapl);
-      isSWMREnabled_ = true;
+      SWMREnabled = true;
     } else {
-      h5file = hdf5::file::create(filename, hdf5::file::AccessFlags::EXCLUSIVE,
+      H5File = hdf5::file::create(Filename, hdf5::file::AccessFlags::EXCLUSIVE,
                                   fcpl, fapl);
     }
-    init(nexus_structure, stream_hdf_info);
-  } catch (std::exception &e) {
+    init(NexusStructure, StreamHDFInfo);
+  } catch (const std::exception &e) {
     LOG(Sev::Error,
         "ERROR could not create the HDF  path={}  file={}  trace:\n{}",
-        boost::filesystem::current_path().string(), filename,
+        boost::filesystem::current_path().string(), Filename,
         hdf5::error::print_nested(e));
     std::throw_with_nested(std::runtime_error("HDFFile failed to open!"));
   }
 }
 
-void HDFFile::init(const std::string &nexus_structure,
-                   std::vector<StreamHDFInfo> &stream_hdf_info) {
-  auto Document = nlohmann::json::parse(nexus_structure);
-  init(Document, stream_hdf_info);
+void HDFFile::init(const std::string &NexusStructure,
+                   std::vector<StreamHDFInfo> &StreamHDFInfo) {
+  auto Document = nlohmann::json::parse(NexusStructure);
+  init(Document, StreamHDFInfo);
 }
 
-void HDFFile::init(nlohmann::json const &nexus_structure,
-                   std::vector<StreamHDFInfo> &stream_hdf_info) {
+void HDFFile::init(const nlohmann::json &NexusStructure,
+                   std::vector<StreamHDFInfo> &StreamHDFInfo) {
 
   try {
-    check_hdf_version();
+    checkHDFVersion();
 
     hdf5::property::AttributeCreationList acpl;
     acpl.character_encoding(hdf5::datatype::CharacterEncoding::UTF8);
@@ -839,81 +826,83 @@ void HDFFile::init(nlohmann::json const &nexus_structure,
     auto var_string = hdf5::datatype::String::variable();
     var_string.encoding(hdf5::datatype::CharacterEncoding::UTF8);
 
-    root_group = h5file.root();
+    RootGroup = H5File.root();
 
     std::deque<std::string> path;
-    if (nexus_structure.is_object()) {
-      auto value = &nexus_structure;
+    if (NexusStructure.is_object()) {
+      auto value = &NexusStructure;
       if (auto ChildrenMaybe = find<json>("children", *value)) {
         auto Children = ChildrenMaybe.inner();
         if (Children.is_array()) {
           for (auto &Child : Children) {
-            create_hdf_structures(&Child, root_group, 0, lcpl, var_string,
-                                  stream_hdf_info, path);
+            createHDFStructures(&Child, RootGroup, 0, lcpl, var_string,
+                                StreamHDFInfo, path);
           }
         }
       }
     }
 
-    write_attribute_str(root_group, "HDF5_Version", h5_version_string_linked());
-    write_attribute_str(root_group, "file_name",
-                        h5file.id().file_name().stem().string());
-    write_attribute_str(root_group, "creator",
-                        fmt::format("kafka-to-nexus commit {:.7}", GIT_COMMIT));
-    write_hdf_iso8601_now(root_group, "file_time");
-    write_attributes_if_present(root_group, &nexus_structure);
+    writeStringAttribute(RootGroup, "HDF5_Version", h5VersionStringLinked());
+    writeStringAttribute(RootGroup, "file_name",
+                         H5File.id().file_name().stem().string());
+    writeStringAttribute(
+        RootGroup, "creator",
+        fmt::format("kafka-to-nexus commit {:.7}", GIT_COMMIT));
+    writeHDFISO8601AttributeCurrentTime(RootGroup, "file_time");
+    writeAttributesIfPresent(RootGroup, &NexusStructure);
   } catch (std::exception &e) {
     LOG(Sev::Critical, "ERROR could not initialize  file={}  trace:\n{}",
-        h5file.id().file_name().string(), hdf5::error::print_nested(e));
+        H5File.id().file_name().string(), hdf5::error::print_nested(e));
     std::throw_with_nested(std::runtime_error("HDFFile failed to initialize!"));
   }
 }
 
 void HDFFile::close() {
   try {
-    if (h5file.is_valid()) {
+    if (H5File.is_valid()) {
       LOG(Sev::Debug, "flushing");
       flush();
       LOG(Sev::Debug, "closing");
-      h5file.close();
+      H5File.close();
       LOG(Sev::Debug, "closed");
     }
-  } catch (std::exception const &E) {
+  } catch (const std::exception &E) {
     auto Trace = hdf5::error::print_nested(E);
     LOG(Sev::Error, "ERROR could not close  file={}  trace:\n{}",
-        h5file.id().file_name().string(), Trace);
+        H5File.id().file_name().string(), Trace);
     std::throw_with_nested(std::runtime_error(fmt::format(
         "HDFFile failed to close.  Current Path: {}  Filename: {}  Trace:\n{}",
         boost::filesystem::current_path().string(),
-        h5file.id().file_name().string(), Trace)));
+        H5File.id().file_name().string(), Trace)));
   }
 }
 
-void HDFFile::reopen(std::string filename, nlohmann::json const &config_file) {
+void HDFFile::reopen(const std::string &Filename,
+                     const nlohmann::json &ConfigFile) {
   try {
     hdf5::property::FileCreationList fcpl;
     hdf5::property::FileAccessList fapl;
-    set_common_props(fcpl, fapl);
+    setCommonProps(fcpl, fapl);
 
-    h5file =
-        hdf5::file::open(filename, hdf5::file::AccessFlags::READWRITE, fapl);
-  } catch (std::exception const &E) {
+    H5File =
+        hdf5::file::open(Filename, hdf5::file::AccessFlags::READWRITE, fapl);
+  } catch (const std::exception &E) {
     auto Trace = hdf5::error::print_nested(E);
     LOG(Sev::Error,
         "ERROR could not reopen HDF file  path={}  file={}  trace:\n{}",
-        boost::filesystem::current_path().string(), filename, Trace);
+        boost::filesystem::current_path().string(), Filename, Trace);
     std::throw_with_nested(std::runtime_error(fmt::format(
         "HDFFile failed to reopen.  Current Path: {}  Filename: {}  Trace:\n{}",
-        boost::filesystem::current_path().string(), filename, Trace)));
+        boost::filesystem::current_path().string(), Filename, Trace)));
   }
 }
 
 void HDFFile::flush() {
   try {
-    if (h5file.is_valid()) {
-      h5file.flush(hdf5::file::Scope::GLOBAL);
+    if (H5File.is_valid()) {
+      H5File.flush(hdf5::file::Scope::GLOBAL);
     }
-  } catch (std::runtime_error const &E) {
+  } catch (const std::runtime_error &E) {
     std::throw_with_nested(std::runtime_error(
         fmt::format("HDFFile failed to flush  what: {}", E.what())));
   } catch (...) {
@@ -930,6 +919,6 @@ void HDFFile::SWMRFlush() {
   }
 }
 
-bool HDFFile::isSWMREnabled() const { return isSWMREnabled_; }
+bool HDFFile::isSWMREnabled() const { return SWMREnabled; }
 
 } // namespace FileWriter

--- a/src/HDFFile.h
+++ b/src/HDFFile.h
@@ -15,8 +15,8 @@ namespace FileWriter {
 
 // POD
 struct StreamHDFInfo {
-  std::string hdf_parent_name;
-  std::string config_stream;
+  std::string HDFParentName;
+  std::string ConfigStream;
 };
 
 class HDFFile final {
@@ -25,27 +25,28 @@ public:
 
   ~HDFFile();
 
-  void init(std::string filename, nlohmann::json const &nexus_structure,
-            nlohmann::json const &config_file,
-            std::vector<StreamHDFInfo> &stream_hdf_info, bool UseHDFSWMR);
+  void init(const std::string &Filename, nlohmann::json const &NexusStructure,
+            nlohmann::json const &ConfigFile,
+            std::vector<StreamHDFInfo> &StreamHDFInfo, bool UseHDFSWMR);
 
-  void init(const std::string &nexus_structure,
-            std::vector<StreamHDFInfo> &stream_hdf_info);
+  void init(const std::string &NexusStructure,
+            std::vector<StreamHDFInfo> &StreamHDFInfo);
 
-  void init(nlohmann::json const &nexus_structure,
-            std::vector<StreamHDFInfo> &stream_hdf_info);
+  void init(const nlohmann::json &NexusStructure,
+            std::vector<StreamHDFInfo> &StreamHDFInfo);
 
-  void reopen(std::string filename, nlohmann::json const &config_file);
+  void reopen(const std::string &Filename, const nlohmann::json &ConfigFile);
 
   void flush();
   void close();
 
-  static std::string h5_version_string_linked();
-  static void write_attributes(hdf5::node::Node &node,
-                               nlohmann::json const *jsv);
+  static std::string h5VersionStringLinked();
+  static void writeAttributes(hdf5::node::Node &Node,
+                              const nlohmann::json *Value);
 
-  static void write_attribute_str(hdf5::node::Node &node, std::string name,
-                                  std::string value);
+  static void writeStringAttribute(hdf5::node::Node &Node,
+                                   const std::string &Name,
+                                   const std::string &Value);
 
   /// If using SWMR, gets invoked by Source and can trigger a flush of the HDF
   /// file.
@@ -53,82 +54,78 @@ public:
 
   bool isSWMREnabled() const;
 
-  hdf5::file::File h5file;
-  hdf5::node::Group root_group;
+  hdf5::file::File H5File;
+  hdf5::node::Group RootGroup;
 
 private:
   friend class ::T_HDFFile;
   friend class CommandHandler;
 
-  static void check_hdf_version();
-  static std::string h5_version_string_headers_compile_time();
+  static void checkHDFVersion();
+  static std::string H5VersionStringHeadersCompileTime();
 
-  static void create_hdf_structures(nlohmann::json const *value,
-                                    hdf5::node::Group &parent, uint16_t level,
-                                    hdf5::property::LinkCreationList lcpl,
-                                    hdf5::datatype::String hdf_type_strfix,
-                                    std::vector<StreamHDFInfo> &stream_hdf_info,
-                                    std::deque<std::string> &path);
+  static void createHDFStructures(
+      const nlohmann::json *Value, hdf5::node::Group &Parent, uint16_t Level,
+      hdf5::property::LinkCreationList LinkCreationPropertyList,
+      hdf5::datatype::String FixedStringHDFType,
+      std::vector<StreamHDFInfo> &HDFStreamInfo, std::deque<std::string> &Path);
 
-  static void write_hdf_ds_scalar_string(hdf5::node::Group &parent,
-                                         std::string name, std::string s1);
+  static void writeHDFISO8601AttributeCurrentTime(hdf5::node::Node &Node,
+                                                  const std::string &Name);
 
-  static void write_hdf_iso8601_now(hdf5::node::Node &node,
-                                    const std::string &name);
+  static void writeAttributesIfPresent(hdf5::node::Node &Node,
+                                       const nlohmann::json *Values);
 
-  static void write_attributes_if_present(hdf5::node::Node &node,
-                                          nlohmann::json const *jsv);
-
-  static std::vector<std::string> populate_strings(nlohmann::json const *vals,
-                                                   hssize_t goal_size);
+  static std::vector<std::string> populateStrings(const nlohmann::json *Values,
+                                                  hssize_t GoalSize);
 
   static std::vector<std::string>
-  populate_fixed_strings(nlohmann::json const *vals, size_t FixedAt,
-                         hssize_t goal_size);
-
-  static void write_ds_string(hdf5::node::Group &parent, std::string name,
-                              hdf5::property::DatasetCreationList &dcpl,
-                              hdf5::dataspace::Dataspace &dataspace,
-                              nlohmann::json const *vals);
+  populateFixedStrings(const nlohmann::json *Values, size_t FixedAt,
+                       hssize_t GoalSize);
 
   static void
-  write_ds_string_fixed_size(hdf5::node::Group &parent, std::string name,
-                             hdf5::property::DatasetCreationList &dcpl,
-                             hdf5::dataspace::Dataspace &dataspace,
-                             hsize_t element_size, nlohmann::json const *vals);
+  WriteStringDataset(hdf5::node::Group &Parent, const std::string &Name,
+                     hdf5::property::DatasetCreationList &DatasetCreationList,
+                     hdf5::dataspace::Dataspace &Dataspace,
+                     const nlohmann::json *Values);
+
+  static void writeFixedSizeStringDataset(
+      hdf5::node::Group &Parent, const std::string &Name,
+      hdf5::property::DatasetCreationList &DatasetCreationList,
+      hdf5::dataspace::Dataspace &Dataspace, hsize_t ElementSize,
+      const nlohmann::json *Values);
+
+  static void writeGenericDataset(const std::string &DataType,
+                                  hdf5::node::Group &Parent,
+                                  const std::string &Name,
+                                  const std::vector<hsize_t> &Sizes,
+                                  const std::vector<hsize_t> &Max,
+                                  hsize_t ElementSize,
+                                  const nlohmann::json *Values);
+
+  static void writeDataset(hdf5::node::Group &Parent,
+                           const nlohmann::json *Values);
 
   static void
-  write_ds_generic(std::string const &dtype, hdf5::node::Group &parent,
-                   std::string const &name, std::vector<hsize_t> const &sizes,
-                   std::vector<hsize_t> const &max, hsize_t element_size,
-                   nlohmann::json const *vals);
+  setCommonProps(hdf5::property::FileCreationList &FileCreationPropertyList,
+                 hdf5::property::FileAccessList &FileAccessPropertyList) {}
 
-  static void write_dataset(hdf5::node::Group &parent,
-                            nlohmann::json const *value);
-
-  static void set_common_props(hdf5::property::FileCreationList &fcpl,
-                               hdf5::property::FileAccessList &fapl) {}
-
-  template <typename T>
-  void write_hdf_ds_iso8601(hdf5::node::Group &parent, const std::string &name,
-                            T &ts);
-
-  static void writeObjectOfAttributes(hdf5::node::Node &node,
-                                      nlohmann::json const *jsv);
+  static void writeObjectOfAttributes(hdf5::node::Node &Node,
+                                      const nlohmann::json *Values);
 
   static void writeArrayOfAttributes(hdf5::node::Node &Node,
-                                     nlohmann::json const *JsonValue);
+                                     const nlohmann::json *Values);
 
   static void writeScalarAttribute(hdf5::node::Node &Node,
                                    const std::string &Name,
-                                   nlohmann::json const *AttrValue);
+                                   const nlohmann::json *Values);
 
-  static void writeAttrOfSpecifiedType(std::string const &DType,
+  static void writeAttrOfSpecifiedType(const std::string &DType,
                                        hdf5::node::Node &Node,
-                                       std::string const &Name,
-                                       nlohmann::json const *Values);
+                                       const std::string &Name,
+                                       const nlohmann::json *Values);
 
-  bool isSWMREnabled_ = false;
+  bool SWMREnabled = false;
 
   using CLOCK = std::chrono::steady_clock;
   std::chrono::milliseconds SWMRFlushInterval{10000};

--- a/src/schemas/NDAr/AreaDetectorWriter.cpp
+++ b/src/schemas/NDAr/AreaDetectorWriter.cpp
@@ -118,7 +118,7 @@ AreaDetectorWriter::init_hdf(hdf5::node::Group &HDFGroup,
         CurrentGroup.attributes.create<std::string>("NX_class");
     ClassAttribute.write("NXlog");
     auto AttributesJson = nlohmann::json::parse(HDFAttributes);
-    FileWriter::HDFFile::write_attributes(HDFGroup, &AttributesJson);
+    FileWriter::HDFFile::writeAttributes(HDFGroup, &AttributesJson);
   } catch (std::exception &E) {
     LOG(Sev::Error, "Unable to initialise areaDetector data tree in "
                     "HDF file with error message: \"{}\"",

--- a/src/schemas/ev42/ev42_rw.cpp
+++ b/src/schemas/ev42/ev42_rw.cpp
@@ -137,7 +137,7 @@ HDFWriterModule::init_hdf(hdf5::node::Group &HDFGroup,
       ds_cue_timestamp_zero.reset();
     }
     auto AttributesJson = nlohmann::json::parse(HDFAttributes);
-    HDFFile::write_attributes(HDFGroup, &AttributesJson);
+    HDFFile::writeAttributes(HDFGroup, &AttributesJson);
   } catch (std::exception &e) {
     auto message = hdf5::error::print_nested(e);
     LOG(Sev::Error, "ERROR ev42 could not init hdf_parent: {}  trace: {}",

--- a/src/schemas/f142/f142_rw.cpp
+++ b/src/schemas/f142/f142_rw.cpp
@@ -241,7 +241,7 @@ HDFWriterModule::init_hdf(hdf5::node::Group &HDFGroup,
         }
       }
       auto AttributesJson = nlohmann::json::parse(*HDFAttributesPtr);
-      HDFFile::write_attributes(HDFGroup, &AttributesJson);
+      HDFFile::writeAttributes(HDFGroup, &AttributesJson);
     } else if (CreateMethod == CreateWriterTypedBaseMethod::OPEN) {
       for (auto const &Info : DatasetInfoList) {
         Info.Ptr = h5::h5d_chunked_1d<uint64_t>::open(HDFGroup, Info.Name, cq,

--- a/src/schemas/senv/FastSampleEnvironmentWriter.cpp
+++ b/src/schemas/senv/FastSampleEnvironmentWriter.cpp
@@ -70,7 +70,7 @@ FastSampleEnvironmentWriter::init_hdf(hdf5::node::Group &HDFGroup,
         CurrentGroup.attributes.create<std::string>("NX_class");
     ClassAttribute.write("NXlog");
     auto AttributesJson = nlohmann::json::parse(HDFAttributes);
-    FileWriter::HDFFile::write_attributes(HDFGroup, &AttributesJson);
+    FileWriter::HDFFile::writeAttributes(HDFGroup, &AttributesJson);
   } catch (std::exception &E) {
     LOG(Sev::Error, "Unable to initialise fast sample environment data tree in "
                     "HDF file with error message: \"{}\"",

--- a/src/tests/HDFFile.cpp
+++ b/src/tests/HDFFile.cpp
@@ -351,7 +351,7 @@ public:
       ASSERT_EQ(attr.datatype().get_class(), hdf5::datatype::Class::STRING);
       std::string val;
       attr.read(val, attr.datatype());
-      ASSERT_EQ(FileWriter::HDFFile::h5_version_string_linked(), val);
+      ASSERT_EQ(FileWriter::HDFFile::h5VersionStringLinked(), val);
     }
     {
       auto attr = root_group.attributes["file_time"];
@@ -1056,7 +1056,7 @@ public:
     })"");
     std::vector<FileWriter::StreamHDFInfo> stream_hdf_info;
     File.init(NexusStructure, stream_hdf_info);
-    auto ds = hdf5::node::get_dataset(File.root_group, "string_fixed_1d_fixed");
+    auto ds = hdf5::node::get_dataset(File.RootGroup, "string_fixed_1d_fixed");
     auto datatype = hdf5::datatype::String(ds.datatype());
     ASSERT_EQ(datatype.encoding(), hdf5::datatype::CharacterEncoding::UTF8);
     ASSERT_EQ(datatype.padding(), hdf5::datatype::StringPad::NULLTERM);
@@ -1082,7 +1082,7 @@ public:
     std::vector<FileWriter::StreamHDFInfo> stream_hdf_info;
     File.init(NexusStructure, stream_hdf_info);
     auto ds =
-        hdf5::node::get_dataset(File.root_group, "string_fixed_1d_variable");
+        hdf5::node::get_dataset(File.RootGroup, "string_fixed_1d_variable");
     auto datatype = hdf5::datatype::String(ds.datatype());
     ASSERT_EQ(datatype.encoding(), hdf5::datatype::CharacterEncoding::UTF8);
     ASSERT_EQ(datatype.padding(), hdf5::datatype::StringPad::NULLTERM);
@@ -1122,7 +1122,7 @@ template <typename T>
 void verifyWrittenDatatype(FileWriter::HDFFile &TestFile,
                            const std::pair<std::string, T> NameAndValue) {
   auto Dataset =
-      hdf5::node::get_dataset(TestFile.root_group, "/" + NameAndValue.first);
+      hdf5::node::get_dataset(TestFile.RootGroup, "/" + NameAndValue.first);
   auto OutputValue = NameAndValue.second;
   Dataset.read(OutputValue);
   ASSERT_EQ(OutputValue, NameAndValue.second);

--- a/src/tests/HDFFileAttributesTest.cpp
+++ b/src/tests/HDFFileAttributesTest.cpp
@@ -170,9 +170,8 @@ TEST(HDFFileAttributesTest, whenCommandContainsArrayAttrItIsWrittenToFile) {
   std::vector<FileWriter::StreamHDFInfo> EmptyStreamHDFInfo;
   TestFile.init(CommandWithArrayAttr, EmptyStreamHDFInfo);
 
-  auto ArrayAttr =
-      node::get_group(TestFile.RootGroup, "group_with_array_attrs")
-          .attributes["array_attribute"];
+  auto ArrayAttr = node::get_group(TestFile.RootGroup, "group_with_array_attrs")
+                       .attributes["array_attribute"];
   std::vector<int> ArrayAttrValues(3);
   ArrayAttr.read(ArrayAttrValues);
   ASSERT_EQ(ArrayAttrValues[0], 1);

--- a/src/tests/HDFFileAttributesTest.cpp
+++ b/src/tests/HDFFileAttributesTest.cpp
@@ -25,7 +25,7 @@ TEST(HDFFileAttributesTest,
   std::vector<FileWriter::StreamHDFInfo> EmptyStreamHDFInfo;
   TestFile.init(CommandWithNumericalAttr, EmptyStreamHDFInfo);
 
-  auto Attr = hdf5::node::get_dataset(TestFile.root_group,
+  auto Attr = hdf5::node::get_dataset(TestFile.RootGroup,
                                       "/dataset_with_numerical_attr")
                   .attributes["the_answer_is"];
   int AttrValue;
@@ -54,7 +54,7 @@ TEST(HDFFileAttributesTest,
   std::vector<FileWriter::StreamHDFInfo> EmptyStreamHDFInfo;
   TestFile.init(CommandWithScalarStringAttr, EmptyStreamHDFInfo);
 
-  auto StringAttr = hdf5::node::get_group(TestFile.root_group,
+  auto StringAttr = hdf5::node::get_group(TestFile.RootGroup,
                                           "/group_with_scalar_string_attr")
                         .attributes["hello"];
   ASSERT_EQ(StringAttr.datatype().get_class(), hdf5::datatype::Class::STRING);
@@ -93,14 +93,14 @@ TEST(HDFFileAttributesTest,
   TestFile.init(CommandWithArrayOfAttrs, EmptyStreamHDFInfo);
 
   auto IntAttr =
-      node::get_group(TestFile.root_group, "group_with_array_of_attrs")
+      node::get_group(TestFile.RootGroup, "group_with_array_of_attrs")
           .attributes["integer_attribute"];
   int64_t IntValue;
   IntAttr.read(IntValue);
   ASSERT_EQ(IntValue, 42);
 
   auto StringAttr =
-      node::get_group(TestFile.root_group, "group_with_array_of_attrs")
+      node::get_group(TestFile.RootGroup, "group_with_array_of_attrs")
           .attributes["string_attribute"];
   std::string StringValue;
   StringAttr.read(StringValue, StringAttr.datatype());
@@ -133,7 +133,7 @@ TEST(HDFFileAttributesTest,
   std::vector<FileWriter::StreamHDFInfo> EmptyStreamHDFInfo;
   TestFile.init(CommandWithTypedAttrs, EmptyStreamHDFInfo);
 
-  auto IntAttr = node::get_group(TestFile.root_group, "group_with_typed_attrs")
+  auto IntAttr = node::get_group(TestFile.RootGroup, "group_with_typed_attrs")
                      .attributes["uint32_attribute"];
   uint32_t IntValue;
   IntAttr.read(IntValue);
@@ -171,7 +171,7 @@ TEST(HDFFileAttributesTest, whenCommandContainsArrayAttrItIsWrittenToFile) {
   TestFile.init(CommandWithArrayAttr, EmptyStreamHDFInfo);
 
   auto ArrayAttr =
-      node::get_group(TestFile.root_group, "group_with_array_attrs")
+      node::get_group(TestFile.RootGroup, "group_with_array_attrs")
           .attributes["array_attribute"];
   std::vector<int> ArrayAttrValues(3);
   ArrayAttr.read(ArrayAttrValues);
@@ -180,7 +180,7 @@ TEST(HDFFileAttributesTest, whenCommandContainsArrayAttrItIsWrittenToFile) {
   ASSERT_EQ(ArrayAttrValues[2], 3);
 
   auto ArrayStringAttr =
-      node::get_group(TestFile.root_group, "group_with_array_attrs")
+      node::get_group(TestFile.RootGroup, "group_with_array_attrs")
           .attributes["array_string_attribute"];
   std::vector<std::string> ArrayStringAttrValues(2);
   ArrayStringAttr.read(ArrayStringAttrValues);

--- a/src/tests/HDFFileTestHelper.cpp
+++ b/src/tests/HDFFileTestHelper.cpp
@@ -7,7 +7,7 @@ FileWriter::HDFFile createInMemoryTestFile(const std::string &Filename) {
   fapl.driver(hdf5::file::MemoryDriver());
 
   FileWriter::HDFFile TestFile;
-  TestFile.h5file =
+  TestFile.H5File =
       hdf5::file::create(Filename, hdf5::file::AccessFlags::TRUNCATE,
                          hdf5::property::FileCreationList(), fapl);
 


### PR DESCRIPTION
### Description of work

Lots of LLVM changes whilst I was in this file. I am aware there are many other variable names that need changing in this file but there were bits that were inconsistent such as the order of const and the variable type. 

Now the forwarder will not terminate when it cannot write a particular structure to a file and continue writing the file and rest of the structures. If it cannot initialise or find the file it will still terminate.

### Issue

Closes #263 

### Acceptance Criteria

Mainly HDFFile.cpp and .h
FileWriterTask.cpp
CommandHandler.cpp

### Unit Tests

Just refactored variable names so the HDF unit tests have changed slightly but nothing functional. 


---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
