### PR TITLE
Fix error in `commitOffsets`

### DIFF
--- a/src/KafkaW/Consumer.cpp
+++ b/src/KafkaW/Consumer.cpp
@@ -193,6 +193,11 @@ void Consumer::addTopicAtTimestamp(std::string const Topic,
 void Consumer::commitOffsets() const {
   auto CommitErr = rd_kafka_commit(RdKafka, PartitionList, false);
   KERR(RdKafka, CommitErr);
+  if (CommitErr == RD_KAFKA_RESP_ERR__NO_OFFSET) {
+    LOG(Sev::Warning, "Could not commit offsets in Consumer, possibly already "
+                      "at the correct offset");
+    return;
+  }
   if (CommitErr != RD_KAFKA_RESP_ERR_NO_ERROR) {
     throw std::runtime_error("Could not commit offsets in Consumer");
   }


### PR DESCRIPTION
### Description of work

The `KafkaW::Consumer` throws an error if `rd_kafka_commit` returns something different from `RD_KAFKA_RESP_ERR_NO_ERROR`. This happens for example when there are no older messages (eventually within the specified time window) in the log. According to the discussion in this [ticket](https://github.com/confluentinc/confluent-kafka-python/issues/71) though

>   _NO_OFFSET is a "soft error", it means it didnt have to commit the offset because the current offset had already been committed. 

With this PR `RD_KAFKA_RESP_ERR__NO_OFFSET` is not considered an error, but a waning is emitted.

### Issue

[DM-1197](https://jira.esss.lu.se/browse/DM-1197)

### Other

Can someone please give it a try?

---

## Code Review (To be filled in by the reviewer only)

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
