### PR TITLE
Updating h5cpp version

### DIFF
--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -3,7 +3,7 @@ gtest/3121b20-dm3@ess-dmsc/stable
 fmt/5.2.0@bincrafters/stable
 FlatBuffers/1.9.0@ess-dmsc/stable
 hdf5/1.10.2-dm2@ess-dmsc/stable
-h5cpp/0.1.0@ess-dmsc/testing
+h5cpp/0.1.0-dm2@ess-dmsc/testing
 librdkafka/0.11.5@ess-dmsc/stable
 jsonformoderncpp/3.1.0@vthiery/stable
 graylog-logger/1.0.5-dm1@ess-dmsc/stable


### PR DESCRIPTION
### Description of work

Updating the h5cpp version to 0.1.0-dm2

this should pass on the mac node before merging. 

