### PR TITLE
re DM-1244 log container output to stdout when program terminates

### DIFF
--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -91,6 +91,16 @@ def build_and_run(options, request):
     def fin():
         # Stop the containers then remove them and their volumes (--volumes option)
         print("containers stopping", flush=True)
+        try:
+            # Used for when there are multiple filewriter instances -  the service is not called "filewriter"
+            multiple_log_options = dict(options)
+            multiple_log_options["SERVICE"] = ["filewriter1", "filewriter2"]
+            cmd.logs(multiple_log_options)
+        except:
+            pass
+        log_options = dict(options)
+        log_options["SERVICE"] = ["filewriter"]
+        cmd.logs(log_options)
         options["--timeout"] = 30
         cmd.down(options)
         print("containers stopped", flush=True)

--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -97,10 +97,9 @@ def build_and_run(options, request):
             multiple_log_options["SERVICE"] = ["filewriter1", "filewriter2"]
             cmd.logs(multiple_log_options)
         except:
-            pass
-        log_options = dict(options)
-        log_options["SERVICE"] = ["filewriter"]
-        cmd.logs(log_options)
+            log_options = dict(options)
+            log_options["SERVICE"] = ["filewriter"]
+            cmd.logs(log_options)
         options["--timeout"] = 30
         cmd.down(options)
         print("containers stopped", flush=True)

--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -92,7 +92,8 @@ def build_and_run(options, request):
         # Stop the containers then remove them and their volumes (--volumes option)
         print("containers stopping", flush=True)
         try:
-            # Used for when there are multiple filewriter instances -  the service is not called "filewriter"
+            # Used for when there are multiple filewriter instances
+            # as the service is not called "filewriter"
             multiple_log_options = dict(options)
             multiple_log_options["SERVICE"] = ["filewriter1", "filewriter2"]
             cmd.logs(multiple_log_options)


### PR DESCRIPTION
### Description of work

Adding the filewriter container output to jenkins if the program terminates. Previously this was uncaught as it would stop logging to a file (done through the command line args)

for when multiple instances of the filewriter are used, the test fixture has a try/except block in the fixture finaliser to try and log the output of both containers. otherwise it will log just the single container named "filewriter"

### Issue

Closes DM-1244

### Acceptance Criteria

To test:

Remove the `log-file` argument in one of the test `ini`s and check the container outputs any logs to stdout

### Unit Tests

None

### Other

None

---

## Code Review (To be filled in by the reviewer only)

- [x] Is the code of an acceptable quality?
- [x] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).
