### PR TITLE
Fixed length strings in attributes

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -55,7 +55,7 @@ type is optional in the case of scalars, but compulsory for arrays.
 ``` 
 
 
-## Fixed-length strings in attributes
+## Fixed-length strings and encoding in attributes
 
 Example:
 
@@ -68,6 +68,7 @@ Example:
       "name": "string_attribute",
       "values": "string_value",
       "type": "string",
+      "encoding": "ascii  (optional, utf8 is the default)",
       "string_size": 32
     },
     {

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -53,3 +53,29 @@ type is optional in the case of scalars, but compulsory for arrays.
   ]
 }
 ``` 
+
+
+## Fixed-length strings in attributes
+
+Example:
+
+```json
+{
+  "type": "group",
+  "name": "group_with_array_of_attrs",
+  "attributes": [
+    {
+      "name": "string_attribute",
+      "values": "string_value",
+      "type": "string",
+      "string_size": 32
+    },
+    {
+      "name": "string_array_attribute",
+      "values": ["string_value_0", "string_value_1", "string_value_2"],
+      "type": "string",
+      "string_size": 32
+    }
+  ]
+}
+```

--- a/src/HDFFile.cpp
+++ b/src/HDFFile.cpp
@@ -277,8 +277,7 @@ void writeAttrStringFixedLength(hdf5::node::Node &Node, std::string const &Name,
     SpaceMem = hdf5::dataspace::Scalar();
   }
   try {
-    size_t ElementSize = StringSize;
-    auto Type = hdf5::datatype::String::fixed(ElementSize);
+    auto Type = hdf5::datatype::String::fixed(StringSize);
     Type.encoding(Encoding);
     Type.padding(hdf5::datatype::StringPad::NULLTERM);
     auto Attribute = Node.attributes.create(Name, Type, SpaceMem);
@@ -297,9 +296,8 @@ void writeAttrStringFixedLength(hdf5::node::Node &Node, std::string const &Name,
             Name);
       }
     }
