### PR TITLE
Optionally write latest LogData value into configurable dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ datasets:
 - `type`: The data type contained in the flat buffer. Can be `int8` to `int64`,
   similar for `uint8`, `float` and `double`.
 - `array_size`: The size of the array. Scalar if not specified or `0`.
+- `store_latest_into`: (optional) Name of the dataset into which the latest
+  received value should be stored on file writer close.
 
 
 ### Single Writer, Multiple Reader support

--- a/src/h5.cpp
+++ b/src/h5.cpp
@@ -620,6 +620,10 @@ template <typename T> AppendResult h5d_chunked_2d<T>::flush_buf() {
   return AppendResult::OK;
 }
 
+template <typename T> size_t h5d_chunked_2d<T>::size() const {
+  return ds.snow.at(0);
+}
+
 // clang-format off
 
 template append_ret h5d::append_data_1d(uint8_t const *data, hsize_t nlen);
@@ -787,6 +791,17 @@ template append_ret h5d_chunked_2d< int32_t>::h5d_chunked_2d::append_data_2d( in
 template append_ret h5d_chunked_2d< int64_t>::h5d_chunked_2d::append_data_2d( int64_t const *data, hsize_t nlen);
 template append_ret h5d_chunked_2d<   float>::h5d_chunked_2d::append_data_2d(   float const *data, hsize_t nlen);
 template append_ret h5d_chunked_2d<  double>::h5d_chunked_2d::append_data_2d(  double const *data, hsize_t nlen);
+
+template size_t h5d_chunked_2d< uint8_t>::h5d_chunked_2d::size() const;
+template size_t h5d_chunked_2d<uint16_t>::h5d_chunked_2d::size() const;
+template size_t h5d_chunked_2d<uint32_t>::h5d_chunked_2d::size() const;
+template size_t h5d_chunked_2d<uint64_t>::h5d_chunked_2d::size() const;
+template size_t h5d_chunked_2d<  int8_t>::h5d_chunked_2d::size() const;
+template size_t h5d_chunked_2d< int16_t>::h5d_chunked_2d::size() const;
+template size_t h5d_chunked_2d< int32_t>::h5d_chunked_2d::size() const;
+template size_t h5d_chunked_2d< int64_t>::h5d_chunked_2d::size() const;
+template size_t h5d_chunked_2d<   float>::h5d_chunked_2d::size() const;
+template size_t h5d_chunked_2d<  double>::h5d_chunked_2d::size() const;
 
 // clang-format on
 

--- a/src/h5.cpp
+++ b/src/h5.cpp
@@ -460,6 +460,10 @@ template <typename T> AppendResult h5d_chunked_1d<T>::flush_buf() {
   return AppendResult::OK;
 }
 
+template <typename T> size_t h5d_chunked_1d<T>::size() const {
+  return ds.snow.at(0);
+}
+
 Chunked1DString::Chunked1DString(h5d ds) : ds(std::move(ds)) {}
 
 Chunked1DString::ptr Chunked1DString::create(hdf5::node::Group Node,
@@ -733,6 +737,17 @@ template append_ret h5d_chunked_1d< int32_t>::h5d_chunked_1d::append_data_1d( in
 template append_ret h5d_chunked_1d< int64_t>::h5d_chunked_1d::append_data_1d( int64_t const *data, hsize_t nlen);
 template append_ret h5d_chunked_1d<   float>::h5d_chunked_1d::append_data_1d(   float const *data, hsize_t nlen);
 template append_ret h5d_chunked_1d<  double>::h5d_chunked_1d::append_data_1d(  double const *data, hsize_t nlen);
+
+template size_t h5d_chunked_1d< uint8_t>::h5d_chunked_1d::size() const;
+template size_t h5d_chunked_1d<uint16_t>::h5d_chunked_1d::size() const;
+template size_t h5d_chunked_1d<uint32_t>::h5d_chunked_1d::size() const;
+template size_t h5d_chunked_1d<uint64_t>::h5d_chunked_1d::size() const;
+template size_t h5d_chunked_1d<  int8_t>::h5d_chunked_1d::size() const;
+template size_t h5d_chunked_1d< int16_t>::h5d_chunked_1d::size() const;
+template size_t h5d_chunked_1d< int32_t>::h5d_chunked_1d::size() const;
+template size_t h5d_chunked_1d< int64_t>::h5d_chunked_1d::size() const;
+template size_t h5d_chunked_1d<   float>::h5d_chunked_1d::size() const;
+template size_t h5d_chunked_1d<  double>::h5d_chunked_1d::size() const;
 
 template h5d_chunked_2d< uint8_t>::ptr h5d_chunked_2d< uint8_t>::create(hdf5::node::Group loc, std::string name, hsize_t ncols, hsize_t chunk_bytes, CollectiveQueue *cq);
 template h5d_chunked_2d<uint16_t>::ptr h5d_chunked_2d<uint16_t>::create(hdf5::node::Group loc, std::string name, hsize_t ncols, hsize_t chunk_bytes, CollectiveQueue *cq);

--- a/src/h5.h
+++ b/src/h5.h
@@ -87,6 +87,7 @@ public:
   append_ret append_data_1d(T const *data, hsize_t nlen);
   AppendResult flush_buf();
   void buffer_init(size_t buf_size, size_t buf_packet_max);
+  size_t size() const;
 
 private:
   h5d_chunked_1d(std::string name, h5d ds);

--- a/src/h5.h
+++ b/src/h5.h
@@ -134,6 +134,7 @@ public:
   append_ret append_data_2d(T const *data, hsize_t nlen);
   AppendResult flush_buf();
   void buffer_init(size_t buf_size, size_t buf_packet_max);
+  size_t size() const;
 
 private:
   h5d_chunked_2d(std::string name, h5d ds, hsize_t ncols);

--- a/src/schemas/f142/WriterArray.h
+++ b/src/schemas/f142/WriterArray.h
@@ -14,10 +14,10 @@ namespace f142 {
 /// \tparam  FV  The Flatbuffers datatype for this dataset
 template <typename DT, typename FV> class WriterArray : public WriterTypedBase {
 public:
-  WriterArray(hdf5::node::Group hdf_group, std::string const &source_name,
+  WriterArray(hdf5::node::Group HdfGroup, std::string const &source_name,
               hsize_t ColumnCount, Value FlatbuffersValueTypeId,
               CollectiveQueue *cq);
-  WriterArray(hdf5::node::Group, std::string const &source_name,
+  WriterArray(hdf5::node::Group HdfGroup, std::string const &source_name,
               hsize_t ColumnCount, Value FlatbuffersValueTypeId,
               CollectiveQueue *cq, HDFIDStore *hdf_store);
   h5::append_ret write(FBUF const *fbuf) override;
@@ -32,7 +32,7 @@ public:
 /// \tparam  DT  The C datatype for this dataset
 /// \tparam  FV  The Flatbuffers datatype for this dataset
 template <typename DT, typename FV>
-WriterArray<DT, FV>::WriterArray(hdf5::node::Group hdf_group,
+WriterArray<DT, FV>::WriterArray(hdf5::node::Group HdfGroup,
                                  std::string const &source_name,
                                  hsize_t ColumnCount,
                                  Value FlatbuffersValueTypeId,
@@ -44,7 +44,7 @@ WriterArray<DT, FV>::WriterArray(hdf5::node::Group hdf_group,
     return;
   }
   LOG(Sev::Debug, "f142 init_impl  ColumnCount: {}", ColumnCount);
-  ChunkedDataset = h5::h5d_chunked_2d<DT>::create(hdf_group, source_name,
+  ChunkedDataset = h5::h5d_chunked_2d<DT>::create(HdfGroup, source_name,
                                                   ColumnCount, 64 * 1024, cq);
   if (ChunkedDataset == nullptr) {
     LOG(Sev::Error,
@@ -58,7 +58,7 @@ WriterArray<DT, FV>::WriterArray(hdf5::node::Group hdf_group,
 /// \tparam  DT  The C datatype for this dataset
 /// \tparam  FV  The Flatbuffers datatype for this dataset
 template <typename DT, typename FV>
-WriterArray<DT, FV>::WriterArray(hdf5::node::Group hdf_group,
+WriterArray<DT, FV>::WriterArray(hdf5::node::Group HdfGroup,
                                  std::string const &source_name,
                                  hsize_t ColumnCount,
                                  Value FlatbuffersValueTypeId,
@@ -71,7 +71,7 @@ WriterArray<DT, FV>::WriterArray(hdf5::node::Group hdf_group,
   }
   LOG(Sev::Debug, "f142 writer_typed_array reopen  ColumnCount: {}",
       ColumnCount);
-  ChunkedDataset = h5::h5d_chunked_2d<DT>::open(hdf_group, source_name,
+  ChunkedDataset = h5::h5d_chunked_2d<DT>::open(HdfGroup, source_name,
                                                 ColumnCount, cq, hdf_store);
   if (ChunkedDataset == nullptr) {
     LOG(Sev::Error,

--- a/src/schemas/f142/WriterArray.h
+++ b/src/schemas/f142/WriterArray.h
@@ -15,10 +15,11 @@ namespace f142 {
 template <typename DT, typename FV> class WriterArray : public WriterTypedBase {
 public:
   WriterArray(hdf5::node::Group hdf_group, std::string const &source_name,
-              hsize_t ncols, Value FlatbuffersValueTypeId, CollectiveQueue *cq);
-  WriterArray(hdf5::node::Group, std::string const &source_name, hsize_t ncols,
-              Value FlatbuffersValueTypeId, CollectiveQueue *cq,
-              HDFIDStore *hdf_store);
+              hsize_t ColumnCount, Value FlatbuffersValueTypeId,
+              CollectiveQueue *cq);
+  WriterArray(hdf5::node::Group, std::string const &source_name,
+              hsize_t ColumnCount, Value FlatbuffersValueTypeId,
+              CollectiveQueue *cq, HDFIDStore *hdf_store);
   h5::append_ret write(FBUF const *fbuf) override;
   void storeLatestInto(std::string const &StoreLatestInto) override;
   uptr<h5::h5d_chunked_2d<DT>> ChunkedDataset;
@@ -32,21 +33,23 @@ public:
 /// \tparam  FV  The Flatbuffers datatype for this dataset
 template <typename DT, typename FV>
 WriterArray<DT, FV>::WriterArray(hdf5::node::Group hdf_group,
-                                 std::string const &source_name, hsize_t ncols,
+                                 std::string const &source_name,
+                                 hsize_t ColumnCount,
                                  Value FlatbuffersValueTypeId,
                                  CollectiveQueue *cq)
     : FlatbuffersValueTypeId(FlatbuffersValueTypeId) {
-  if (ncols <= 0) {
-    LOG(Sev::Error, "can not handle number of columns ncols == {}", ncols);
+  if (ColumnCount <= 0) {
+    LOG(Sev::Error, "can not handle number of columns ColumnCount == {}",
+        ColumnCount);
     return;
   }
-  LOG(Sev::Debug, "f142 init_impl  ncols: {}", ncols);
-  ChunkedDataset = h5::h5d_chunked_2d<DT>::create(hdf_group, source_name, ncols,
-                                                  64 * 1024, cq);
+  LOG(Sev::Debug, "f142 init_impl  ColumnCount: {}", ColumnCount);
+  ChunkedDataset = h5::h5d_chunked_2d<DT>::create(hdf_group, source_name,
+                                                  ColumnCount, 64 * 1024, cq);
   if (ChunkedDataset == nullptr) {
     LOG(Sev::Error,
         "could not create hdf dataset  source_name: {}  number of columns: {}",
-        source_name, ncols);
+        source_name, ColumnCount);
   }
 }
 
@@ -56,21 +59,24 @@ WriterArray<DT, FV>::WriterArray(hdf5::node::Group hdf_group,
 /// \tparam  FV  The Flatbuffers datatype for this dataset
 template <typename DT, typename FV>
 WriterArray<DT, FV>::WriterArray(hdf5::node::Group hdf_group,
-                                 std::string const &source_name, hsize_t ncols,
+                                 std::string const &source_name,
+                                 hsize_t ColumnCount,
                                  Value FlatbuffersValueTypeId,
                                  CollectiveQueue *cq, HDFIDStore *hdf_store)
     : FlatbuffersValueTypeId(FlatbuffersValueTypeId) {
-  if (ncols <= 0) {
-    LOG(Sev::Error, "can not handle number of columns ncols == {}", ncols);
+  if (ColumnCount <= 0) {
+    LOG(Sev::Error, "can not handle number of columns ColumnCount == {}",
+        ColumnCount);
     return;
   }
-  LOG(Sev::Debug, "f142 writer_typed_array reopen  ncols: {}", ncols);
-  ChunkedDataset = h5::h5d_chunked_2d<DT>::open(hdf_group, source_name, ncols,
-                                                cq, hdf_store);
+  LOG(Sev::Debug, "f142 writer_typed_array reopen  ColumnCount: {}",
+      ColumnCount);
+  ChunkedDataset = h5::h5d_chunked_2d<DT>::open(hdf_group, source_name,
+                                                ColumnCount, cq, hdf_store);
   if (ChunkedDataset == nullptr) {
     LOG(Sev::Error,
         "could not create hdf dataset  source_name: {}  number of columns: {}",
-        source_name, ncols);
+        source_name, ColumnCount);
     return;
   }
   ChunkedDataset->buffer_init(ChunkSize, 0);

--- a/src/schemas/f142/WriterArray.h
+++ b/src/schemas/f142/WriterArray.h
@@ -19,6 +19,7 @@ public:
               Value fb_value_type_id, CollectiveQueue *cq,
               HDFIDStore *hdf_store);
   h5::append_ret write_impl(FBUF const *fbuf) override;
+  void storeLatestInto(std::string const &StoreLatestInto) override;
   uptr<h5::h5d_chunked_2d<DT>> ds;
   Value _fb_value_type_id = Value::NONE;
 };
@@ -102,6 +103,43 @@ h5::append_ret WriterArray<DT, FV>::write_impl(LogData const *fbuf) {
     return Result;
   }
   return this->ds->append_data_2d(v2->data(), v2->size());
+}
+
+template <typename DT, typename FV>
+void WriterArray<DT, FV>::storeLatestInto(std::string const &StoreLatestInto) {
+  LOG(Sev::Critical, "LATEST WRITER");
+  auto &Dataset = ds->ds.Dataset;
+  auto Type = Dataset.datatype();
+  auto SpaceSrc = hdf5::dataspace::Simple(Dataset.dataspace());
+  auto DimSrc = SpaceSrc.current_dimensions();
+  if (DimSrc.size() < 2) {
+    throw std::runtime_error("unexpected dimensions");
+  }
+  auto DimMem = DimSrc;
+  for (size_t I = 1; I < DimSrc.size(); ++I) {
+    DimMem.at(I - 1) = DimMem.at(I);
+  }
+  DimMem.resize(DimMem.size() - 1);
+  size_t N = 1;
+  for (size_t I = 0; I < DimMem.size(); ++I) {
+    N *= DimMem.at(I);
+  }
+  hdf5::Dimensions Offset;
+  Offset.resize(DimSrc.size());
+  for (size_t I = 0; I < Offset.size(); ++I) {
+    Offset.at(I) = 0;
+  }
+  Offset.at(0) = ds->ds.snow.at(0) - 1;
+  hdf5::Dimensions Block = DimSrc;
+  Block.at(0) = 1;
+  SpaceSrc.selection(hdf5::dataspace::SelectionOperation::SET,
+                     hdf5::dataspace::Hyperslab(Offset, Block));
+  std::vector<char> Buffer(N * Type.size());
+  hdf5::dataspace::Simple SpaceMem(DimMem);
+  Dataset.read(Buffer, Type, SpaceMem, SpaceSrc);
+  auto Latest =
+      Dataset.link().parent().create_dataset(StoreLatestInto, Type, SpaceMem);
+  Latest.write(Buffer, Type, SpaceMem, SpaceMem);
 }
 }
 }

--- a/src/schemas/f142/WriterArray.h
+++ b/src/schemas/f142/WriterArray.h
@@ -22,7 +22,7 @@ public:
   h5::append_ret write_impl(FBUF const *fbuf) override;
   void storeLatestInto(std::string const &StoreLatestInto) override;
   uptr<h5::h5d_chunked_2d<DT>> ChunkedDataset;
-  Value _fb_value_type_id = Value::NONE;
+  Value FlatbuffersValueTypeId = Value::NONE;
   size_t ChunkSize = 64 * 1024;
 };
 
@@ -33,8 +33,9 @@ public:
 template <typename DT, typename FV>
 WriterArray<DT, FV>::WriterArray(hdf5::node::Group hdf_group,
                                  std::string const &source_name, hsize_t ncols,
-                                 Value fb_value_type_id, CollectiveQueue *cq)
-    : _fb_value_type_id(fb_value_type_id) {
+                                 Value FlatbuffersValueTypeId,
+                                 CollectiveQueue *cq)
+    : FlatbuffersValueTypeId(FlatbuffersValueTypeId) {
   if (ncols <= 0) {
     LOG(Sev::Error, "can not handle number of columns ncols == {}", ncols);
     return;
@@ -56,9 +57,9 @@ WriterArray<DT, FV>::WriterArray(hdf5::node::Group hdf_group,
 template <typename DT, typename FV>
 WriterArray<DT, FV>::WriterArray(hdf5::node::Group hdf_group,
                                  std::string const &source_name, hsize_t ncols,
-                                 Value fb_value_type_id, CollectiveQueue *cq,
-                                 HDFIDStore *hdf_store)
-    : _fb_value_type_id(fb_value_type_id) {
+                                 Value FlatbuffersValueTypeId,
+                                 CollectiveQueue *cq, HDFIDStore *hdf_store)
+    : FlatbuffersValueTypeId(FlatbuffersValueTypeId) {
   if (ncols <= 0) {
     LOG(Sev::Error, "can not handle number of columns ncols == {}", ncols);
     return;
@@ -83,7 +84,7 @@ template <typename DT, typename FV>
 h5::append_ret WriterArray<DT, FV>::write_impl(LogData const *fbuf) {
   h5::append_ret Result{h5::AppendResult::ERROR, 0, 0};
   auto vt = fbuf->value_type();
-  if (vt == Value::NONE || vt != _fb_value_type_id) {
+  if (vt == Value::NONE || vt != FlatbuffersValueTypeId) {
     Result.ErrorString =
         fmt::format("vt == Value::NONE || vt != _fb_value_type_id");
     return Result;

--- a/src/schemas/f142/WriterArray.h
+++ b/src/schemas/f142/WriterArray.h
@@ -19,7 +19,7 @@ public:
   WriterArray(hdf5::node::Group, std::string const &source_name, hsize_t ncols,
               Value fb_value_type_id, CollectiveQueue *cq,
               HDFIDStore *hdf_store);
-  h5::append_ret write_impl(FBUF const *fbuf) override;
+  h5::append_ret write(FBUF const *fbuf) override;
   void storeLatestInto(std::string const &StoreLatestInto) override;
   uptr<h5::h5d_chunked_2d<DT>> ChunkedDataset;
   Value FlatbuffersValueTypeId = Value::NONE;
@@ -81,7 +81,7 @@ WriterArray<DT, FV>::WriterArray(hdf5::node::Group hdf_group,
 /// \tparam  DT  The C datatype for this dataset
 /// \tparam  FV  The Flatbuffers datatype for this dataset
 template <typename DT, typename FV>
-h5::append_ret WriterArray<DT, FV>::write_impl(LogData const *fbuf) {
+h5::append_ret WriterArray<DT, FV>::write(LogData const *fbuf) {
   h5::append_ret Result{h5::AppendResult::ERROR, 0, 0};
   auto vt = fbuf->value_type();
   if (vt == Value::NONE || vt != FlatbuffersValueTypeId) {

--- a/src/schemas/f142/WriterArray.h
+++ b/src/schemas/f142/WriterArray.h
@@ -2,6 +2,7 @@
 
 #include "../../logger.h"
 #include "WriterTypedBase.h"
+#include <numeric>
 
 namespace FileWriter {
 namespace Schemas {
@@ -119,15 +120,10 @@ void WriterArray<DT, FV>::storeLatestInto(std::string const &StoreLatestInto) {
     DimMem.at(I - 1) = DimMem.at(I);
   }
   DimMem.resize(DimMem.size() - 1);
-  size_t N = 1;
-  for (size_t I = 0; I < DimMem.size(); ++I) {
-    N *= DimMem.at(I);
-  }
+  auto N = std::accumulate(DimMem.begin(), DimMem.end(), 1,
+                           std::multiplies<size_t>());
   hdf5::Dimensions Offset;
-  Offset.resize(DimSrc.size());
-  for (size_t I = 0; I < Offset.size(); ++I) {
-    Offset.at(I) = 0;
-  }
+  Offset.assign(DimSrc.size(), 0);
   if (DimSrc.at(0) == 0) {
     return;
   }

--- a/src/schemas/f142/WriterArray.h
+++ b/src/schemas/f142/WriterArray.h
@@ -107,7 +107,6 @@ h5::append_ret WriterArray<DT, FV>::write_impl(LogData const *fbuf) {
 
 template <typename DT, typename FV>
 void WriterArray<DT, FV>::storeLatestInto(std::string const &StoreLatestInto) {
-  LOG(Sev::Critical, "LATEST WRITER");
   auto &Dataset = ds->ds.Dataset;
   auto Type = Dataset.datatype();
   auto SpaceSrc = hdf5::dataspace::Simple(Dataset.dataspace());

--- a/src/schemas/f142/WriterArray.h
+++ b/src/schemas/f142/WriterArray.h
@@ -14,10 +14,10 @@ namespace f142 {
 /// \tparam  FV  The Flatbuffers datatype for this dataset
 template <typename DT, typename FV> class WriterArray : public WriterTypedBase {
 public:
-  WriterArray(hdf5::node::Group HdfGroup, std::string const &source_name,
+  WriterArray(hdf5::node::Group HdfGroup, std::string const &SourceName,
               hsize_t ColumnCount, Value FlatbuffersValueTypeId,
               CollectiveQueue *cq);
-  WriterArray(hdf5::node::Group HdfGroup, std::string const &source_name,
+  WriterArray(hdf5::node::Group HdfGroup, std::string const &SourceName,
               hsize_t ColumnCount, Value FlatbuffersValueTypeId,
               CollectiveQueue *cq, HDFIDStore *hdf_store);
   h5::append_ret write(FBUF const *fbuf) override;
@@ -33,7 +33,7 @@ public:
 /// \tparam  FV  The Flatbuffers datatype for this dataset
 template <typename DT, typename FV>
 WriterArray<DT, FV>::WriterArray(hdf5::node::Group HdfGroup,
-                                 std::string const &source_name,
+                                 std::string const &SourceName,
                                  hsize_t ColumnCount,
                                  Value FlatbuffersValueTypeId,
                                  CollectiveQueue *cq)
@@ -44,12 +44,12 @@ WriterArray<DT, FV>::WriterArray(hdf5::node::Group HdfGroup,
     return;
   }
   LOG(Sev::Debug, "f142 init_impl  ColumnCount: {}", ColumnCount);
-  ChunkedDataset = h5::h5d_chunked_2d<DT>::create(HdfGroup, source_name,
+  ChunkedDataset = h5::h5d_chunked_2d<DT>::create(HdfGroup, SourceName,
                                                   ColumnCount, 64 * 1024, cq);
   if (ChunkedDataset == nullptr) {
     LOG(Sev::Error,
-        "could not create hdf dataset  source_name: {}  number of columns: {}",
-        source_name, ColumnCount);
+        "could not create hdf dataset  SourceName: {}  number of columns: {}",
+        SourceName, ColumnCount);
   }
 }
 
@@ -59,7 +59,7 @@ WriterArray<DT, FV>::WriterArray(hdf5::node::Group HdfGroup,
 /// \tparam  FV  The Flatbuffers datatype for this dataset
 template <typename DT, typename FV>
 WriterArray<DT, FV>::WriterArray(hdf5::node::Group HdfGroup,
-                                 std::string const &source_name,
+                                 std::string const &SourceName,
                                  hsize_t ColumnCount,
                                  Value FlatbuffersValueTypeId,
                                  CollectiveQueue *cq, HDFIDStore *hdf_store)
@@ -71,12 +71,12 @@ WriterArray<DT, FV>::WriterArray(hdf5::node::Group HdfGroup,
   }
   LOG(Sev::Debug, "f142 writer_typed_array reopen  ColumnCount: {}",
       ColumnCount);
-  ChunkedDataset = h5::h5d_chunked_2d<DT>::open(HdfGroup, source_name,
+  ChunkedDataset = h5::h5d_chunked_2d<DT>::open(HdfGroup, SourceName,
                                                 ColumnCount, cq, hdf_store);
   if (ChunkedDataset == nullptr) {
     LOG(Sev::Error,
-        "could not create hdf dataset  source_name: {}  number of columns: {}",
-        source_name, ColumnCount);
+        "could not create hdf dataset  SourceName: {}  number of columns: {}",
+        SourceName, ColumnCount);
     return;
   }
   ChunkedDataset->buffer_init(ChunkSize, 0);

--- a/src/schemas/f142/WriterArray.h
+++ b/src/schemas/f142/WriterArray.h
@@ -15,9 +15,9 @@ namespace f142 {
 template <typename DT, typename FV> class WriterArray : public WriterTypedBase {
 public:
   WriterArray(hdf5::node::Group hdf_group, std::string const &source_name,
-              hsize_t ncols, Value fb_value_type_id, CollectiveQueue *cq);
+              hsize_t ncols, Value FlatbuffersValueTypeId, CollectiveQueue *cq);
   WriterArray(hdf5::node::Group, std::string const &source_name, hsize_t ncols,
-              Value fb_value_type_id, CollectiveQueue *cq,
+              Value FlatbuffersValueTypeId, CollectiveQueue *cq,
               HDFIDStore *hdf_store);
   h5::append_ret write(FBUF const *fbuf) override;
   void storeLatestInto(std::string const &StoreLatestInto) override;
@@ -86,7 +86,7 @@ h5::append_ret WriterArray<DT, FV>::write(LogData const *fbuf) {
   auto vt = fbuf->value_type();
   if (vt == Value::NONE || vt != FlatbuffersValueTypeId) {
     Result.ErrorString =
-        fmt::format("vt == Value::NONE || vt != _fb_value_type_id");
+        fmt::format("vt == Value::NONE || vt != FlatbuffersValueTypeId");
     return Result;
   }
   auto v1 = (FV const *)fbuf->value();

--- a/src/schemas/f142/WriterScalar.h
+++ b/src/schemas/f142/WriterScalar.h
@@ -23,6 +23,7 @@ public:
   void storeLatestInto(std::string const &StoreLatestInto) override;
   uptr<h5::h5d_chunked_1d<DT>> ChunkedDataset;
   Value FlatbuffersValueTypeId = Value::NONE;
+  size_t ChunkSize = 64 * 1024;
 };
 
 /// \brief  Create a new dataset for scalar numeric types
@@ -61,8 +62,7 @@ WriterScalar<DT, FV>::WriterScalar(hdf5::node::Group hdf_group,
     LOG(Sev::Error, "could not create hdf dataset  source_name: {}",
         source_name);
   }
-  // TODO take from config
-  ChunkedDataset->buffer_init(64 * 1024, 0);
+  ChunkedDataset->buffer_init(ChunkSize, 0);
 }
 
 /// \brief  Write to a numeric scalar dataset

--- a/src/schemas/f142/WriterScalar.h
+++ b/src/schemas/f142/WriterScalar.h
@@ -91,7 +91,6 @@ h5::append_ret WriterScalar<DT, FV>::write_impl(LogData const *Buffer) {
 
 template <typename DT, typename FV>
 void WriterScalar<DT, FV>::storeLatestInto(std::string const &StoreLatestInto) {
-  LOG(Sev::Critical, "LATEST WRITER");
   auto &Dataset = ds->ds.Dataset;
   auto Type = Dataset.datatype();
   auto SpaceSrc = hdf5::dataspace::Simple(Dataset.dataspace());

--- a/src/schemas/f142/WriterScalar.h
+++ b/src/schemas/f142/WriterScalar.h
@@ -19,7 +19,7 @@ public:
   WriterScalar(hdf5::node::Group hdf_group, std::string const &source_name,
                Value fb_value_type_id, CollectiveQueue *cq,
                HDFIDStore *hdf_store);
-  h5::append_ret write_impl(FBUF const *fbuf) override;
+  h5::append_ret write(FBUF const *fbuf) override;
   void storeLatestInto(std::string const &StoreLatestInto) override;
   uptr<h5::h5d_chunked_1d<DT>> ds;
   Value _fb_value_type_id = Value::NONE;
@@ -68,7 +68,7 @@ WriterScalar<DT, FV>::WriterScalar(hdf5::node::Group hdf_group,
 /// \tparam  DT  The C datatype for this dataset
 /// \tparam  FV  The Flatbuffers datatype for this dataset
 template <typename DT, typename FV>
-h5::append_ret WriterScalar<DT, FV>::write_impl(LogData const *Buffer) {
+h5::append_ret WriterScalar<DT, FV>::write(LogData const *Buffer) {
   h5::append_ret Result{h5::AppendResult::ERROR, 0, 0};
   auto ValueType = Buffer->value_type();
   if (ValueType == Value::NONE || ValueType != _fb_value_type_id) {

--- a/src/schemas/f142/WriterScalar.h
+++ b/src/schemas/f142/WriterScalar.h
@@ -113,16 +113,24 @@ void WriterScalar<DT, FV>::storeLatestInto(std::string const &StoreLatestInto) {
   for (size_t I = 0; I < Offset.size(); ++I) {
     Offset.at(I) = 0;
   }
+  if (DimSrc.at(0) == 0) {
+    return;
+  }
+  hdf5::dataspace::Simple SpaceMem(DimMem);
+  hdf5::node::Dataset Latest;
+  try {
+    Latest = Dataset.link().parent().get_dataset(StoreLatestInto);
+  } catch (...) {
+    Latest =
+        Dataset.link().parent().create_dataset(StoreLatestInto, Type, SpaceMem);
+  }
   Offset.at(0) = ds->ds.snow.at(0) - 1;
   hdf5::Dimensions Block = DimSrc;
   Block.at(0) = 1;
   SpaceSrc.selection(hdf5::dataspace::SelectionOperation::SET,
                      hdf5::dataspace::Hyperslab(Offset, Block));
   std::vector<char> Buffer(N * Type.size());
-  hdf5::dataspace::Simple SpaceMem(DimMem);
   Dataset.read(Buffer, Type, SpaceMem, SpaceSrc);
-  auto Latest =
-      Dataset.link().parent().create_dataset(StoreLatestInto, Type, SpaceMem);
   Latest.write(Buffer, Type, SpaceMem, SpaceMem);
 }
 }

--- a/src/schemas/f142/WriterScalar.h
+++ b/src/schemas/f142/WriterScalar.h
@@ -20,6 +20,7 @@ public:
                Value fb_value_type_id, CollectiveQueue *cq,
                HDFIDStore *hdf_store);
   h5::append_ret write_impl(FBUF const *fbuf) override;
+  void storeLatestInto(std::string const &StoreLatestInto) override;
   uptr<h5::h5d_chunked_1d<DT>> ds;
   Value _fb_value_type_id = Value::NONE;
 };
@@ -86,6 +87,43 @@ h5::append_ret WriterScalar<DT, FV>::write_impl(LogData const *Buffer) {
     return Result;
   }
   return this->ds->append_data_1d(&Value, 1);
+}
+
+template <typename DT, typename FV>
+void WriterScalar<DT, FV>::storeLatestInto(std::string const &StoreLatestInto) {
+  LOG(Sev::Critical, "LATEST WRITER");
+  auto &Dataset = ds->ds.Dataset;
+  auto Type = Dataset.datatype();
+  auto SpaceSrc = hdf5::dataspace::Simple(Dataset.dataspace());
+  auto DimSrc = SpaceSrc.current_dimensions();
+  if (DimSrc.size() < 1) {
+    throw std::runtime_error("unexpected dimensions");
+  }
+  auto DimMem = DimSrc;
+  for (size_t I = 1; I < DimSrc.size(); ++I) {
+    DimMem.at(I - 1) = DimMem.at(I);
+  }
+  DimMem.resize(DimMem.size() - 1);
+  size_t N = 1;
+  for (size_t I = 0; I < DimMem.size(); ++I) {
+    N *= DimMem.at(I);
+  }
+  hdf5::Dimensions Offset;
+  Offset.resize(DimSrc.size());
+  for (size_t I = 0; I < Offset.size(); ++I) {
+    Offset.at(I) = 0;
+  }
+  Offset.at(0) = ds->ds.snow.at(0) - 1;
+  hdf5::Dimensions Block = DimSrc;
+  Block.at(0) = 1;
+  SpaceSrc.selection(hdf5::dataspace::SelectionOperation::SET,
+                     hdf5::dataspace::Hyperslab(Offset, Block));
+  std::vector<char> Buffer(N * Type.size());
+  hdf5::dataspace::Simple SpaceMem(DimMem);
+  Dataset.read(Buffer, Type, SpaceMem, SpaceSrc);
+  auto Latest =
+      Dataset.link().parent().create_dataset(StoreLatestInto, Type, SpaceMem);
+  Latest.write(Buffer, Type, SpaceMem, SpaceMem);
 }
 }
 }

--- a/src/schemas/f142/WriterScalar.h
+++ b/src/schemas/f142/WriterScalar.h
@@ -22,7 +22,7 @@ public:
   h5::append_ret write(FBUF const *fbuf) override;
   void storeLatestInto(std::string const &StoreLatestInto) override;
   uptr<h5::h5d_chunked_1d<DT>> ChunkedDataset;
-  Value _fb_value_type_id = Value::NONE;
+  Value FlatbuffersValueTypeId = Value::NONE;
 };
 
 /// \brief  Create a new dataset for scalar numeric types
@@ -32,8 +32,9 @@ public:
 template <typename DT, typename FV>
 WriterScalar<DT, FV>::WriterScalar(hdf5::node::Group hdf_group,
                                    std::string const &source_name,
-                                   Value fb_value_type_id, CollectiveQueue *cq)
-    : _fb_value_type_id(fb_value_type_id) {
+                                   Value FlatbuffersValueTypeId,
+                                   CollectiveQueue *cq)
+    : FlatbuffersValueTypeId(FlatbuffersValueTypeId) {
   LOG(Sev::Debug, "f142 WriterScalar ctor");
   ChunkedDataset =
       h5::h5d_chunked_1d<DT>::create(hdf_group, source_name, 64 * 1024, cq);
@@ -50,9 +51,9 @@ WriterScalar<DT, FV>::WriterScalar(hdf5::node::Group hdf_group,
 template <typename DT, typename FV>
 WriterScalar<DT, FV>::WriterScalar(hdf5::node::Group hdf_group,
                                    std::string const &source_name,
-                                   Value fb_value_type_id, CollectiveQueue *cq,
-                                   HDFIDStore *hdf_store)
-    : _fb_value_type_id(fb_value_type_id) {
+                                   Value FlatbuffersValueTypeId,
+                                   CollectiveQueue *cq, HDFIDStore *hdf_store)
+    : FlatbuffersValueTypeId(FlatbuffersValueTypeId) {
   LOG(Sev::Debug, "f142 WriterScalar ctor");
   ChunkedDataset =
       h5::h5d_chunked_1d<DT>::open(hdf_group, source_name, cq, hdf_store);
@@ -72,9 +73,9 @@ template <typename DT, typename FV>
 h5::append_ret WriterScalar<DT, FV>::write(LogData const *Buffer) {
   h5::append_ret Result{h5::AppendResult::ERROR, 0, 0};
   auto ValueType = Buffer->value_type();
-  if (ValueType == Value::NONE || ValueType != _fb_value_type_id) {
+  if (ValueType == Value::NONE || ValueType != FlatbuffersValueTypeId) {
     Result.ErrorString = fmt::format(
-        "ValueType == Value::NONE || ValueType != _fb_value_type_id");
+        "ValueType == Value::NONE || ValueType != FlatbuffersValueTypeId");
     return Result;
   }
   auto ValueMember = (FV const *)Buffer->value();

--- a/src/schemas/f142/WriterScalar.h
+++ b/src/schemas/f142/WriterScalar.h
@@ -38,7 +38,7 @@ WriterScalar<DT, FV>::WriterScalar(hdf5::node::Group HdfGroup,
     : FlatbuffersValueTypeId(FlatbuffersValueTypeId) {
   LOG(Sev::Debug, "f142 WriterScalar ctor");
   ChunkedDataset =
-      h5::h5d_chunked_1d<DT>::create(HdfGroup, SourceName, 64 * 1024, cq);
+      h5::h5d_chunked_1d<DT>::create(HdfGroup, SourceName, ChunkSize, cq);
   if (ChunkedDataset == nullptr) {
     LOG(Sev::Error, "could not create hdf dataset  SourceName: {}", SourceName);
   }
@@ -123,7 +123,7 @@ void WriterScalar<DT, FV>::storeLatestInto(std::string const &StoreLatestInto) {
     Latest =
         Dataset.link().parent().create_dataset(StoreLatestInto, Type, SpaceMem);
   }
-  Offset.at(0) = ChunkedDataset->ds.snow.at(0) - 1;
+  Offset.at(0) = ChunkedDataset->size() - 1;
   hdf5::Dimensions Block = DimSrc;
   Block.at(0) = 1;
   SpaceSrc.selection(hdf5::dataspace::SelectionOperation::SET,

--- a/src/schemas/f142/WriterScalar.h
+++ b/src/schemas/f142/WriterScalar.h
@@ -14,9 +14,9 @@ namespace f142 {
 template <typename DT, typename FV>
 class WriterScalar : public WriterTypedBase {
 public:
-  WriterScalar(hdf5::node::Group HdfGroup, std::string const &source_name,
+  WriterScalar(hdf5::node::Group HdfGroup, std::string const &SourceName,
                Value fb_value_type_id, CollectiveQueue *cq);
-  WriterScalar(hdf5::node::Group HdfGroup, std::string const &source_name,
+  WriterScalar(hdf5::node::Group HdfGroup, std::string const &SourceName,
                Value fb_value_type_id, CollectiveQueue *cq,
                HDFIDStore *hdf_store);
   h5::append_ret write(FBUF const *fbuf) override;
@@ -32,16 +32,15 @@ public:
 /// \tparam  FV  The Flatbuffers datatype for this dataset
 template <typename DT, typename FV>
 WriterScalar<DT, FV>::WriterScalar(hdf5::node::Group HdfGroup,
-                                   std::string const &source_name,
+                                   std::string const &SourceName,
                                    Value FlatbuffersValueTypeId,
                                    CollectiveQueue *cq)
     : FlatbuffersValueTypeId(FlatbuffersValueTypeId) {
   LOG(Sev::Debug, "f142 WriterScalar ctor");
   ChunkedDataset =
-      h5::h5d_chunked_1d<DT>::create(HdfGroup, source_name, 64 * 1024, cq);
+      h5::h5d_chunked_1d<DT>::create(HdfGroup, SourceName, 64 * 1024, cq);
   if (ChunkedDataset == nullptr) {
-    LOG(Sev::Error, "could not create hdf dataset  source_name: {}",
-        source_name);
+    LOG(Sev::Error, "could not create hdf dataset  SourceName: {}", SourceName);
   }
 }
 
@@ -51,16 +50,15 @@ WriterScalar<DT, FV>::WriterScalar(hdf5::node::Group HdfGroup,
 /// \tparam  FV  The Flatbuffers datatype for this dataset
 template <typename DT, typename FV>
 WriterScalar<DT, FV>::WriterScalar(hdf5::node::Group HdfGroup,
-                                   std::string const &source_name,
+                                   std::string const &SourceName,
                                    Value FlatbuffersValueTypeId,
                                    CollectiveQueue *cq, HDFIDStore *hdf_store)
     : FlatbuffersValueTypeId(FlatbuffersValueTypeId) {
   LOG(Sev::Debug, "f142 WriterScalar ctor");
   ChunkedDataset =
-      h5::h5d_chunked_1d<DT>::open(HdfGroup, source_name, cq, hdf_store);
+      h5::h5d_chunked_1d<DT>::open(HdfGroup, SourceName, cq, hdf_store);
   if (ChunkedDataset == nullptr) {
-    LOG(Sev::Error, "could not create hdf dataset  source_name: {}",
-        source_name);
+    LOG(Sev::Error, "could not create hdf dataset  SourceName: {}", SourceName);
   }
   ChunkedDataset->buffer_init(ChunkSize, 0);
 }

--- a/src/schemas/f142/WriterScalar.h
+++ b/src/schemas/f142/WriterScalar.h
@@ -14,9 +14,9 @@ namespace f142 {
 template <typename DT, typename FV>
 class WriterScalar : public WriterTypedBase {
 public:
-  WriterScalar(hdf5::node::Group hdf_group, std::string const &source_name,
+  WriterScalar(hdf5::node::Group HdfGroup, std::string const &source_name,
                Value fb_value_type_id, CollectiveQueue *cq);
-  WriterScalar(hdf5::node::Group hdf_group, std::string const &source_name,
+  WriterScalar(hdf5::node::Group HdfGroup, std::string const &source_name,
                Value fb_value_type_id, CollectiveQueue *cq,
                HDFIDStore *hdf_store);
   h5::append_ret write(FBUF const *fbuf) override;
@@ -31,14 +31,14 @@ public:
 /// \tparam  DT  The C datatype for this dataset
 /// \tparam  FV  The Flatbuffers datatype for this dataset
 template <typename DT, typename FV>
-WriterScalar<DT, FV>::WriterScalar(hdf5::node::Group hdf_group,
+WriterScalar<DT, FV>::WriterScalar(hdf5::node::Group HdfGroup,
                                    std::string const &source_name,
                                    Value FlatbuffersValueTypeId,
                                    CollectiveQueue *cq)
     : FlatbuffersValueTypeId(FlatbuffersValueTypeId) {
   LOG(Sev::Debug, "f142 WriterScalar ctor");
   ChunkedDataset =
-      h5::h5d_chunked_1d<DT>::create(hdf_group, source_name, 64 * 1024, cq);
+      h5::h5d_chunked_1d<DT>::create(HdfGroup, source_name, 64 * 1024, cq);
   if (ChunkedDataset == nullptr) {
     LOG(Sev::Error, "could not create hdf dataset  source_name: {}",
         source_name);
@@ -50,14 +50,14 @@ WriterScalar<DT, FV>::WriterScalar(hdf5::node::Group hdf_group,
 /// \tparam  DT  The C datatype for this dataset
 /// \tparam  FV  The Flatbuffers datatype for this dataset
 template <typename DT, typename FV>
-WriterScalar<DT, FV>::WriterScalar(hdf5::node::Group hdf_group,
+WriterScalar<DT, FV>::WriterScalar(hdf5::node::Group HdfGroup,
                                    std::string const &source_name,
                                    Value FlatbuffersValueTypeId,
                                    CollectiveQueue *cq, HDFIDStore *hdf_store)
     : FlatbuffersValueTypeId(FlatbuffersValueTypeId) {
   LOG(Sev::Debug, "f142 WriterScalar ctor");
   ChunkedDataset =
-      h5::h5d_chunked_1d<DT>::open(hdf_group, source_name, cq, hdf_store);
+      h5::h5d_chunked_1d<DT>::open(HdfGroup, source_name, cq, hdf_store);
   if (ChunkedDataset == nullptr) {
     LOG(Sev::Error, "could not create hdf dataset  source_name: {}",
         source_name);

--- a/src/schemas/f142/WriterScalarString.cpp
+++ b/src/schemas/f142/WriterScalarString.cpp
@@ -6,30 +6,28 @@ namespace f142 {
 
 /// \brief  Create a new dataset for scalar stringss
 WriterScalarString::WriterScalarString(hdf5::node::Group HdfGroup,
-                                       std::string const &source_name,
+                                       std::string const &SourceName,
                                        Value fb_value_type_id,
                                        CollectiveQueue *cq) {
   LOG(Sev::Debug, "f142 init_impl  WriterScalarString");
   ChunkedDataset =
-      h5::Chunked1DString::create(HdfGroup, source_name, 64 * 1024, cq);
+      h5::Chunked1DString::create(HdfGroup, SourceName, 64 * 1024, cq);
   if (ChunkedDataset == nullptr) {
-    LOG(Sev::Error, "could not create hdf dataset  source_name: {}",
-        source_name);
+    LOG(Sev::Error, "could not create hdf dataset  SourceName: {}", SourceName);
   }
 }
 
 /// \brief  Open a dataset for scalar strings
 WriterScalarString::WriterScalarString(hdf5::node::Group HdfGroup,
-                                       std::string const &source_name,
+                                       std::string const &SourceName,
                                        Value fb_value_type_id,
                                        CollectiveQueue *cq,
                                        HDFIDStore *hdf_store) {
   LOG(Sev::Debug, "f142 init_impl  WriterScalarString");
   ChunkedDataset =
-      h5::Chunked1DString::open(HdfGroup, source_name, cq, hdf_store);
+      h5::Chunked1DString::open(HdfGroup, SourceName, cq, hdf_store);
   if (ChunkedDataset == nullptr) {
-    LOG(Sev::Error, "could not create hdf dataset  source_name: {}",
-        source_name);
+    LOG(Sev::Error, "could not create hdf dataset  SourceName: {}", SourceName);
   }
 }
 

--- a/src/schemas/f142/WriterScalarString.cpp
+++ b/src/schemas/f142/WriterScalarString.cpp
@@ -5,13 +5,13 @@ namespace Schemas {
 namespace f142 {
 
 /// \brief  Create a new dataset for scalar stringss
-WriterScalarString::WriterScalarString(hdf5::node::Group hdf_group,
+WriterScalarString::WriterScalarString(hdf5::node::Group HdfGroup,
                                        std::string const &source_name,
                                        Value fb_value_type_id,
                                        CollectiveQueue *cq) {
   LOG(Sev::Debug, "f142 init_impl  WriterScalarString");
   ChunkedDataset =
-      h5::Chunked1DString::create(hdf_group, source_name, 64 * 1024, cq);
+      h5::Chunked1DString::create(HdfGroup, source_name, 64 * 1024, cq);
   if (ChunkedDataset == nullptr) {
     LOG(Sev::Error, "could not create hdf dataset  source_name: {}",
         source_name);
@@ -19,14 +19,14 @@ WriterScalarString::WriterScalarString(hdf5::node::Group hdf_group,
 }
 
 /// \brief  Open a dataset for scalar strings
-WriterScalarString::WriterScalarString(hdf5::node::Group hdf_group,
+WriterScalarString::WriterScalarString(hdf5::node::Group HdfGroup,
                                        std::string const &source_name,
                                        Value fb_value_type_id,
                                        CollectiveQueue *cq,
                                        HDFIDStore *hdf_store) {
   LOG(Sev::Debug, "f142 init_impl  WriterScalarString");
   ChunkedDataset =
-      h5::Chunked1DString::open(hdf_group, source_name, cq, hdf_store);
+      h5::Chunked1DString::open(HdfGroup, source_name, cq, hdf_store);
   if (ChunkedDataset == nullptr) {
     LOG(Sev::Error, "could not create hdf dataset  source_name: {}",
         source_name);

--- a/src/schemas/f142/WriterScalarString.cpp
+++ b/src/schemas/f142/WriterScalarString.cpp
@@ -32,7 +32,7 @@ WriterScalarString::WriterScalarString(hdf5::node::Group hdf_group,
 }
 
 /// \brief  Write to a scalar string dataset
-h5::append_ret WriterScalarString::write_impl(LogData const *fbuf) {
+h5::append_ret WriterScalarString::write(LogData const *fbuf) {
   auto vt = fbuf->value_type();
   if (vt != Value::String) {
     return {h5::AppendResult::ERROR, 0, 0};

--- a/src/schemas/f142/WriterScalarString.cpp
+++ b/src/schemas/f142/WriterScalarString.cpp
@@ -10,8 +10,9 @@ WriterScalarString::WriterScalarString(hdf5::node::Group hdf_group,
                                        Value fb_value_type_id,
                                        CollectiveQueue *cq) {
   LOG(Sev::Debug, "f142 init_impl  WriterScalarString");
-  this->ds = h5::Chunked1DString::create(hdf_group, source_name, 64 * 1024, cq);
-  if (!this->ds) {
+  ChunkedDataset =
+      h5::Chunked1DString::create(hdf_group, source_name, 64 * 1024, cq);
+  if (ChunkedDataset == nullptr) {
     LOG(Sev::Error, "could not create hdf dataset  source_name: {}",
         source_name);
   }
@@ -24,8 +25,9 @@ WriterScalarString::WriterScalarString(hdf5::node::Group hdf_group,
                                        CollectiveQueue *cq,
                                        HDFIDStore *hdf_store) {
   LOG(Sev::Debug, "f142 init_impl  WriterScalarString");
-  ds = h5::Chunked1DString::open(hdf_group, source_name, cq, hdf_store);
-  if (!this->ds) {
+  ChunkedDataset =
+      h5::Chunked1DString::open(hdf_group, source_name, cq, hdf_store);
+  if (ChunkedDataset == nullptr) {
     LOG(Sev::Error, "could not create hdf dataset  source_name: {}",
         source_name);
   }
@@ -42,10 +44,10 @@ h5::append_ret WriterScalarString::write(LogData const *fbuf) {
     return {h5::AppendResult::ERROR, 0, 0};
   }
   auto v2 = v1->value();
-  if (!this->ds) {
+  if (ChunkedDataset == nullptr) {
     return {h5::AppendResult::ERROR, 0, 0};
   }
-  return this->ds->append(v2->str());
+  return ChunkedDataset->append(v2->str());
 }
 }
 }

--- a/src/schemas/f142/WriterScalarString.h
+++ b/src/schemas/f142/WriterScalarString.h
@@ -17,7 +17,7 @@ public:
                      std::string const &source_name, Value fb_value_type_id,
                      CollectiveQueue *cq, HDFIDStore *hdf_store);
   h5::append_ret write(FBUF const *fbuf) override;
-  h5::Chunked1DString::ptr ds;
+  h5::Chunked1DString::ptr ChunkedDataset;
   Value _fb_value_type_id = Value::String;
 };
 }

--- a/src/schemas/f142/WriterScalarString.h
+++ b/src/schemas/f142/WriterScalarString.h
@@ -16,7 +16,7 @@ public:
   WriterScalarString(hdf5::node::Group hdf_group,
                      std::string const &source_name, Value fb_value_type_id,
                      CollectiveQueue *cq, HDFIDStore *hdf_store);
-  h5::append_ret write_impl(FBUF const *fbuf) override;
+  h5::append_ret write(FBUF const *fbuf) override;
   h5::Chunked1DString::ptr ds;
   Value _fb_value_type_id = Value::String;
 };

--- a/src/schemas/f142/WriterScalarString.h
+++ b/src/schemas/f142/WriterScalarString.h
@@ -11,14 +11,15 @@ namespace f142 {
 class WriterScalarString : public WriterTypedBase {
 public:
   WriterScalarString(hdf5::node::Group hdf_group,
-                     std::string const &source_name, Value fb_value_type_id,
-                     CollectiveQueue *cq);
+                     std::string const &source_name,
+                     Value FlatbuffersValueTypeId, CollectiveQueue *cq);
   WriterScalarString(hdf5::node::Group hdf_group,
-                     std::string const &source_name, Value fb_value_type_id,
-                     CollectiveQueue *cq, HDFIDStore *hdf_store);
+                     std::string const &source_name,
+                     Value FlatbuffersValueTypeId, CollectiveQueue *cq,
+                     HDFIDStore *hdf_store);
   h5::append_ret write(FBUF const *fbuf) override;
   h5::Chunked1DString::ptr ChunkedDataset;
-  Value _fb_value_type_id = Value::String;
+  Value FlatbuffersValueTypeId = Value::String;
 };
 }
 }

--- a/src/schemas/f142/WriterScalarString.h
+++ b/src/schemas/f142/WriterScalarString.h
@@ -10,11 +10,9 @@ namespace f142 {
 /// \brief  Implementation for scalar strings
 class WriterScalarString : public WriterTypedBase {
 public:
-  WriterScalarString(hdf5::node::Group hdf_group,
-                     std::string const &source_name,
+  WriterScalarString(hdf5::node::Group HdfGroup, std::string const &source_name,
                      Value FlatbuffersValueTypeId, CollectiveQueue *cq);
-  WriterScalarString(hdf5::node::Group hdf_group,
-                     std::string const &source_name,
+  WriterScalarString(hdf5::node::Group HdfGroup, std::string const &source_name,
                      Value FlatbuffersValueTypeId, CollectiveQueue *cq,
                      HDFIDStore *hdf_store);
   h5::append_ret write(FBUF const *fbuf) override;

--- a/src/schemas/f142/WriterScalarString.h
+++ b/src/schemas/f142/WriterScalarString.h
@@ -10,9 +10,9 @@ namespace f142 {
 /// \brief  Implementation for scalar strings
 class WriterScalarString : public WriterTypedBase {
 public:
-  WriterScalarString(hdf5::node::Group HdfGroup, std::string const &source_name,
+  WriterScalarString(hdf5::node::Group HdfGroup, std::string const &SourceName,
                      Value FlatbuffersValueTypeId, CollectiveQueue *cq);
-  WriterScalarString(hdf5::node::Group HdfGroup, std::string const &source_name,
+  WriterScalarString(hdf5::node::Group HdfGroup, std::string const &SourceName,
                      Value FlatbuffersValueTypeId, CollectiveQueue *cq,
                      HDFIDStore *hdf_store);
   h5::append_ret write(FBUF const *fbuf) override;

--- a/src/schemas/f142/WriterTypedBase.h
+++ b/src/schemas/f142/WriterTypedBase.h
@@ -11,7 +11,7 @@ namespace f142 {
 class WriterTypedBase {
 public:
   virtual ~WriterTypedBase() = default;
-  virtual h5::append_ret write_impl(FBUF const *fbuf) = 0;
+  virtual h5::append_ret write(FBUF const *fbuf) = 0;
   virtual void storeLatestInto(std::string const &StoreLatestInto) {}
 };
 }

--- a/src/schemas/f142/WriterTypedBase.h
+++ b/src/schemas/f142/WriterTypedBase.h
@@ -12,6 +12,7 @@ class WriterTypedBase {
 public:
   virtual ~WriterTypedBase() = default;
   virtual h5::append_ret write_impl(FBUF const *fbuf) = 0;
+  virtual void storeLatestInto(std::string const &StoreLatestInto) {}
 };
 }
 }

--- a/src/schemas/f142/f142_rw.cpp
+++ b/src/schemas/f142/f142_rw.cpp
@@ -157,7 +157,7 @@ void HDFWriterModule::parse_config(std::string const &ConfigurationStream,
   }
 
   LOG(Sev::Debug,
-      "HDFWriterModule::parse_config f142 source_name: {}  type: {}  "
+      "HDFWriterModule::parse_config f142 SourceName: {}  type: {}  "
       "array_size: {}",
       SourceName, TypeName, ArraySize);
 

--- a/src/schemas/f142/f142_rw.cpp
+++ b/src/schemas/f142/f142_rw.cpp
@@ -280,7 +280,7 @@ HDFWriterModule::write(FlatbufferMessage const &Message) {
     }
     return HDFWriterModule::WriteResult::ERROR_IO();
   }
-  auto wret = ValueWriter->write_impl(fbuf);
+  auto wret = ValueWriter->write(fbuf);
   if (!wret) {
     auto Now = CLOCK::now();
     if (Now > TimestampLastErrorLog + ErrorLogMinInterval) {

--- a/src/schemas/f142/f142_rw.cpp
+++ b/src/schemas/f142/f142_rw.cpp
@@ -147,7 +147,8 @@ void HDFWriterModule::parse_config(std::string const &ConfigurationStream,
   if (auto TypeNameMaybe = find<std::string>("type", ConfigurationStreamJson)) {
     TypeName = TypeNameMaybe.inner();
   } else {
-    return;
+    throw std::runtime_error(
+        fmt::format("Missing key \"type\" in f142 writer configuration"));
   }
 
   if (auto ArraySizeMaybe =
@@ -175,6 +176,11 @@ void HDFWriterModule::parse_config(std::string const &ConfigurationStream,
         1024 * 1024;
     LOG(Sev::Debug, "index_every_bytes: {}", IndexEveryBytes);
   } catch (...) { /* it's ok if not found */
+  }
+  if (ConfigurationStreamJson.find("store_latest_into") !=
+      ConfigurationStreamJson.end()) {
+    StoreLatestInto = ConfigurationStreamJson["store_latest_into"];
+    LOG(Sev::Debug, "StoreLatestInto: {}", StoreLatestInto);
   }
 }
 
@@ -335,6 +341,9 @@ int32_t HDFWriterModule::flush() {
 
 /// \brief  Implement HDFWriterModule interface.
 int32_t HDFWriterModule::close() {
+  if (!StoreLatestInto.empty()) {
+    ValueWriter->storeLatestInto(StoreLatestInto);
+  }
   for (auto const &Info : DatasetInfoList) {
     Info.Ptr.reset();
   }

--- a/src/schemas/f142/f142_rw.h
+++ b/src/schemas/f142/f142_rw.h
@@ -99,6 +99,7 @@ public:
   uint64_t IndexEveryBytes = std::numeric_limits<uint64_t>::max();
   uint64_t TimestampMax = 0;
   size_t ArraySize = 0;
+  std::string StoreLatestInto;
 
   // Helper for experiments on my other branch
   void enable_cq(CollectiveQueue *cq, HDFIDStore *hdf_store,

--- a/src/tests/Schema_f142.cpp
+++ b/src/tests/Schema_f142.cpp
@@ -194,6 +194,55 @@ TEST(Schema_f142, writeScalarString) {
   }
 }
 
+TEST(Schema_f142, writeScalarFloatWithLatestWithoutContent) {
+  auto StreamJson = json::parse(R""({
+    "source": "the_source_01",
+    "writer_module": "f142",
+    "store_latest_into": "the_latest_value",
+    "type": "float"
+  })"");
+  auto File = createInMemoryTestFile(
+      "Schema_f142.writeScalarFloatWithLatestWithoutContent");
+  {
+    FileWriter::Schemas::f142::HDFWriterModule WriterModule;
+    WriterModule.parse_config(StreamJson.dump(), "{}");
+    auto Group = File.root();
+    WriterModule.init_hdf(Group, "{}");
+    WriterModule.close();
+  }
+
+  ASSERT_TRUE(File.root().has_dataset("value"));
+  ASSERT_TRUE(File.root().has_dataset("time"));
+  ASSERT_TRUE(File.root().has_dataset("cue_timestamp_zero"));
+  ASSERT_TRUE(File.root().has_dataset("cue_index"));
+  ASSERT_FALSE(File.root().has_dataset("the_latest_value"));
+}
+
+TEST(Schema_f142, writeArrayFloatWithLatestWithoutContent) {
+  auto StreamJson = json::parse(R""({
+    "source": "the_source_01",
+    "writer_module": "f142",
+    "store_latest_into": "the_latest_value",
+    "type": "float",
+    "array_size": 5
+  })"");
+  auto File = createInMemoryTestFile(
+      "Schema_f142.writeArrayFloatWithLatestWithoutContent");
+  {
+    FileWriter::Schemas::f142::HDFWriterModule WriterModule;
+    WriterModule.parse_config(StreamJson.dump(), "{}");
+    auto Group = File.root();
+    WriterModule.init_hdf(Group, "{}");
+    WriterModule.close();
+  }
+
+  ASSERT_TRUE(File.root().has_dataset("value"));
+  ASSERT_TRUE(File.root().has_dataset("time"));
+  ASSERT_TRUE(File.root().has_dataset("cue_timestamp_zero"));
+  ASSERT_TRUE(File.root().has_dataset("cue_index"));
+  ASSERT_FALSE(File.root().has_dataset("the_latest_value"));
+}
+
 TEST(Schema_f142, writeScalarFloatWithLatest) {
   using DT = float;
   auto StreamJson = json::parse(R""({
@@ -211,8 +260,8 @@ TEST(Schema_f142, writeScalarFloatWithLatest) {
     WriterModule.init_hdf(Group, "{}");
     for (auto Value : Expected) {
       auto Builder = makeValueFloat(Value);
-      auto Msg = FileWriter::Msg::owned(
-          reinterpret_cast<char *>(Builder->GetBufferPointer()),
+      auto Msg = FileWriter::FlatbufferMessage(
+          reinterpret_cast<char const *>(Builder->GetBufferPointer()),
           Builder->GetSize());
       WriterModule.write(Msg);
     }
@@ -257,8 +306,8 @@ TEST(Schema_f142, writeArrayFloatWithLatest) {
     WriterModule.init_hdf(Group, "{}");
     for (auto Value : Expected) {
       auto Builder = makeValue(Value);
-      auto Msg = FileWriter::Msg::owned(
-          reinterpret_cast<char *>(Builder->GetBufferPointer()),
+      auto Msg = FileWriter::FlatbufferMessage(
+          reinterpret_cast<char const *>(Builder->GetBufferPointer()),
           Builder->GetSize());
       WriterModule.write(Msg);
     }


### PR DESCRIPTION
### Description of work

Optionally write latest LogData value into configurable dataset defined by json configuration key `store_latest_into`.
Used so far on `amor` branch.

### Unit Tests

New tests:

```
writeScalarFloatWithLatestWithoutContent
writeArrayFloatWithLatestWithoutContent
writeScalarFloatWithLatest
writeArrayFloatWithLatest
```
