### PR TITLE
Add local conan server in system tests Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ ARG http_proxy
 
 ARG https_proxy
 
+ARG local_conan_server
+
 ENV BUILD_PACKAGES "build-essential git python python-pip cmake python-setuptools autoconf libtool automake"
 
 # Install packages - We don't want to purge kafkacat and tzdata after building
@@ -21,6 +23,9 @@ RUN apt-get update -y && \
 # Replace the default profile and remotes with the ones from our Ubuntu build node
 ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/registry.json" "/root/.conan/registry.json"
 ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/default_profile" "/root/.conan/profiles/default"
+
+# Add local Conan server
+RUN if [ ! -z "$local_conan_server" ]; then conan remote add --insert 0 ess-dmsc-local "$local_conan_server"; fi
 
 COPY ./conan ../kafka_to_nexus_src/conan
 RUN cd kafka_to_nexus && conan install --build=outdated ../kafka_to_nexus_src/conan/conanfile.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -296,7 +296,7 @@ def get_macos_pipeline() {
 
 def get_system_tests_pipeline() {
   return {
-    node('integration-test') {
+    node('system-test') {
       cleanWs()
       dir("${project}") {
         try {

--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -60,6 +60,8 @@ def build_filewriter_image():
         build_args["http_proxy"] = os.environ["http_proxy"]
     if "https_proxy" in os.environ:
         build_args["https_proxy"] = os.environ["https_proxy"]
+    if "local_conan_server" in os.environ:
+        build_args["local_conan_server"] = os.environ["local_conan_server"]
     image, logs = client.images.build(path="../", tag="kafka-to-nexus:latest", rm=False, buildargs=build_args)
     for item in logs:
         print(item, flush=True)


### PR DESCRIPTION
### Description of work

Make dockerised system tests use cached binary Conan packages instead of building them from source.

### Issue

Closes #DM-1268.

### Acceptance Criteria

The system tests should download binary Conan packages from the local server, instead of building them from source.

### Unit Tests

n/a

### Other

Changed system tests.

---

## Code Review (To be filled in by the reviewer only)

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?

---

## Nominate for Group Code Review (Anyone can nominate it)
Indicate if you think the code should be reviewed in a Thursday code review session.

- [ ] Recommend for group code review

Also, nominate it on the code_review Slack channel (does someone want to automate this?).