### PR TITLE
Add timeout for system test step in jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -280,8 +280,8 @@ def get_system_tests_pipeline() {
             scl enable rh-python35 -- python -m pip install --user -r system-tests/requirements.txt
             """
           }  // stage
+          timeout(time: 30, activity: true)
           stage("System tests: Run") {
-            timeout(time: 30, activity: true)
             // Stop and remove any containers that may have been from the job before,
             // i.e. if a Jenkins job has been aborted.
             sh "docker stop \$(docker ps -a -q) && docker rm \$(docker ps -a -q) || true"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -281,7 +281,7 @@ def get_system_tests_pipeline() {
             """
           }  // stage
           stage("System tests: Run") {
-            timeout(30, true, MINUTES)
+            timeout(time: 30, activity: true)
             // Stop and remove any containers that may have been from the job before,
             // i.e. if a Jenkins job has been aborted.
             sh "docker stop \$(docker ps -a -q) && docker rm \$(docker ps -a -q) || true"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -280,14 +280,15 @@ def get_system_tests_pipeline() {
             scl enable rh-python35 -- python -m pip install --user -r system-tests/requirements.txt
             """
           }  // stage
-          timeout(time: 30, activity: true)
           stage("System tests: Run") {
             // Stop and remove any containers that may have been from the job before,
             // i.e. if a Jenkins job has been aborted.
             sh "docker stop \$(docker ps -a -q) && docker rm \$(docker ps -a -q) || true"
-            sh """cd system-tests/
-            scl enable rh-python35 -- python -m pytest -s --junitxml=./SystemTestsOutput.xml .
-            """
+            timeout(time: 30, activity: true){
+              sh """cd system-tests/
+              scl enable rh-python35 -- python -m pytest -s --junitxml=./SystemTestsOutput.xml .
+              """
+            }
           }  // stage
         } finally {
           stage ("System tests: Clean Up") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -281,6 +281,7 @@ def get_system_tests_pipeline() {
             """
           }  // stage
           stage("System tests: Run") {
+            timeout(30, true, MINUTES)
             // Stop and remove any containers that may have been from the job before,
             // i.e. if a Jenkins job has been aborted.
             sh "docker stop \$(docker ps -a -q) && docker rm \$(docker ps -a -q) || true"


### PR DESCRIPTION
### Description of work

Sometimes the system tests hang for no apparent reason so adding a timeout to them to stop when no logs have been printed for 30 minutes. 

### Issue

Closes #347 

### Acceptance Criteria

N/A

### Unit Tests

N/A

### Other

N/A

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
