### PR TITLE
340 broker and topic settings as structs

### DIFF
--- a/src/CLIOptions.cpp
+++ b/src/CLIOptions.cpp
@@ -139,7 +139,7 @@ void setCLIOptions(CLI::App &App, MainOpt &MainOptions) {
       MainOptions.topic_write_duration,
       "Stream-master option - topic write interval (milliseconds)");
   addKafkaOption(App, "-S,--kafka-config",
-                 MainOptions.StreamerConfiguration.Settings.KafkaConfiguration,
+                 MainOptions.StreamerConfiguration.Settings.Configuration,
                  "LibRDKafka options");
   App.set_config("-c,--config-file", "", "Read configuration from an ini file");
 }

--- a/src/CommandListener.cpp
+++ b/src/CommandListener.cpp
@@ -15,7 +15,7 @@ void CommandListener::start() {
   KafkaW::BrokerSettings BrokerSettings;
   BrokerSettings.PollTimeoutMS = 500;
   BrokerSettings.Address = config.command_broker_uri.host_port;
-  BrokerSettings.KafkaConfiguration["group.id"] = fmt::format(
+  BrokerSettings.Configuration["group.id"] = fmt::format(
       "filewriter--commandhandler--host:{}--pid:{}--topic:{}--time:{}",
       gethostname_wrapper(), getpid_wrapper(), config.command_broker_uri.topic,
       std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/src/KafkaW/BrokerSettings.cpp
+++ b/src/KafkaW/BrokerSettings.cpp
@@ -7,7 +7,7 @@ namespace KafkaW {
 
 void BrokerSettings::apply(rd_kafka_conf_t *RdKafkaConfiguration) {
   std::vector<char> ErrorString(256);
-  for (const auto &ConfigurationItem : KafkaConfiguration) {
+  for (const auto &ConfigurationItem : Configuration) {
     LOG(Sev::Debug, "set config: {} = {}", ConfigurationItem.first,
         ConfigurationItem.second);
     if (RD_KAFKA_CONF_OK !=

--- a/src/KafkaW/BrokerSettings.h
+++ b/src/KafkaW/BrokerSettings.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <map>
-#include <string>
+#include "SettingsInterface.h"
 
 struct rd_kafka_conf_s;
 typedef struct rd_kafka_conf_s rd_kafka_conf_t;
@@ -9,12 +8,14 @@ typedef struct rd_kafka_conf_s rd_kafka_conf_t;
 namespace KafkaW {
 
 /// Collect options used to connect to the broker.
-struct BrokerSettings {
+struct BrokerSettings : public KafkaW::SettingsInterface {
   BrokerSettings() = default;
+
+  virtual void apply() override{};
   void apply(rd_kafka_conf_t *RdKafkaConfiguration);
   std::string Address;
   int PollTimeoutMS = 100;
-  std::map<std::string, std::string> KafkaConfiguration = {
+  std::map<std::string, std::string> Configuration = {
       {"metadata.request.timeout.ms", "2000"}, // 2 Secs
       {"socket.timeout.ms", "2000"},
       {"message.max.bytes", "24117248"}, // 23 MiB
@@ -29,6 +30,5 @@ struct BrokerSettings {
       {"statistics.interval.ms", "600000"}, // 1 Min
       {"api.version.request", "true"},
   };
-  ;
 };
 } // namespace KafkaW

--- a/src/KafkaW/BrokerSettings.h
+++ b/src/KafkaW/BrokerSettings.h
@@ -9,8 +9,7 @@ typedef struct rd_kafka_conf_s rd_kafka_conf_t;
 namespace KafkaW {
 
 /// Collect options used to connect to the broker.
-class BrokerSettings {
-public:
+struct BrokerSettings {
   BrokerSettings() = default;
   void apply(rd_kafka_conf_t *RdKafkaConfiguration);
   std::string Address;

--- a/src/KafkaW/ProducerTopic.cpp
+++ b/src/KafkaW/ProducerTopic.cpp
@@ -25,7 +25,7 @@ ProducerTopic::ProducerTopic(std::shared_ptr<Producer> Producer,
     : Producer_(Producer), Name(Name_) {
   TopicSettings TopicSettings;
   rd_kafka_topic_conf_t *topic_conf = rd_kafka_topic_conf_new();
-  TopicSettings.applySettingsToRdKafkaConf(topic_conf);
+  TopicSettings.apply(topic_conf);
 
   RdKafkaTopic =
       rd_kafka_topic_new(Producer_->getRdKafkaPtr(), Name.c_str(), topic_conf);

--- a/src/KafkaW/SettingsInterface.h
+++ b/src/KafkaW/SettingsInterface.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <map>
+#include <string>
+namespace KafkaW {
+struct SettingsInterface {
+  virtual void apply() = 0;
+  std::map<std::string, std::string> Configuration;
+};
+}

--- a/src/KafkaW/TopicSettings.cpp
+++ b/src/KafkaW/TopicSettings.cpp
@@ -5,7 +5,7 @@ namespace KafkaW {
 
 TopicSettings::TopicSettings() {}
 
-void TopicSettings::applySettingsToRdKafkaConf(rd_kafka_topic_conf_t *conf) {
+void TopicSettings::apply(rd_kafka_topic_conf_t *conf) {
   std::vector<char> ErrorString(1024);
   for (auto &c : ConfigurationIntegers) {
     std::string ConfigString = fmt::format("{:d}", c.second);
@@ -18,7 +18,7 @@ void TopicSettings::applySettingsToRdKafkaConf(rd_kafka_topic_conf_t *conf) {
           ConfigString, ErrorString.data());
     }
   }
-  for (auto &c : ConfigurationStrings) {
+  for (auto &c : Configuration) {
     LOG(Sev::Debug, "use  {}: {}", c.first, c.second);
     auto err = rd_kafka_topic_conf_set(conf, c.first.c_str(), c.second.c_str(),
                                        ErrorString.data(), ErrorString.size());

--- a/src/KafkaW/TopicSettings.h
+++ b/src/KafkaW/TopicSettings.h
@@ -1,16 +1,15 @@
 #pragma once
 
+#include "SettingsInterface.h"
 #include "logger.h"
 #include <librdkafka/rdkafka.h>
-#include <map>
-#include <string>
 
 namespace KafkaW {
 
-struct TopicSettings {
+struct TopicSettings : public KafkaW::SettingsInterface {
   TopicSettings();
-  void applySettingsToRdKafkaConf(rd_kafka_topic_conf_t *conf);
+  virtual void apply() override{};
+  void apply(rd_kafka_topic_conf_t *conf);
   std::map<std::string, int> ConfigurationIntegers;
-  std::map<std::string, std::string> ConfigurationStrings;
 };
 }

--- a/src/KafkaW/TopicSettings.h
+++ b/src/KafkaW/TopicSettings.h
@@ -7,8 +7,7 @@
 
 namespace KafkaW {
 
-class TopicSettings {
-public:
+struct TopicSettings {
   TopicSettings();
   void applySettingsToRdKafkaConf(rd_kafka_topic_conf_t *conf);
   std::map<std::string, int> ConfigurationIntegers;

--- a/src/Streamer.cpp
+++ b/src/Streamer.cpp
@@ -29,7 +29,7 @@ FileWriter::Streamer::Streamer(const std::string &Broker,
     throw std::runtime_error("Missing broker or topic");
   }
 
-  Options.Settings.KafkaConfiguration["group.id"] =
+  Options.Settings.Configuration["group.id"] =
       fmt::format("filewriter--streamer--host:{}--pid:{}--topic:{}--time:{}",
                   gethostname_wrapper(), getpid_wrapper(), TopicName,
                   std::chrono::duration_cast<std::chrono::milliseconds>(


### PR DESCRIPTION
### Description of work

- Both broker and topic settings are now structs.
- Because C++ api indeed has a common interface for configuration/settings I created a
SettingsInterface.h to reflect this relation. 
- Currently TopicSettings are not explicitly set anywhere but `apply(rd_kafka_topic_conf_t *conf)` method is called and removing entire struct would require changes beyond kafkaW. If we want to consider it I'd suggest discussing it and creating a separate ticket.

### Issue

Closes #340 

### Acceptance Criteria
- BrokerSettings.h/cpp
- TopicSettings.h/cpp
- SettingsInterface.h

Functionality itself does not change
### Unit Tests

n/a

### Other

n/a

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