-    auto Data = populateFixedStrings(Values, ElementSize);
-    LOG(Sev::Debug, "ElementSize: {}  Data.size(): {}", ElementSize,
-        Data.size());
+    auto Data = populateFixedStrings(Values, StringSize);
+    LOG(Sev::Debug, "StringSize: {}  Data.size(): {}", StringSize, Data.size());
     // Fixed string support seems broken in h5cpp
     if (0 > H5Awrite(static_cast<hid_t>(Attribute), static_cast<hid_t>(Type),
                      Data.data())) {

--- a/src/HDFFile.cpp
+++ b/src/HDFFile.cpp
@@ -222,9 +222,13 @@ void HDFFile::writeArrayOfAttributes(hdf5::node::Node &Node,
       if (auto ValuesMaybe = find<json>("values", Attribute)) {
         std::string DType;
         auto const &Values = ValuesMaybe.inner();
+        uint32_t StringSize = 0;
+        if (auto StringSizeMaybe = find<uint32_t>("string_size", Attribute)) {
+          StringSize = StringSizeMaybe.inner();
+        }
         if (auto AttrType = find<std::string>("type", Attribute)) {
           DType = AttrType.inner();
-          writeAttrOfSpecifiedType(DType, Node, Name, &Values);
+          writeAttrOfSpecifiedType(DType, Node, Name, StringSize, &Values);
         } else {
           if (Values.is_array()) {
             LOG(Sev::Warning, "Attributes with array values must specify type")
@@ -244,8 +248,9 @@ void HDFFile::writeArrayOfAttributes(hdf5::node::Node &Node,
 /// \param Values : the attribute values
 void HDFFile::writeAttrOfSpecifiedType(std::string const &DType,
                                        hdf5::node::Node &Node,
-                                       const std::string &Name,
-                                       const nlohmann::json *Values) {
+                                       std::string const &Name,
+                                       uint32_t StringSize,
+                                       nlohmann::json const *Values) {
   try {
     if (DType == "uint8") {
       writeAttrNumeric<uint8_t>(Node, Name, Values);
@@ -278,18 +283,62 @@ void HDFFile::writeAttrOfSpecifiedType(std::string const &DType,
       writeAttrNumeric<double>(Node, Name, Values);
     }
     if (DType == "string") {
-      if (Values->is_array()) {
-        auto ValueArray = populateStrings(Values, Values->size());
-        auto StringAttr =
-            Node.attributes.create(Name, hdf5::datatype::create<std::string>(),
-                                   hdf5::dataspace::Simple{{Values->size()}});
-        StringAttr.write(ValueArray);
+      if (StringSize > 0) {
+        hdf5::dataspace::Dataspace SpaceMem;
+        if (Values->is_array()) {
+          SpaceMem = hdf5::dataspace::Simple({Values->size()});
+        } else {
+          SpaceMem = hdf5::dataspace::Scalar();
+        }
+        try {
+          size_t ElementSize = StringSize;
+          auto Type = hdf5::datatype::String::fixed(ElementSize);
+          Type.encoding(hdf5::datatype::CharacterEncoding::UTF8);
+          Type.padding(hdf5::datatype::StringPad::NULLTERM);
+          auto Attribute = Node.attributes.create(Name, Type, SpaceMem);
+          auto SpaceFile = Attribute.dataspace();
+          try {
+            auto S = hdf5::dataspace::Simple(SpaceFile);
+            auto D = S.current_dimensions();
+            LOG(Sev::Debug, "Simple {}  {}", D.size(), D.at(0));
+          } catch (...) {
+            try {
+              auto S = hdf5::dataspace::Scalar(SpaceFile);
+              LOG(Sev::Debug, "Scalar");
+            } catch (...) {
+              LOG(Sev::Error, "Unknown dataspace requested for fixed length "
+                              "string dataset {}",
+                  Name);
+            }
+          }
+          auto Data = populateFixedStrings(Values, ElementSize);
+          LOG(Sev::Debug, "ElementSize: {}  Data.size(): {}", ElementSize,
+              Data.size());
+          // Fixed string support seems broken in h5cpp
+          if (0 > H5Awrite(static_cast<hid_t>(Attribute),
+                           static_cast<hid_t>(Type), Data.data())) {
+            throw std::runtime_error(
+                fmt::format("Attribute {} write failed", Name));
+          }
+        } catch (std::exception const &E) {
+          std::throw_with_nested(std::runtime_error(fmt::format(
+              "Failed to write fixed-size string attribute {} in {}", Name,
+              static_cast<std::string>(Node.link().path()))));
+        }
       } else {
-        std::string const StringValue = Values->get<std::string>();
-        auto StringType = hdf5::datatype::String::fixed(StringValue.size());
-        auto StringAttr =
-            Node.attributes.create(Name, StringType, hdf5::dataspace::Scalar());
-        StringAttr.write(StringValue, StringType);
+        if (Values->is_array()) {
+          auto ValueArray = populateStrings(Values, Values->size());
+          auto StringAttr = Node.attributes.create(
+              Name, hdf5::datatype::create<std::string>(),
+              hdf5::dataspace::Simple{{Values->size()}});
+          StringAttr.write(ValueArray);
+        } else {
+          std::string const StringValue = Values->get<std::string>();
+          auto StringType = hdf5::datatype::String::fixed(StringValue.size());
+          auto StringAttr = Node.attributes.create(Name, StringType,
+                                                   hdf5::dataspace::Scalar());
+          StringAttr.write(StringValue, StringType);
+        }
       }
     }
   } catch (const std::exception &e) {

--- a/src/HDFFile.cpp
+++ b/src/HDFFile.cpp
@@ -246,16 +246,18 @@ void writeAttrStringVariableLength(hdf5::node::Node &Node,
                                    json const &Values) {
   if (Values.is_array()) {
     auto ValueArray = populateStrings(Values, Values.size());
-    auto StringAttr =
-        Node.attributes.create(Name, hdf5::datatype::create<std::string>(),
-                               hdf5::dataspace::Simple{{Values.size()}});
+    auto Type = hdf5::datatype::String::variable();
+    Type.encoding(hdf5::datatype::CharacterEncoding::UTF8);
+    auto StringAttr = Node.attributes.create(
+        Name, Type, hdf5::dataspace::Simple{{Values.size()}});
     StringAttr.write(ValueArray);
   } else {
     std::string const StringValue = Values.get<std::string>();
-    auto StringType = hdf5::datatype::String::fixed(StringValue.size());
+    auto Type = hdf5::datatype::String::variable();
+    Type.encoding(hdf5::datatype::CharacterEncoding::UTF8);
     auto StringAttr =
-        Node.attributes.create(Name, StringType, hdf5::dataspace::Scalar());
-    StringAttr.write(StringValue, StringType);
+        Node.attributes.create(Name, Type, hdf5::dataspace::Scalar());
+    StringAttr.write(StringValue, Type);
   }
 }
 
@@ -369,7 +371,7 @@ void HDFFile::writeAttrOfSpecifiedType(std::string const &DType,
 /// \param node : node to write attributes on
 /// \param jsv : json value object of attributes
 void HDFFile::writeObjectOfAttributes(hdf5::node::Node &Node,
-                                      const nlohmann::json *Values) {
+                                      nlohmann::json const *Values) {
   for (auto It = Values->begin(); It != Values->end(); ++It) {
     auto const Name = It.key();
     writeScalarAttribute(Node, Name, &It.value());

--- a/src/HDFFile.cpp
+++ b/src/HDFFile.cpp
@@ -473,6 +473,7 @@ std::vector<char> populateFixedStrings(nlohmann::json const &Values,
     ai.push(0);
     an.push(Values.size());
     while (!as.empty()) {
+      // Limit the dimensionality of the data array
       if (as.size() > 10) {
         break;
       }

--- a/src/HDFFile.cpp
+++ b/src/HDFFile.cpp
@@ -669,7 +669,7 @@ void HDFFile::writeDataset(hdf5::node::Group &Parent,
     return;
   }
 
-  std::string DataType = "int64";
+  std::string DataType;
   hsize_t ElementSize = H5T_VARIABLE;
 
   std::vector<hsize_t> Sizes;
@@ -718,8 +718,14 @@ void HDFFile::writeDataset(hdf5::node::Group &Parent,
   }
   auto DatasetValuesInnerObject = DatasetValuesObject.inner();
 
-  if (DatasetValuesInnerObject.is_number_float()) {
-    DataType = "double";
+  if (DataType.empty()) {
+    if (DatasetValuesInnerObject.is_number_float()) {
+      DataType = "double";
+    } else if (DatasetValuesInnerObject.is_number_integer()) {
+      DataType = "int64";
+    } else if (DatasetValuesInnerObject.is_string()) {
+      DataType = "string";
+    }
   }
 
   auto Max = Sizes;

--- a/src/HDFFile.h
+++ b/src/HDFFile.h
@@ -79,12 +79,11 @@ private:
   static std::vector<std::string> populateStrings(const nlohmann::json *Values,
                                                   hssize_t GoalSize);
 
-  static std::vector<std::string>
-  populateFixedStrings(const nlohmann::json *Values, size_t FixedAt,
-                       hssize_t GoalSize);
+  static std::vector<char> populateFixedStrings(const nlohmann::json *Values,
+                                                size_t FixedAt);
 
   static void
-  WriteStringDataset(hdf5::node::Group &Parent, const std::string &Name,
+  writeStringDataset(hdf5::node::Group &Parent, const std::string &Name,
                      hdf5::property::DatasetCreationList &DatasetCreationList,
                      hdf5::dataspace::Dataspace &Dataspace,
                      const nlohmann::json *Values);

--- a/src/HDFFile.h
+++ b/src/HDFFile.h
@@ -76,17 +76,11 @@ private:
   static void writeAttributesIfPresent(hdf5::node::Node &Node,
                                        const nlohmann::json *Values);
 
-  static std::vector<std::string> populateStrings(const nlohmann::json *Values,
-                                                  hssize_t GoalSize);
-
-  static std::vector<char> populateFixedStrings(const nlohmann::json *Values,
-                                                size_t FixedAt);
-
   static void
   writeStringDataset(hdf5::node::Group &Parent, const std::string &Name,
                      hdf5::property::DatasetCreationList &DatasetCreationList,
                      hdf5::dataspace::Dataspace &Dataspace,
-                     const nlohmann::json *Values);
+                     nlohmann::json const &Values);
 
   static void writeFixedSizeStringDataset(
       hdf5::node::Group &Parent, const std::string &Name,
@@ -123,7 +117,7 @@ private:
                                        hdf5::node::Node &Node,
                                        std::string const &Name,
                                        uint32_t StringSize,
-                                       nlohmann::json const *Values);
+                                       nlohmann::json const &Values);
 
   bool SWMREnabled = false;
 
@@ -131,5 +125,11 @@ private:
   std::chrono::milliseconds SWMRFlushInterval{10000};
   std::chrono::time_point<CLOCK> SWMRFlushLast = CLOCK::now();
 };
+
+std::vector<std::string> populateStrings(nlohmann::json const &Values,
+                                         size_t const GoalSize);
+
+std::vector<char> populateFixedStrings(nlohmann::json const &Values,
+                                       size_t const FixedAt);
 
 } // namespace FileWriter

--- a/src/HDFFile.h
+++ b/src/HDFFile.h
@@ -113,11 +113,11 @@ private:
                                    const std::string &Name,
                                    const nlohmann::json *Values);
 
-  static void writeAttrOfSpecifiedType(const std::string &DType,
-                                       hdf5::node::Node &Node,
-                                       std::string const &Name,
-                                       uint32_t StringSize,
-                                       nlohmann::json const &Values);
+  static void
+  writeAttrOfSpecifiedType(const std::string &DType, hdf5::node::Node &Node,
+                           std::string const &Name, uint32_t StringSize,
+                           hdf5::datatype::CharacterEncoding Encoding,
+                           nlohmann::json const &Values);
 
   bool SWMREnabled = false;
 

--- a/src/HDFFile.h
+++ b/src/HDFFile.h
@@ -121,8 +121,9 @@ private:
 
   static void writeAttrOfSpecifiedType(const std::string &DType,
                                        hdf5::node::Node &Node,
-                                       const std::string &Name,
-                                       const nlohmann::json *Values);
+                                       std::string const &Name,
+                                       uint32_t StringSize,
+                                       nlohmann::json const *Values);
 
   bool SWMREnabled = false;
 

--- a/src/tests/HDFFile.cpp
+++ b/src/tests/HDFFile.cpp
@@ -242,17 +242,6 @@ public:
                   ["string_1_2_0", "string_1_2_1"]
                 ]
               ]
-            },
-            {
-              "NOTE": "Disabled because h5cpp seems unhappy about fixed length strings currently.",
-              "type": "DISABLED_dataset",
-              "name": "string_fixed_1d",
-              "dataset": {
-                "type":"string",
-                "string_size": 32,
-                "size": ["unlimited"]
-              },
-              "values": ["the-scalar-string", "another-one"]
             }
           ]
         })"");

--- a/src/tests/HDFFile.cpp
+++ b/src/tests/HDFFile.cpp
@@ -1217,11 +1217,13 @@ TEST(HDFFile, createStaticDatasetsStrings) {
             "name": "string_var_2d",
             "dataset": {
               "type": "string",
-              "size": ["unlimited", 2]
+              "size": ["unlimited", 4]
             },
             "values": [
-              ["string_0_0", "string_0_1"],
-              ["string_1_0", "string_1_1"]
+              ["string_0_0", "string_0_1", "string_0_2", "string_0_3"],
+              ["string_1_0", "string_1_1", "string_1_2", "string_1_3"],
+              ["string_2_0", "string_2_1", "string_2_2", "string_2_3"],
+              ["string_3_0", "string_3_1", "string_3_2", "string_3_3"]
             ]
           },
           {
@@ -1230,11 +1232,13 @@ TEST(HDFFile, createStaticDatasetsStrings) {
             "dataset": {
               "type": "string",
               "string_size": 32,
-              "size": ["unlimited", 2]
+              "size": ["unlimited", 4]
             },
             "values": [
-              ["string_0_0", "string_0_1"],
-              ["string_1_0", "string_1_1"]
+              ["string_0_0", "string_0_1", "string_0_2", "string_0_3"],
+              ["string_1_0", "string_1_1", "string_1_2", "string_1_3"],
+              ["string_2_0", "string_2_1", "string_2_2", "string_2_3"],
+              ["string_3_0", "string_3_1", "string_3_2", "string_3_3"]
             ]
           }
         ]
@@ -1275,17 +1279,41 @@ TEST(HDFFile, createStaticDatasetsStrings) {
     Dataset = hdf5::node::get_dataset(File.root(), "/some_group/string_fix_1d");
     ASSERT_EQ(Dataset.datatype(), StringFix);
     ASSERT_EQ(Dataset.dataspace().type(), hdf5::dataspace::Type::SIMPLE);
-    Dataset = hdf5::node::get_dataset(File.root(), "/some_group/string_fix_2d");
-    ASSERT_EQ(Dataset.datatype(), StringFix);
-    ASSERT_EQ(Dataset.dataspace().type(), hdf5::dataspace::Type::SIMPLE);
-    Dataset = hdf5::node::get_dataset(File.root(), "/some_group/string_var_2d");
-    ASSERT_EQ(Dataset.datatype(), StringVar);
-    ASSERT_EQ(Dataset.dataspace().type(), hdf5::dataspace::Type::SIMPLE);
-    SpaceFile = Dataset.dataspace();
-    // SpaceFile.selection()
-    std::vector<char> Buffer;
-    Buffer.resize(10000);
-    // Dataset.read(Buffer, StringVar, hdf5::dataspace::Simple({1}),
-    // hdf5::dataspace::Simple({1}));
+    {
+      auto Dataset =
+          hdf5::node::get_dataset(File.root(), "/some_group/string_fix_2d");
+      ASSERT_EQ(Dataset.datatype(), StringFix);
+      ASSERT_EQ(Dataset.dataspace().type(), hdf5::dataspace::Type::SIMPLE);
+      hdf5::dataspace::Simple SpaceFile = Dataset.dataspace();
+      SpaceFile.selection(hdf5::dataspace::SelectionOperation::SET,
+                          hdf5::dataspace::Hyperslab({2, 1}, {1, 3}));
+      std::vector<char> Buffer(3 * 32);
+      // Dataset.read(*Buffer.data(), StringFix, hdf5::dataspace::Simple({2}),
+      // SpaceFile);
+      hdf5::dataspace::Simple SpaceMem({3});
+      if (0 >
+          H5Dread(static_cast<hid_t>(Dataset), static_cast<hid_t>(StringFix),
+                  static_cast<hid_t>(SpaceMem), static_cast<hid_t>(SpaceFile),
+                  H5P_DEFAULT, Buffer.data())) {
+        ASSERT_TRUE(false);
+      }
+      ASSERT_EQ(std::string(Buffer.data() + 0 * 32), "string_2_1");
+      ASSERT_EQ(std::string(Buffer.data() + 1 * 32), "string_2_2");
+      ASSERT_EQ(std::string(Buffer.data() + 2 * 32), "string_2_3");
+    }
+    {
+      auto Dataset =
+          hdf5::node::get_dataset(File.root(), "/some_group/string_var_2d");
+      ASSERT_EQ(Dataset.datatype(), StringVar);
+      ASSERT_EQ(Dataset.dataspace().type(), hdf5::dataspace::Type::SIMPLE);
+      hdf5::dataspace::Simple SpaceFile = Dataset.dataspace();
+      SpaceFile.selection(hdf5::dataspace::SelectionOperation::SET,
+                          hdf5::dataspace::Hyperslab({2, 1}, {1, 2}));
+      std::vector<std::string> Buffer;
+      Buffer.resize(2);
+      Dataset.read(Buffer, StringVar, hdf5::dataspace::Simple({2}), SpaceFile);
+      ASSERT_EQ(Buffer.at(0), "string_2_1");
+      ASSERT_EQ(Buffer.at(1), "string_2_2");
+    }
   }
 }

--- a/src/tests/HDFFile.cpp
+++ b/src/tests/HDFFile.cpp
@@ -1157,3 +1157,135 @@ TEST_F(T_CommandHandler, createStaticDatasetOfEachIntType) {
   verifyWrittenDatatype(TestFile, TestInt32);
   verifyWrittenDatatype(TestFile, TestInt64);
 }
+
+TEST(HDFFile, createStaticDatasetsStrings) {
+  std::string const hdf_output_filename =
+      "Test.HDFFile.createStaticDatasetsStrings";
+  unlink(hdf_output_filename.c_str());
+  auto CommandJSON = json::parse(R""(
+{
+  "cmd": "FileWriter_new",
+  "file_attributes": {
+  },
+  "nexus_structure": {
+    "children": [
+      {
+        "type": "group",
+        "name": "some_group",
+        "attributes": {
+          "NX_class": "NXinstrument"
+        },
+        "children": [
+          {
+            "type": "dataset",
+            "name": "string_var_0d",
+            "dataset": {
+              "type": "string"
+            },
+            "values": "the-scalar-string"
+          },
+          {
+            "type": "dataset",
+            "name": "string_fix_0d",
+            "dataset": {
+              "type": "string",
+              "string_size": 32
+            },
+            "values": "string_scalar"
+          },
+          {
+            "type": "dataset",
+            "name": "string_var_1d",
+            "dataset": {
+              "type": "string",
+              "size": ["unlimited"]
+            },
+            "values": ["the-scalar-string", "another-one", "a-third"]
+          },
+          {
+            "type": "dataset",
+            "name": "string_fix_1d",
+            "dataset": {
+              "type": "string",
+              "string_size": 32,
+              "size": ["unlimited"]
+            },
+            "values": ["the-scalar-string", "another-one", "a-third"]
+          },
+          {
+            "type": "dataset",
+            "name": "string_var_2d",
+            "dataset": {
+              "type": "string",
+              "size": ["unlimited", 2]
+            },
+            "values": [
+              ["string_0_0", "string_0_1"],
+              ["string_1_0", "string_1_1"]
+            ]
+          },
+          {
+            "type": "dataset",
+            "name": "string_fix_2d",
+            "dataset": {
+              "type": "string",
+              "string_size": 32,
+              "size": ["unlimited", 2]
+            },
+            "values": [
+              ["string_0_0", "string_0_1"],
+              ["string_1_0", "string_1_1"]
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}
+  )"");
+  CommandJSON["file_attributes"]["file_name"] = hdf_output_filename;
+  auto CommandString = CommandJSON.dump();
+  std::string Filename = CommandJSON["file_attributes"]["file_name"];
+  ASSERT_GT(Filename.size(), 8u);
+  std::vector<FileWriter::StreamHDFInfo> NoStreams;
+  {
+    FileWriter::HDFFile File;
+    File.init(Filename, CommandJSON["nexus_structure"], json::object(),
+              NoStreams, false);
+  }
+  {
+    auto File = hdf5::file::open(Filename, hdf5::file::AccessFlags::READONLY);
+    auto StringVar = hdf5::datatype::String::variable();
+    StringVar.encoding(hdf5::datatype::CharacterEncoding::UTF8);
+    StringVar.padding(hdf5::datatype::StringPad::NULLTERM);
+    auto StringFix = hdf5::datatype::String::fixed(32);
+    StringFix.encoding(hdf5::datatype::CharacterEncoding::UTF8);
+    StringFix.padding(hdf5::datatype::StringPad::NULLTERM);
+    hdf5::node::Dataset Dataset;
+    hdf5::dataspace::Simple SpaceFile;
+    Dataset = hdf5::node::get_dataset(File.root(), "/some_group/string_var_0d");
+    ASSERT_EQ(Dataset.datatype(), StringVar);
+    ASSERT_EQ(Dataset.dataspace().type(), hdf5::dataspace::Type::SCALAR);
+    Dataset = hdf5::node::get_dataset(File.root(), "/some_group/string_fix_0d");
+    ASSERT_EQ(Dataset.datatype(), StringFix);
+    ASSERT_EQ(Dataset.dataspace().type(), hdf5::dataspace::Type::SCALAR);
+    Dataset = hdf5::node::get_dataset(File.root(), "/some_group/string_var_1d");
+    ASSERT_EQ(Dataset.datatype(), StringVar);
+    ASSERT_EQ(Dataset.dataspace().type(), hdf5::dataspace::Type::SIMPLE);
+    Dataset = hdf5::node::get_dataset(File.root(), "/some_group/string_fix_1d");
+    ASSERT_EQ(Dataset.datatype(), StringFix);
+    ASSERT_EQ(Dataset.dataspace().type(), hdf5::dataspace::Type::SIMPLE);
+    Dataset = hdf5::node::get_dataset(File.root(), "/some_group/string_fix_2d");
+    ASSERT_EQ(Dataset.datatype(), StringFix);
+    ASSERT_EQ(Dataset.dataspace().type(), hdf5::dataspace::Type::SIMPLE);
+    Dataset = hdf5::node::get_dataset(File.root(), "/some_group/string_var_2d");
+    ASSERT_EQ(Dataset.datatype(), StringVar);
+    ASSERT_EQ(Dataset.dataspace().type(), hdf5::dataspace::Type::SIMPLE);
+    SpaceFile = Dataset.dataspace();
+    // SpaceFile.selection()
+    std::vector<char> Buffer;
+    Buffer.resize(10000);
+    // Dataset.read(Buffer, StringVar, hdf5::dataspace::Simple({1}),
+    // hdf5::dataspace::Simple({1}));
+  }
+}

--- a/src/tests/HDFFileAttributesTest.cpp
+++ b/src/tests/HDFFileAttributesTest.cpp
@@ -221,6 +221,32 @@ TEST(HDFFileAttributesTest,
             "values": ["string_value_0", "string_value_1", "string_value_2"],
             "type": "string",
             "string_size": 32
+          },
+          {
+            "name": "string_variable_ascii_attribute",
+            "values": "string_value",
+            "type": "string",
+            "encoding": "ascii"
+          },
+          {
+            "name": "string_variable_ascii_array_attribute",
+            "values": ["string_value_0", "string_value_1", "string_value_2"],
+            "type": "string",
+            "encoding": "ascii"
+          },
+          {
+            "name": "string_fixed_ascii_attribute",
+            "values": "string_value",
+            "type": "string",
+            "encoding": "ascii",
+            "string_size": 32
+          },
+          {
+            "name": "string_fixed_ascii_array_attribute",
+            "values": ["string_value_0", "string_value_1", "string_value_2"],
+            "type": "string",
+            "encoding": "ascii",
+            "string_size": 32
           }
         ]
       }
@@ -275,6 +301,60 @@ TEST(HDFFileAttributesTest,
     auto Type = hdf5::datatype::String(StringArrayAttr.datatype());
     ASSERT_FALSE(Type.is_variable_length());
     ASSERT_EQ(Type.encoding(), hdf5::datatype::CharacterEncoding::UTF8);
+    std::vector<char> Buffer(3 * 32);
+    ASSERT_LE(0, H5Aread(static_cast<hid_t>(StringArrayAttr),
+                         static_cast<hid_t>(StringArrayAttr.datatype()),
+                         Buffer.data()));
+    ASSERT_EQ(std::string(Buffer.data() + 0 * 32), "string_value_0");
+    ASSERT_EQ(std::string(Buffer.data() + 1 * 32), "string_value_1");
+    ASSERT_EQ(std::string(Buffer.data() + 2 * 32), "string_value_2");
+  }
+
+  {
+    auto StringAttr =
+        node::get_group(TestFile.RootGroup, "group_with_attributes")
+            .attributes["string_variable_ascii_attribute"];
+    auto Type = hdf5::datatype::String(StringAttr.datatype());
+    ASSERT_TRUE(Type.is_variable_length());
+    ASSERT_EQ(Type.encoding(), hdf5::datatype::CharacterEncoding::ASCII);
+    std::string StringValue;
+    StringAttr.read(StringValue, StringAttr.datatype());
+    ASSERT_EQ(StringValue, "string_value");
+  }
+
+  {
+    auto StringArrayAttr =
+        node::get_group(TestFile.RootGroup, "group_with_attributes")
+            .attributes["string_variable_ascii_array_attribute"];
+    auto Type = hdf5::datatype::String(StringArrayAttr.datatype());
+    ASSERT_TRUE(Type.is_variable_length());
+    ASSERT_EQ(Type.encoding(), hdf5::datatype::CharacterEncoding::ASCII);
+    std::vector<std::string> Buffer;
+    Buffer.resize(3);
+    StringArrayAttr.read(Buffer, StringArrayAttr.datatype());
+  }
+
+  {
+    auto StringAttr =
+        node::get_group(TestFile.RootGroup, "group_with_attributes")
+            .attributes["string_fixed_ascii_attribute"];
+    auto Type = hdf5::datatype::String(StringAttr.datatype());
+    ASSERT_FALSE(Type.is_variable_length());
+    ASSERT_EQ(Type.encoding(), hdf5::datatype::CharacterEncoding::ASCII);
+    std::string StringValue;
+    StringAttr.read(StringValue, StringAttr.datatype());
+    std::string Expected("string_value");
+    StringValue.resize(Expected.size());
+    ASSERT_EQ(StringValue, Expected.data());
+  }
+
+  {
+    auto StringArrayAttr =
+        node::get_group(TestFile.RootGroup, "group_with_attributes")
+            .attributes["string_fixed_ascii_array_attribute"];
+    auto Type = hdf5::datatype::String(StringArrayAttr.datatype());
+    ASSERT_FALSE(Type.is_variable_length());
+    ASSERT_EQ(Type.encoding(), hdf5::datatype::CharacterEncoding::ASCII);
     std::vector<char> Buffer(3 * 32);
     ASSERT_LE(0, H5Aread(static_cast<hid_t>(StringArrayAttr),
                          static_cast<hid_t>(StringArrayAttr.datatype()),

--- a/src/tests/HDFFileAttributesTest.cpp
+++ b/src/tests/HDFFileAttributesTest.cpp
@@ -236,9 +236,9 @@ TEST(HDFFileAttributesTest,
             .attributes["string_variable_attribute"];
     auto Type = hdf5::datatype::String(StringAttr.datatype());
     ASSERT_TRUE(Type.is_variable_length());
+    ASSERT_EQ(Type.encoding(), hdf5::datatype::CharacterEncoding::UTF8);
     std::string StringValue;
     StringAttr.read(StringValue, StringAttr.datatype());
-    ASSERT_EQ(Type.encoding(), hdf5::datatype::CharacterEncoding::UTF8);
     ASSERT_EQ(StringValue, "string_value");
   }
 
@@ -282,5 +282,39 @@ TEST(HDFFileAttributesTest,
     ASSERT_EQ(std::string(Buffer.data() + 0 * 32), "string_value_0");
     ASSERT_EQ(std::string(Buffer.data() + 1 * 32), "string_value_1");
     ASSERT_EQ(std::string(Buffer.data() + 2 * 32), "string_value_2");
+  }
+}
+
+TEST(HDFFileAttributesTest, ObjectOfAttributesOfTypeString) {
+  using namespace hdf5;
+
+  auto TestFile = HDFFileTestHelper::createInMemoryTestFile(
+      "test-object-of-attributes-with-strings.nxs");
+
+  std::string Command = R""({
+    "children": [
+      {
+        "type": "group",
+        "name": "group_with_object_of_attributes",
+        "attributes": {
+          "some_attribute": "Some Value"
+        }
+      }
+    ]
+  })"";
+
+  std::vector<FileWriter::StreamHDFInfo> EmptyStreamHDFInfo;
+  TestFile.init(Command, EmptyStreamHDFInfo);
+
+  {
+    auto StringAttr =
+        node::get_group(TestFile.RootGroup, "group_with_object_of_attributes")
+            .attributes["some_attribute"];
+    auto Type = hdf5::datatype::String(StringAttr.datatype());
+    ASSERT_TRUE(Type.is_variable_length());
+    ASSERT_EQ(Type.encoding(), hdf5::datatype::CharacterEncoding::UTF8);
+    std::string StringValue;
+    StringAttr.read(StringValue, StringAttr.datatype());
+    ASSERT_EQ(StringValue, "Some Value");
   }
 }


### PR DESCRIPTION
### Description of work

Improve support for fixed length string attributes as described in `docs/attributes.md`.

Used and tested so far on the AMOR instrument as part of branch `amor`.

### Unit Tests

New unit tests include `HDFFile.createStaticDatasetsStrings` and `HDFFileAttributesTest.ArrayOfAttributesWithFixedLengthStringItIsWrittenAsFixedLengthStrings`
