### PR TITLE
Simplify data gather

### DIFF
--- a/src/HDFFile.cpp
+++ b/src/HDFFile.cpp
@@ -446,8 +446,8 @@ void HDFFile::writeScalarAttribute(hdf5::node::Node &Node,
 }
 
 void HDFFile::writeAttributesIfPresent(hdf5::node::Node &Node,
-                                       const nlohmann::json *Values) {
-  if (auto AttributesMaybe = find<json>("attributes", *Values)) {
+                                       nlohmann::json const &Values) {
+  if (auto AttributesMaybe = find<json>("attributes", Values)) {
     auto const Attributes = AttributesMaybe.inner();
     writeAttributes(Node, &Attributes);
   }
@@ -719,7 +719,7 @@ void HDFFile::writeDataset(hdf5::node::Group &Parent,
                       &DatasetValuesInnerObject);
   auto dset = hdf5::node::Dataset(Parent.nodes[Name]);
 
-  writeAttributesIfPresent(dset, Values);
+  writeAttributesIfPresent(dset, *Values);
 }
 
 void HDFFile::createHDFStructures(
@@ -761,7 +761,7 @@ void HDFFile::createHDFStructures(
     // If the current level in the HDF can act as a parent, then continue the
     // recursion with the (optional) "children" array.
     if (hdf_this.is_valid()) {
-      writeAttributesIfPresent(hdf_this, Value);
+      writeAttributesIfPresent(hdf_this, *Value);
       if (auto ChildrenMaybe = find<json>("children", *Value)) {
         auto Children = ChildrenMaybe.inner();
         if (Children.is_array()) {
@@ -895,7 +895,7 @@ void HDFFile::init(const nlohmann::json &NexusStructure,
         RootGroup, "creator",
         fmt::format("kafka-to-nexus commit {:.7}", GIT_COMMIT));
     writeHDFISO8601AttributeCurrentTime(RootGroup, "file_time");
-    writeAttributesIfPresent(RootGroup, &NexusStructure);
+    writeAttributesIfPresent(RootGroup, NexusStructure);
   } catch (std::exception const &E) {
     LOG(Sev::Critical, "Failed to initialize  file={}  trace:\n{}",
         H5File.id().file_name().string(), hdf5::error::print_nested(E));

--- a/src/HDFFile.cpp
+++ b/src/HDFFile.cpp
@@ -218,7 +218,7 @@ static void writeHDFISO8601Attribute(hdf5::node::Node &Node,
 }
 
 void HDFFile::writeHDFISO8601AttributeCurrentTime(hdf5::node::Node &Node,
-                                                  const std::string &Name) {
+                                                  std::string const &Name) {
   using namespace date;
   using namespace std::chrono;
   const time_zone *CurrentTimeZone;
@@ -235,11 +235,14 @@ void HDFFile::writeHDFISO8601AttributeCurrentTime(hdf5::node::Node &Node,
 }
 
 void HDFFile::writeAttributes(hdf5::node::Node &Node,
-                              const nlohmann::json *Value) {
+                              nlohmann::json const *Value) {
+  if (Value == nullptr) {
+    return;
+  }
   if (Value->is_array()) {
-    writeArrayOfAttributes(Node, Value);
+    writeArrayOfAttributes(Node, *Value);
   } else if (Value->is_object()) {
-    writeObjectOfAttributes(Node, Value);
+    writeObjectOfAttributes(Node, *Value);
   }
 }
 
@@ -248,11 +251,11 @@ void HDFFile::writeAttributes(hdf5::node::Node &Node,
 /// \param Node : node to write attributes on
 /// \param JsonValue : json value array of attribute objects
 void HDFFile::writeArrayOfAttributes(hdf5::node::Node &Node,
-                                     const nlohmann::json *Values) {
-  if (!Values->is_array()) {
+                                     nlohmann::json const &Values) {
+  if (!Values.is_array()) {
     return;
   }
-  for (auto const &Attribute : *Values) {
+  for (auto const &Attribute : Values) {
     if (Attribute.is_object()) {
       string Name;
       if (auto NameMaybe = find<std::string>("name", Attribute)) {
@@ -282,7 +285,7 @@ void HDFFile::writeArrayOfAttributes(hdf5::node::Node &Node,
             LOG(Sev::Warning, "Attributes with array values must specify type")
             continue;
           }
-          writeScalarAttribute(Node, Name, &Values);
+          writeScalarAttribute(Node, Name, Values);
         }
       }
     }
@@ -417,10 +420,10 @@ void HDFFile::writeAttrOfSpecifiedType(
 /// \param node : node to write attributes on
 /// \param jsv : json value object of attributes
 void HDFFile::writeObjectOfAttributes(hdf5::node::Node &Node,
-                                      nlohmann::json const *Values) {
-  for (auto It = Values->begin(); It != Values->end(); ++It) {
+                                      nlohmann::json const &Values) {
+  for (auto It = Values.begin(); It != Values.end(); ++It) {
     auto const Name = It.key();
-    writeScalarAttribute(Node, Name, &It.value());
+    writeScalarAttribute(Node, Name, It.value());
   }
 }
 
@@ -429,16 +432,16 @@ void HDFFile::writeObjectOfAttributes(hdf5::node::Node &Node,
 /// \param Name : Name of the attribute
 /// \param Values : Json value containing the attribute value
 void HDFFile::writeScalarAttribute(hdf5::node::Node &Node,
-                                   const std::string &Name,
-                                   const nlohmann::json *Values) {
-  if (Values->is_string()) {
-    writeStringAttribute(Node, Name, Values->get<std::string>());
-  } else if (Values->is_number_integer()) {
-    writeAttribute(Node, Name, Values->get<int64_t>());
-  } else if (Values->is_number_unsigned()) {
-    writeAttribute(Node, Name, Values->get<uint64_t>());
-  } else if (Values->is_number_float()) {
-    writeAttribute(Node, Name, Values->get<double>());
+                                   std::string const &Name,
+                                   nlohmann::json const &Values) {
+  if (Values.is_string()) {
+    writeStringAttribute(Node, Name, Values);
+  } else if (Values.is_number_integer()) {
+    writeAttribute(Node, Name, Values.get<int64_t>());
+  } else if (Values.is_number_unsigned()) {
+    writeAttribute(Node, Name, Values.get<uint64_t>());
+  } else if (Values.is_number_float()) {
+    writeAttribute(Node, Name, Values.get<double>());
   }
 }
 

--- a/src/HDFFile.h
+++ b/src/HDFFile.h
@@ -74,7 +74,7 @@ private:
                                                   const std::string &Name);
 
   static void writeAttributesIfPresent(hdf5::node::Node &Node,
-                                       const nlohmann::json *Values);
+                                       nlohmann::json const &Values);
 
   static void
   writeStringDataset(hdf5::node::Group &Parent, const std::string &Name,

--- a/src/HDFFile.h
+++ b/src/HDFFile.h
@@ -42,11 +42,11 @@ public:
 
   static std::string h5VersionStringLinked();
   static void writeAttributes(hdf5::node::Node &Node,
-                              const nlohmann::json *Value);
+                              nlohmann::json const *Value);
 
   static void writeStringAttribute(hdf5::node::Node &Node,
-                                   const std::string &Name,
-                                   const std::string &Value);
+                                   std::string const &Name,
+                                   std::string const &Value);
 
   /// If using SWMR, gets invoked by Source and can trigger a flush of the HDF
   /// file.
@@ -104,14 +104,14 @@ private:
                  hdf5::property::FileAccessList &FileAccessPropertyList) {}
 
   static void writeObjectOfAttributes(hdf5::node::Node &Node,
-                                      const nlohmann::json *Values);
+                                      const nlohmann::json &Values);
 
   static void writeArrayOfAttributes(hdf5::node::Node &Node,
-                                     const nlohmann::json *Values);
+                                     const nlohmann::json &Values);
 
   static void writeScalarAttribute(hdf5::node::Node &Node,
                                    const std::string &Name,
-                                   const nlohmann::json *Values);
+                                   const nlohmann::json &Values);
 
   static void
   writeAttrOfSpecifiedType(const std::string &DType, hdf5::node::Node &Node,

--- a/src/HDFFile.h
+++ b/src/HDFFile.h
@@ -126,10 +126,4 @@ private:
   std::chrono::time_point<CLOCK> SWMRFlushLast = CLOCK::now();
 };
 
-std::vector<std::string> populateStrings(nlohmann::json const &Values,
-                                         size_t const GoalSize);
-
-std::vector<char> populateFixedStrings(nlohmann::json const &Values,
-                                       size_t const FixedAt);
-
 } // namespace FileWriter


### PR DESCRIPTION
### Description of work

Reduce duplication of code: To prepare writing to HDF, we often have to gather n-dimensional json arrays into a buffer suitable for the call to h5cpp. Previously, we had some code duplication for the cases of numerical and string data. This is now unified.

### Acceptance Criteria

Tests should pass as before.
