### PR TITLE
Streamer logs a warning if timestamp is missing

### DIFF
--- a/src/Streamer.cpp
+++ b/src/Streamer.cpp
@@ -151,7 +151,7 @@ FileWriter::Streamer::pollAndProcess(FileWriter::DemuxTopic &MessageProcessor) {
     return ProcessMessageResult::OK;
   }
 
-  if (static_cast<std::int64_t>(Message->getTimestamp()) == 0) {
+  if (Message->getTimestamp() == 0) {
     LOG(Sev::Error,
         "Message from topic \"{}\", source \"{}\" has no timestamp, ignoring",
         MessageProcessor.topic(), Message->getSourceName());

--- a/src/Streamer.cpp
+++ b/src/Streamer.cpp
@@ -151,6 +151,13 @@ FileWriter::Streamer::pollAndProcess(FileWriter::DemuxTopic &MessageProcessor) {
     return ProcessMessageResult::OK;
   }
 
+  if (static_cast<std::int64_t>(Message->getTimestamp()) == 0) {
+    LOG(Sev::Error,
+        "Message from topic \"{}\", source \"{}\" has no timestamp, ignoring",
+        MessageProcessor.topic(), Message->getSourceName());
+    return ProcessMessageResult::ERR;
+  }
+
   // Timestamp of message is before the "start" timestamp
   if (static_cast<std::int64_t>(Message->getTimestamp()) <
       std::chrono::duration_cast<std::chrono::nanoseconds>(

--- a/src/tests/StreamerTest.cpp
+++ b/src/tests/StreamerTest.cpp
@@ -239,7 +239,8 @@ protected:
   StreamerStandIn TestStreamer;
 };
 
-TEST_F(StreamerProcessTimingTest, MessageHasNoTimestamp) {
+TEST_F(StreamerProcessTimingTest,
+       pollAndProcessReturnsErrIfMessageHasNoTimestamp) {
   FlatbufferReaderRegistry::Registrar<StreamerNoTimestampTestDummyReader>
       RegisterIt(ReaderKey);
   TestStreamer.Options.StartTimestamp = std::chrono::milliseconds{1};


### PR DESCRIPTION
### Description of work

With this PR an explicit check for a valid timestamp (_i.e. > 0_) in the flatbuffer message is checked. If the timestamp is not set the Streamer logs an error message and returns `ProcessMessageResult::ERR`.

### Issue

DM-1141

### Acceptance Criteria

*List the changes in functionality or code that the reviewer needs to review.*

### Unit Tests

* Add test for missing (_i.e. > 0_) timestamp field.
* Changed `StreamerTestDummyReader` class so that `timestamp(FlatbufferMessage const &Message)` returns a small, but valid value (it returns 1)

---

## Code Review (To be filled in by the reviewer only)

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
