### PR TITLE
310 exception throwing

### DIFF
--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -135,10 +135,13 @@ static StreamSettings extractStreamInformationFromJsonForSource(
     LOG(Sev::Info, "Run parallel for source: {}", StreamSettings.Source);
   }
 
-  auto ModuleFactory = HDFWriterModuleRegistry::find(StreamSettings.Module);
-  if (!ModuleFactory) {
+  HDFWriterModuleRegistry::ModuleFactory ModuleFactory;
+  try {
+    ModuleFactory = HDFWriterModuleRegistry::find(StreamSettings.Module);
+  } catch (std::exception const &E) {
     throw std::runtime_error(
-        fmt::format("Module '{}' is not available", StreamSettings.Module));
+        fmt::format("Error while getting '{}',  source: {}  what: {}",
+                    StreamSettings.Module, StreamSettings.Source, E.what()));
   }
 
   auto HDFWriterModule = ModuleFactory();
@@ -316,9 +319,13 @@ void CommandHandler::addStreamSourceToWriterModule(
     if (UseParallelWriter && StreamSettings.RunParallel) {
     } else {
       LOG(Sev::Debug, "add Source as non-parallel: {}", StreamSettings.Topic);
-      auto ModuleFactory = HDFWriterModuleRegistry::find(StreamSettings.Module);
-      if (!ModuleFactory) {
-        LOG(Sev::Info, "Module '{}' is not available", StreamSettings.Module);
+      HDFWriterModuleRegistry::ModuleFactory ModuleFactory;
+
+      try {
+        ModuleFactory = HDFWriterModuleRegistry::find(StreamSettings.Module);
+      } catch (std::exception const &E) {
+        LOG(Sev::Info, "Module '{}' is not available, error {}",
+            StreamSettings.Module, E.what());
         continue;
       }
 

--- a/src/FlatbufferReader.cpp
+++ b/src/FlatbufferReader.cpp
@@ -13,7 +13,16 @@ std::map<std::string, FlatbufferReaderRegistry::ReaderPtr> &getReaders() {
 
 FlatbufferReaderRegistry::ReaderPtr &find(std::string const &key) {
   auto &_items = getReaders();
-  return _items.at(key);
+  try {
+    return _items.at(key);
+  } catch (std::out_of_range &E) {
+    auto s = fmt::format("No such Reader in registry: \"{}\"", E.what());
+    std::throw_with_nested(std::out_of_range(s));
+  } catch (std::exception &E) {
+    auto s = fmt::format(
+        "Error while reading the FlatbufferReaderRegistry map: {}", E.what());
+    std::throw_with_nested(s);
+  }
 }
 
 void addReader(std::string FlatbufferID, FlatbufferReader::ptr &&item) {

--- a/src/FlatbufferReader.cpp
+++ b/src/FlatbufferReader.cpp
@@ -18,10 +18,6 @@ FlatbufferReaderRegistry::ReaderPtr &find(std::string const &key) {
   } catch (std::out_of_range &E) {
     auto s = fmt::format("No such Reader in registry: \"{}\"", E.what());
     std::throw_with_nested(std::out_of_range(s));
-  } catch (std::exception &E) {
-    auto s = fmt::format(
-        "Error while reading the FlatbufferReaderRegistry map: {}", E.what());
-    std::throw_with_nested(s);
   }
 }
 

--- a/src/FlatbufferReader.h
+++ b/src/FlatbufferReader.h
@@ -35,8 +35,6 @@ namespace FlatbufferReaderRegistry {
 using ReaderPtr = FlatbufferReader::ptr;
 std::map<std::string, ReaderPtr> &getReaders();
 
-/// @todo The following two functions should probably throw an exception if key
-/// is not found.
 FlatbufferReader::ptr &find(std::string const &FlatbufferID);
 
 void addReader(std::string FlatbufferID, FlatbufferReader::ptr &&item);

--- a/src/HDFWriterModule.cpp
+++ b/src/HDFWriterModule.cpp
@@ -12,11 +12,8 @@ std::map<std::string, HDFWriterModuleRegistry::ModuleFactory> &getFactories() {
 HDFWriterModuleRegistry::ModuleFactory &find(std::string const &key) {
   static HDFWriterModuleRegistry::ModuleFactory empty;
   auto &_items = getFactories();
-  auto f = _items.find(key);
-  if (f == _items.end()) {
-    return empty;
-  }
-  return f->second;
+  auto &f = _items.at(key);
+  return f;
 }
 
 void addWriterModule(std::string key, ModuleFactory value) {

--- a/src/HDFWriterModule.cpp
+++ b/src/HDFWriterModule.cpp
@@ -12,8 +12,7 @@ std::map<std::string, HDFWriterModuleRegistry::ModuleFactory> &getFactories() {
 HDFWriterModuleRegistry::ModuleFactory &find(std::string const &key) {
   static HDFWriterModuleRegistry::ModuleFactory empty;
   auto &_items = getFactories();
-  auto &f = _items.at(key);
-  return f;
+  return _items.at(key);
 }
 
 void addWriterModule(std::string key, ModuleFactory value) {

--- a/src/HDFWriterModule.cpp
+++ b/src/HDFWriterModule.cpp
@@ -10,7 +10,6 @@ std::map<std::string, HDFWriterModuleRegistry::ModuleFactory> &getFactories() {
 }
 
 HDFWriterModuleRegistry::ModuleFactory &find(std::string const &key) {
-  static HDFWriterModuleRegistry::ModuleFactory empty;
   auto &_items = getFactories();
   return _items.at(key);
 }

--- a/src/HDFWriterModule.h
+++ b/src/HDFWriterModule.h
@@ -220,8 +220,6 @@ std::map<std::string, ModuleFactory> &getFactories();
 void addWriterModule(std::string key, ModuleFactory value);
 
 /// \return The `ModuleFactory` for the given `key`.
-/// @todo This function should probably throw an exception if key
-/// is not found.
 ModuleFactory &find(std::string const &key);
 
 /// Registers the writer module at program start if instantiated in the

--- a/src/tests/HDFFile.cpp
+++ b/src/tests/HDFFile.cpp
@@ -106,6 +106,21 @@ public:
     ch.handle(CommandString);
   }
 
+  static void new_04() {
+    auto CommandData =
+        gulp(std::string(TEST_DATA_PATH) + "/msg-cmd-new-04.json");
+    std::string CommandString(CommandData.data(),
+                              CommandData.data() + CommandData.size());
+    LOG(Sev::Debug, "CommandString: {:.{}}", CommandString.data(),
+        CommandString.size());
+    auto Command = json::parse(CommandString);
+    std::string fname = Command["file_attributes"]["file_name"];
+    unlink(fname.c_str());
+    MainOpt main_opt;
+    FileWriter::CommandHandler ch(main_opt, nullptr);
+    ch.handle(CommandString);
+  }
+
   static bool check_cue(std::vector<uint64_t> const &event_time_zero,
                         std::vector<uint32_t> const &event_index,
                         uint64_t cue_timestamp_zero, uint32_t cue_index) {
@@ -1092,6 +1107,8 @@ public:
 };
 
 TEST_F(T_CommandHandler, New03) { T_CommandHandler::new_03(); }
+
+TEST_F(T_CommandHandler, New04) { EXPECT_NO_THROW(T_CommandHandler::new_04()); }
 
 TEST_F(T_CommandHandler, CreateStaticFileWithHdfOutputPrefix) {
   T_CommandHandler::create_static_file_with_hdf_output_prefix();

--- a/src/tests/ReaderRegistration.cpp
+++ b/src/tests/ReaderRegistration.cpp
@@ -67,6 +67,6 @@ TEST_F(ReaderRegistrationTest, StrKeyNotFound) {
   std::string TestKey("t3mp");
   { FlatbufferReaderRegistry::Registrar<DummyReader> RegisterIt(TestKey); }
   std::string FailKey("trump");
-  EXPECT_THROW(FlatbufferReaderRegistry::find(FailKey), std::out_of_range);
+  EXPECT_THROW(FlatbufferReaderRegistry::find(FailKey), std::nested_exception);
 }
 } // namespace FileWriter

--- a/src/tests/WriterRegistration.cpp
+++ b/src/tests/WriterRegistration.cpp
@@ -79,6 +79,6 @@ TEST_F(WriterRegistrationTest, StrKeyNotFound) {
   std::string TestKey("t3mp");
   { HDFWriterModuleRegistry::Registrar<DummyWriter> RegisterIt(TestKey); }
   std::string FailKey("trump");
-  EXPECT_EQ(HDFWriterModuleRegistry::find(FailKey), nullptr);
+  EXPECT_THROW(HDFWriterModuleRegistry::find(FailKey), std::out_of_range);
 }
 } // namespace FileWriter

--- a/src/tests/data/msg-cmd-new-04.json
+++ b/src/tests/data/msg-cmd-new-04.json
@@ -1,0 +1,31 @@
+ 
+{
+  "file_attributes": {
+    "file_name": "a-dummy-name-04.h5"
+  },
+  "cmd": "FileWriter_new",
+  "nexus_structure": {
+    "children": [
+      {
+        "type": "group",
+        "name": "for_example_motor_0000",
+        "attributes": {
+          "NX_class": "NXinstrument"
+        },
+        "children": [
+          {
+            "type": "stream",
+            "stream": {
+              "topic": "topic.that.is.not.registered",
+              "source": "for_example_motor",
+              "module": "asdf",
+              "type": "float",
+              "array_size": 4
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "job_id": "39gershiudsgf"
+}


### PR DESCRIPTION
### Description of work

Both
`FlatbufferReaderRegistry::find(std::string const &FlatbufferID)` 
and 
`HDFWriterModuleRegistry::find(std::string const &key)` 
now use `std::map::at` to look for map entries. `std::map::at` throws `std::out_of_range` if there is no value corresponding to a given key. This is handled appropriately whenever `find` is called.

Closes #310 
Closes #313 

### Acceptance Criteria
`FlatbufferReaderRegistry::find(std::string const &FlatbufferID)`
`HDFWriterModuleRegistry::find(std::string const &key)`

### Unit Tests
Adjusted `(WriterRegistrationTest, StrKeyNotFound)` to expect `out_of_range` errors.

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
