### PR TITLE
Dm 1153 classes to enums

### DIFF
--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -362,7 +362,7 @@ void CommandHandler::addStreamSourceToWriterModule(
           auto StreamGroup = hdf5::node::get_group(
               RootGroup, StreamSettings.StreamHDFInfoObj.HDFParentName);
           auto Err = HDFWriterModule->reopen({StreamGroup});
-          if (Err.is_ERR()) {
+          if (Err != HDFWriterModule_detail::InitResult::OK) {
             LOG(Sev::Error, "can not reopen HDF file for stream {}",
                 StreamSettings.StreamHDFInfoObj.HDFParentName);
             continue;

--- a/src/HDFWriterModule.cpp
+++ b/src/HDFWriterModule.cpp
@@ -35,15 +35,6 @@ static std::map<int8_t, std::string> const InitResultStrings{
     {0, "OK"}, {-1, "ERROR_IO"}, {-2, "ERROR_INCOMPLETE_CONFIGURATION"},
 };
 
-std::string InitResult::to_str() const {
-  auto const &m = InitResultStrings;
-  auto const it = m.find(v);
-  if (it == m.end()) {
-    return "ERROR_UNKNOWN_VALUE";
-  }
-  return it->second;
-}
-
 static std::map<int8_t, std::string> const WriteResultStrings{
     {0, "OK"},
     {-1, "ERROR_IO"},

--- a/src/HDFWriterModule.cpp
+++ b/src/HDFWriterModule.cpp
@@ -31,10 +31,6 @@ void addWriterModule(std::string const &Key, ModuleFactory Value) {
 // Implementation details for `HDFWriterModule`
 namespace HDFWriterModule_detail {
 
-static std::map<int8_t, std::string> const InitResultStrings{
-    {0, "OK"}, {-1, "ERROR_IO"}, {-2, "ERROR_INCOMPLETE_CONFIGURATION"},
-};
-
 static std::map<int8_t, std::string> const WriteResultStrings{
     {0, "OK"},
     {-1, "ERROR_IO"},

--- a/src/HDFWriterModule.cpp
+++ b/src/HDFWriterModule.cpp
@@ -27,29 +27,4 @@ void addWriterModule(std::string const &Key, ModuleFactory Value) {
   m[Key] = std::move(Value);
 }
 } // namespace HDFWriterModuleRegistry
-
-// Implementation details for `HDFWriterModule`
-namespace HDFWriterModule_detail {
-
-static std::map<int8_t, std::string> const WriteResultStrings{
-    {0, "OK"},
-    {-1, "ERROR_IO"},
-    {-2, "ERROR_BAD_FLATBUFFER"},
-    {-3, "ERROR_DATA_STRUCTURE_MISMATCH"},
-    {-4, "ERROR_DATA_TYPE_MISMATCH"},
-    {-5, "ERROR_WITH_MESSAGE"},
-};
-
-std::string WriteResult::to_str() const {
-  auto const &m = WriteResultStrings;
-  auto const it = m.find(v);
-  if (it == m.end()) {
-    return "ERROR_UNKNOWN_VALUE";
-  }
-  if (v == -5) {
-    return std::string(it->second) + ": " + Message;
-  }
-  return it->second;
-}
-} // namespace HDFWriterModule_detail
 } // namespace FileWriter

--- a/src/HDFWriterModule.h
+++ b/src/HDFWriterModule.h
@@ -140,6 +140,5 @@ public:
   WriterException(const char *ErrorMessage)
       : std::runtime_error(ErrorMessage) {}
 };
-
 } // namespace HDFWriterModuleRegistry
 } // namespace FileWriter

--- a/src/HDFWriterModule.h
+++ b/src/HDFWriterModule.h
@@ -16,7 +16,7 @@ namespace HDFWriterModule_detail {
 enum class InitResult { ERROR_IO = -1, OK = 0 };
 
 /// Result type for write operation on the writer module.
-enum class WriteResult { ERROR_BAD_FLATBUFFER = -2, ERROR_IO = -1, OK = 0 };
+enum class WriteResult { OK = 0 };
 
 } // namespace HDFWriterModule_detail
 
@@ -80,7 +80,7 @@ public:
   /// \param msg The message to process
   ///
   /// \return The result.
-  virtual WriteResult write(FlatbufferMessage const &Message) = 0;
+  virtual void write(FlatbufferMessage const &Message) = 0;
 
   /// \brief Flush the internal buffer.
   ///

--- a/src/HDFWriterModule.h
+++ b/src/HDFWriterModule.h
@@ -15,9 +15,6 @@ namespace HDFWriterModule_detail {
 /// \brief Result type for the initialization of the writer module.
 enum class InitResult { ERROR_IO = -1, OK = 0 };
 
-/// Result type for write operation on the writer module.
-enum class WriteResult { OK = 0 };
-
 } // namespace HDFWriterModule_detail
 
 /// \brief Writes a given flatbuffer to HDF.
@@ -34,8 +31,6 @@ class HDFWriterModule {
 public:
   using ptr = std::unique_ptr<HDFWriterModule>;
   using InitResult = HDFWriterModule_detail::InitResult;
-  using WriteResult = HDFWriterModule_detail::WriteResult;
-
   virtual ~HDFWriterModule() = default;
 
   /// \brief Parses the configuration of a stream.

--- a/src/HDFWriterModule.h
+++ b/src/HDFWriterModule.h
@@ -15,79 +15,9 @@ namespace HDFWriterModule_detail {
 /// \brief Result type for the initialization of the writer module.
 enum class InitResult { ERROR_IO = -1, OK = 0 };
 
-/// Result type for write operation on the writer module. Not an enum but a
-/// class because we have a message for the sad code path.
-class WriteResult {
-public:
-  /// Everything was fine.
-  ///
-  /// \return The okay result.
-  static WriteResult OK() { return WriteResult(0); }
-  static WriteResult OK_WITH_TIMESTAMP(uint64_t timestamp) {
-    WriteResult ret(1);
-    ret.timestamp_ = timestamp;
-    return ret;
-  }
-  /// I/O error, for example if libhdf returned with a I/O error.
-  ///
-  /// \return The error result.
-  static inline WriteResult ERROR_IO() { return WriteResult(-1); }
+/// Result type for write operation on the writer module.
+enum class WriteResult { ERROR_BAD_FLATBUFFER = -2, ERROR_IO = -1, OK = 0 };
 
-  static inline WriteResult ERROR_WITH_MESSAGE(std::string const &Message) {
-    return WriteResult(Message);
-  }
-
-  /// \brief Indicates that the flatbuffer contained semantically invalid data,
-  /// even
-  /// though the flatbuffer is technically valid.
-  ///
-  /// The case that the flatbuffer itself is invalid should not occur as that
-  /// is already checked for before passing the flatbuffer to the
-  /// `HDFWriterModule`.
-  ///
-  /// \return The bad flatbuffer result.
-  static inline WriteResult ERROR_BAD_FLATBUFFER() { return WriteResult(-2); }
-
-  /// \brief Indicates that the data is structurally invalid, for example if it
-  /// has the wrong array sizes.
-  ///
-  /// \return The data structure error result.
-  static inline WriteResult ERROR_DATA_STRUCTURE_MISMATCH() {
-    return WriteResult(-3);
-  }
-
-  /// \brief A special case of `ERROR_DATA_STRUCTURE_MISMATCH` to indicate that
-  /// the data type does not match.
-  ///
-  /// For example a float instead of the expected
-  /// double.
-  ///
-  /// \return The data type error result.
-  static inline WriteResult ERROR_DATA_TYPE_MISMATCH() {
-    return WriteResult(-4);
-  }
-  inline bool is_OK() const { return v == 0; }
-  inline bool is_OK_WITH_TIMESTAMP() const { return v == 1; }
-
-  /// \brief Indicates if any error has occurred.
-  ///
-  /// \return True if any error has occurred.
-  inline bool is_ERR() const { return v < 0; }
-
-  /// \brief Gets status reports.
-  ///
-  /// \return The status.
-  std::string to_str() const;
-  inline uint64_t timestamp() const { return timestamp_; }
-
-private:
-  explicit inline WriteResult(int8_t v) : v(v) {}
-  explicit inline WriteResult(std::string Message)
-      : v(-5), Message(std::move(Message)) {}
-  int8_t v = -1;
-  uint64_t timestamp_ = 0;
-  std::string Message;
-};
 } // namespace HDFWriterModule_detail
 
 /// \brief Writes a given flatbuffer to HDF.
@@ -204,5 +134,12 @@ public:
     addWriterModule(FlatbufferID, FactoryFunction);
   };
 };
+
+class WriterException : public std::runtime_error {
+public:
+  WriterException(const char *ErrorMessage)
+      : std::runtime_error(ErrorMessage) {}
+};
+
 } // namespace HDFWriterModuleRegistry
 } // namespace FileWriter

--- a/src/HDFWriterModule.h
+++ b/src/HDFWriterModule.h
@@ -13,45 +13,7 @@ namespace FileWriter {
 namespace HDFWriterModule_detail {
 
 /// \brief Result type for the initialization of the writer module.
-class InitResult {
-public:
-  /// Everything was fine.
-  ///
-  /// \return The okay result.
-  static InitResult OK() { return InitResult(0); }
-
-  /// I/O error, for example if libhdf returned with a I/O error.
-  ///
-  /// \return The error result.
-  static inline InitResult ERROR_IO() { return InitResult(-1); }
-
-  /// The writer module needs more configuration that was is available.
-  ///
-  /// \return The incomplete configuration error result.
-  static inline InitResult ERROR_INCOMPLETE_CONFIGURATION() {
-    return InitResult(-2);
-  }
-
-  /// Indicates if status is okay.
-  ///
-  /// \return True if okay.
-  inline bool is_OK() const { return v == 0; }
-
-  /// Indicates if any error has occurred. More specific query function will
-  /// come as need arises.
-  ///
-  /// \return True if any error has occurred
-  inline bool is_ERR() const { return v < 0; }
-
-  /// Used for status reports.
-  ///
-  /// \return The status.
-  std::string to_str() const;
-
-private:
-  explicit inline InitResult(int8_t v) : v(v) {}
-  int8_t v = -1;
-};
+enum class InitResult { ERROR_IO = -1, OK = 0 };
 
 /// Result type for write operation on the writer module. Not an enum but a
 /// class because we have a message for the sad code path.

--- a/src/HDFWriterModule.h
+++ b/src/HDFWriterModule.h
@@ -78,8 +78,6 @@ public:
   /// \brief Process the message in some way, for example write to the HDF file.
   ///
   /// \param msg The message to process
-  ///
-  /// \return The result.
   virtual void write(FlatbufferMessage const &Message) = 0;
 
   /// \brief Flush the internal buffer.

--- a/src/HDFWriterModule.h
+++ b/src/HDFWriterModule.h
@@ -13,7 +13,7 @@ namespace FileWriter {
 namespace HDFWriterModule_detail {
 
 /// \brief Result type for the initialization of the writer module.
-enum class InitResult { ERROR_IO = -1, OK = 0 };
+enum class InitResult { ERROR = -1, OK = 0 };
 
 } // namespace HDFWriterModule_detail
 
@@ -130,7 +130,7 @@ public:
 
 class WriterException : public std::runtime_error {
 public:
-  WriterException(const char *ErrorMessage)
+  WriterException(const std::string &ErrorMessage)
       : std::runtime_error(ErrorMessage) {}
 };
 } // namespace HDFWriterModuleRegistry

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -39,7 +39,7 @@ ProcessMessageResult Source::process_message(FlatbufferMessage const &Message) {
       }
       return ProcessMessageResult::OK;
     } catch (const HDFWriterModuleRegistry::WriterException &E) {
-      LOG(Sev::Debug, "Failure while writing message: {}", E.what());
+      LOG(Sev::Error, "Failure while writing message: {}", E.what());
       return ProcessMessageResult::ERR;
     }
   }

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -31,14 +31,13 @@ ProcessMessageResult Source::process_message(FlatbufferMessage const &Message) {
       return ProcessMessageResult::ERR;
     }
     try {
-      auto ErrorCode = WriterModule->write(Message);
+      WriterModule->write(Message);
       _cnt_msg_written += 1;
       _processed_messages_count += 1;
       if (HDFFileForSWMR != nullptr) {
         HDFFileForSWMR->SWMRFlush();
       }
-      if (ErrorCode == HDFWriterModule_detail::WriteResult::OK)
-        return ProcessMessageResult::OK;
+      return ProcessMessageResult::OK;
     } catch (const HDFWriterModuleRegistry::WriterException &E) {
       LOG(Sev::Debug, "Failure while writing message: {}", E.what());
       return ProcessMessageResult::ERR;

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -1,4 +1,5 @@
 #include "Source.h"
+#include "HDFWriterModule.h"
 #include "helper.h"
 #include "logger.h"
 #include <chrono>
@@ -29,19 +30,19 @@ ProcessMessageResult Source::process_message(FlatbufferMessage const &Message) {
       LOG(Sev::Debug, "!_hdf_writer_module for {}", SourceName);
       return ProcessMessageResult::ERR;
     }
-    auto ret = WriterModule->write(Message);
-    _cnt_msg_written += 1;
-    _processed_messages_count += 1;
-    if (ret.is_ERR()) {
-      if (log_level >= static_cast<int>(Sev::Debug)) {
-        LOG(Sev::Debug, "Failure while writing message: {}", ret.to_str());
+    try {
+      auto ErrorCode = WriterModule->write(Message);
+      _cnt_msg_written += 1;
+      _processed_messages_count += 1;
+      if (HDFFileForSWMR != nullptr) {
+        HDFFileForSWMR->SWMRFlush();
       }
+      if (ErrorCode == HDFWriterModule_detail::WriteResult::OK)
+        return ProcessMessageResult::OK;
+    } catch (const HDFWriterModuleRegistry::WriterException &E) {
+      LOG(Sev::Debug, "Failure while writing message: {}", E.what());
       return ProcessMessageResult::ERR;
     }
-    if (HDFFileForSWMR != nullptr) {
-      HDFFileForSWMR->SWMRFlush();
-    }
-    return ProcessMessageResult::OK;
   }
   return ProcessMessageResult::ERR;
 }

--- a/src/schemas/NDAr/AreaDetectorWriter.cpp
+++ b/src/schemas/NDAr/AreaDetectorWriter.cpp
@@ -128,7 +128,7 @@ AreaDetectorWriter::init_hdf(hdf5::node::Group &HDFGroup,
     LOG(Sev::Error, "Unable to initialise areaDetector data tree in "
                     "HDF file with error message: \"{}\"",
         E.what());
-    return HDFWriterModule::InitResult::ERROR_IO;
+    return HDFWriterModule::InitResult::ERROR;
   }
   return FileWriterBase::InitResult::OK;
 }
@@ -148,7 +148,7 @@ AreaDetectorWriter::reopen(hdf5::node::Group &HDFGroup) {
     LOG(Sev::Error,
         "Failed to reopen datasets in HDF file with error message: \"{}\"",
         std::string(E.what()));
-    return HDFWriterModule::InitResult::ERROR_IO;
+    return HDFWriterModule::InitResult::ERROR;
   }
   return FileWriterBase::InitResult::OK;
 }

--- a/src/schemas/NDAr/AreaDetectorWriter.cpp
+++ b/src/schemas/NDAr/AreaDetectorWriter.cpp
@@ -160,8 +160,7 @@ void appendData(DatasetType &Dataset, const std::uint8_t *Pointer, size_t Size,
       Shape);
 }
 
-FileWriterBase::WriteResult
-AreaDetectorWriter::write(const FileWriter::FlatbufferMessage &Message) {
+void AreaDetectorWriter::write(const FileWriter::FlatbufferMessage &Message) {
   auto NDAr = FB_Tables::GetNDArray(Message.data());
   auto DataShape = hdf5::Dimensions(NDAr->dims()->begin(), NDAr->dims()->end());
   auto CurrentTimestamp =
@@ -209,7 +208,6 @@ AreaDetectorWriter::write(const FileWriter::FlatbufferMessage &Message) {
     CueTimestamp.appendElement(CurrentTimestamp);
     CueCounter = 0;
   }
-  return FileWriterBase::WriteResult::OK;
 }
 
 std::int32_t AreaDetectorWriter::flush() { return 0; }

--- a/src/schemas/NDAr/AreaDetectorWriter.cpp
+++ b/src/schemas/NDAr/AreaDetectorWriter.cpp
@@ -200,7 +200,7 @@ AreaDetectorWriter::write(const FileWriter::FlatbufferMessage &Message) {
     appendData<const char>(Values, DataPtr, NrOfElements, DataShape);
     break;
   default:
-    return FileWriterBase::WriteResult::ERROR_BAD_FLATBUFFER();
+    return FileWriterBase::WriteResult::ERROR_BAD_FLATBUFFER;
   }
   Timestamp.appendElement(CurrentTimestamp);
   if (++CueCounter == CueInterval) {
@@ -208,7 +208,7 @@ AreaDetectorWriter::write(const FileWriter::FlatbufferMessage &Message) {
     CueTimestamp.appendElement(CurrentTimestamp);
     CueCounter = 0;
   }
-  return FileWriterBase::WriteResult::OK();
+  return FileWriterBase::WriteResult::OK;
 }
 
 std::int32_t AreaDetectorWriter::flush() { return 0; }

--- a/src/schemas/NDAr/AreaDetectorWriter.cpp
+++ b/src/schemas/NDAr/AreaDetectorWriter.cpp
@@ -200,7 +200,8 @@ AreaDetectorWriter::write(const FileWriter::FlatbufferMessage &Message) {
     appendData<const char>(Values, DataPtr, NrOfElements, DataShape);
     break;
   default:
-    return FileWriterBase::WriteResult::ERROR_BAD_FLATBUFFER;
+    throw FileWriter::HDFWriterModuleRegistry::WriterException(
+        "Error in flatbuffer.");
   }
   Timestamp.appendElement(CurrentTimestamp);
   if (++CueCounter == CueInterval) {

--- a/src/schemas/NDAr/AreaDetectorWriter.cpp
+++ b/src/schemas/NDAr/AreaDetectorWriter.cpp
@@ -128,9 +128,9 @@ AreaDetectorWriter::init_hdf(hdf5::node::Group &HDFGroup,
     LOG(Sev::Error, "Unable to initialise areaDetector data tree in "
                     "HDF file with error message: \"{}\"",
         E.what());
-    return HDFWriterModule::InitResult::ERROR_IO();
+    return HDFWriterModule::InitResult::ERROR_IO;
   }
-  return FileWriterBase::InitResult::OK();
+  return FileWriterBase::InitResult::OK;
 }
 
 FileWriterBase::InitResult
@@ -148,9 +148,9 @@ AreaDetectorWriter::reopen(hdf5::node::Group &HDFGroup) {
     LOG(Sev::Error,
         "Failed to reopen datasets in HDF file with error message: \"{}\"",
         std::string(E.what()));
-    return HDFWriterModule::InitResult::ERROR_IO();
+    return HDFWriterModule::InitResult::ERROR_IO;
   }
-  return FileWriterBase::InitResult::OK();
+  return FileWriterBase::InitResult::OK;
 }
 template <typename DataType, class DatasetType>
 void appendData(DatasetType &Dataset, const std::uint8_t *Pointer, size_t Size,
@@ -201,7 +201,6 @@ AreaDetectorWriter::write(const FileWriter::FlatbufferMessage &Message) {
     break;
   default:
     return FileWriterBase::WriteResult::ERROR_BAD_FLATBUFFER();
-    break;
   }
   Timestamp.appendElement(CurrentTimestamp);
   if (++CueCounter == CueInterval) {

--- a/src/schemas/NDAr/AreaDetectorWriter.h
+++ b/src/schemas/NDAr/AreaDetectorWriter.h
@@ -41,7 +41,7 @@ public:
 
   InitResult reopen(hdf5::node::Group &HDFGroup) override;
 
-  WriteResult write(FlatbufferMessage const &Message) override;
+  void write(FlatbufferMessage const &Message) override;
 
   int32_t flush() override;
 

--- a/src/schemas/ev42/ev42_rw.cpp
+++ b/src/schemas/ev42/ev42_rw.cpp
@@ -189,7 +189,7 @@ HDFWriterModule::reopen(hdf5::node::Group &HDFGroup) {
 HDFWriterModule::WriteResult
 HDFWriterModule::write(FlatbufferMessage const &Message) {
   if (!ds_event_time_offset) {
-    return HDFWriterModule::WriteResult::ERROR_IO();
+    return HDFWriterModule::WriteResult::ERROR_IO;
   }
   auto fbuf = get_fbuf(Message.data());
   auto w1ret = this->ds_event_time_offset->append_data_1d(
@@ -210,7 +210,7 @@ HDFWriterModule::write(FlatbufferMessage const &Message) {
     this->ds_cue_index->append_data_1d(&event_index, 1);
     index_at_bytes = total_written_bytes;
   }
-  return HDFWriterModule::WriteResult::OK_WITH_TIMESTAMP(fbuf->pulse_time());
+  return HDFWriterModule::WriteResult::OK;
 }
 
 int32_t HDFWriterModule::flush() { return 0; }

--- a/src/schemas/ev42/ev42_rw.cpp
+++ b/src/schemas/ev42/ev42_rw.cpp
@@ -189,7 +189,7 @@ HDFWriterModule::reopen(hdf5::node::Group &HDFGroup) {
 void HDFWriterModule::write(FlatbufferMessage const &Message) {
   if (!ds_event_time_offset) {
     throw FileWriter::HDFWriterModuleRegistry::WriterException(
-        "Writer IO error.");
+        "Error, time of flight not present.");
   }
   auto fbuf = get_fbuf(Message.data());
   auto w1ret = this->ds_event_time_offset->append_data_1d(

--- a/src/schemas/ev42/ev42_rw.cpp
+++ b/src/schemas/ev42/ev42_rw.cpp
@@ -189,7 +189,8 @@ HDFWriterModule::reopen(hdf5::node::Group &HDFGroup) {
 HDFWriterModule::WriteResult
 HDFWriterModule::write(FlatbufferMessage const &Message) {
   if (!ds_event_time_offset) {
-    return HDFWriterModule::WriteResult::ERROR_IO;
+    throw FileWriter::HDFWriterModuleRegistry::WriterException(
+        "Writer IO error.");
   }
   auto fbuf = get_fbuf(Message.data());
   auto w1ret = this->ds_event_time_offset->append_data_1d(

--- a/src/schemas/ev42/ev42_rw.cpp
+++ b/src/schemas/ev42/ev42_rw.cpp
@@ -186,8 +186,7 @@ HDFWriterModule::reopen(hdf5::node::Group &HDFGroup) {
   return HDFWriterModule::InitResult::OK;
 }
 
-HDFWriterModule::WriteResult
-HDFWriterModule::write(FlatbufferMessage const &Message) {
+void HDFWriterModule::write(FlatbufferMessage const &Message) {
   if (!ds_event_time_offset) {
     throw FileWriter::HDFWriterModuleRegistry::WriterException(
         "Writer IO error.");
@@ -211,7 +210,6 @@ HDFWriterModule::write(FlatbufferMessage const &Message) {
     this->ds_cue_index->append_data_1d(&event_index, 1);
     index_at_bytes = total_written_bytes;
   }
-  return HDFWriterModule::WriteResult::OK;
 }
 
 int32_t HDFWriterModule::flush() { return 0; }

--- a/src/schemas/ev42/ev42_rw.cpp
+++ b/src/schemas/ev42/ev42_rw.cpp
@@ -146,7 +146,7 @@ HDFWriterModule::init_hdf(hdf5::node::Group &HDFGroup,
         fmt::format("ev42 could not init hdf_parent: {}  trace: {}",
                     static_cast<std::string>(HDFGroup.link().path()), message));
   }
-  return HDFWriterModule::InitResult::OK();
+  return HDFWriterModule::InitResult::OK;
 }
 
 HDFWriterModule::InitResult
@@ -183,7 +183,7 @@ HDFWriterModule::reopen(hdf5::node::Group &HDFGroup) {
         fmt::format("ev42 could not init hdf_parent: {}",
                     static_cast<std::string>(HDFGroup.link().path())));
   }
-  return HDFWriterModule::InitResult::OK();
+  return HDFWriterModule::InitResult::OK;
 }
 
 HDFWriterModule::WriteResult

--- a/src/schemas/ev42/ev42_rw.h
+++ b/src/schemas/ev42/ev42_rw.h
@@ -21,7 +21,7 @@ public:
   InitResult init_hdf(hdf5::node::Group &HDFGroup,
                       std::string const &HDFAttributes) override;
   HDFWriterModule::InitResult reopen(hdf5::node::Group &HDFGroup) override;
-  WriteResult write(FlatbufferMessage const &Message) override;
+  void write(FlatbufferMessage const &Message) override;
   int32_t flush() override;
   int32_t close() override;
 

--- a/src/schemas/f142/f142_rw.cpp
+++ b/src/schemas/f142/f142_rw.cpp
@@ -236,14 +236,14 @@ HDFWriterModule::init_hdf(hdf5::node::Group &HDFGroup,
       LOG(Sev::Error,
           "Could not create a writer implementation for value_type {}",
           TypeName);
-      return HDFWriterModule::InitResult::ERROR_IO();
+      return HDFWriterModule::InitResult::ERROR_IO;
     }
     if (CreateMethod == CreateWriterTypedBaseMethod::CREATE) {
       for (auto const &Info : DatasetInfoList) {
         Info.Ptr = h5::h5d_chunked_1d<uint64_t>::create(HDFGroup, Info.Name,
                                                         Info.ChunkBytes);
         if (Info.Ptr.get() == nullptr) {
-          return HDFWriterModule::InitResult::ERROR_IO();
+          return HDFWriterModule::InitResult::ERROR_IO;
         }
       }
       auto AttributesJson = nlohmann::json::parse(*HDFAttributes);
@@ -252,7 +252,7 @@ HDFWriterModule::init_hdf(hdf5::node::Group &HDFGroup,
       for (auto const &Info : DatasetInfoList) {
         Info.Ptr = h5::h5d_chunked_1d<uint64_t>::open(HDFGroup, Info.Name);
         if (Info.Ptr.get() == nullptr) {
-          return HDFWriterModule::InitResult::ERROR_IO();
+          return HDFWriterModule::InitResult::ERROR_IO;
         }
         Info.Ptr->buffer_init(Info.BufferSize, Info.BufferPacketMaxSize);
       }
@@ -263,7 +263,7 @@ HDFWriterModule::init_hdf(hdf5::node::Group &HDFGroup,
         "f142 could not init HDFGroup: {}  trace: {}",
         static_cast<std::string>(HDFGroup.link().path()), message)));
   }
-  return HDFWriterModule::InitResult::OK();
+  return HDFWriterModule::InitResult::OK;
 }
 
 /// \brief  Inspect the incoming FlatBuffer from the message and write the

--- a/src/schemas/f142/f142_rw.cpp
+++ b/src/schemas/f142/f142_rw.cpp
@@ -278,7 +278,7 @@ HDFWriterModule::write(FlatbufferMessage const &Message) {
       LOG(Sev::Warning,
           "sorry, but we were unable to initialize for this kind of messages");
     }
-    return HDFWriterModule::WriteResult::ERROR_IO;
+    throw HDFWriterModuleRegistry::WriterException("Writer IO error.");
   }
   auto wret = ValueWriter->write(FlatBuffer);
   if (!wret) {

--- a/src/schemas/f142/f142_rw.cpp
+++ b/src/schemas/f142/f142_rw.cpp
@@ -277,7 +277,8 @@ void HDFWriterModule::write(FlatbufferMessage const &Message) {
       LOG(Sev::Warning,
           "sorry, but we were unable to initialize for this kind of messages");
     }
-    throw HDFWriterModuleRegistry::WriterException("Writer IO error.");
+    throw HDFWriterModuleRegistry::WriterException(
+        "Error, ValueWriter not initialized.");
   }
   auto wret = ValueWriter->write(FlatBuffer);
   if (!wret) {

--- a/src/schemas/f142/f142_rw.cpp
+++ b/src/schemas/f142/f142_rw.cpp
@@ -278,7 +278,7 @@ HDFWriterModule::write(FlatbufferMessage const &Message) {
       LOG(Sev::Warning,
           "sorry, but we were unable to initialize for this kind of messages");
     }
-    return HDFWriterModule::WriteResult::ERROR_IO();
+    return HDFWriterModule::WriteResult::ERROR_IO;
   }
   auto wret = ValueWriter->write(FlatBuffer);
   if (!wret) {
@@ -317,8 +317,7 @@ HDFWriterModule::write(FlatbufferMessage const &Message) {
       }
     }
   }
-  return HDFWriterModule::WriteResult::OK_WITH_TIMESTAMP(
-      FlatBuffer->timestamp());
+  return HDFWriterModule::WriteResult::OK;
 }
 
 /// Implement HDFWriterModule interface, just flushing.

--- a/src/schemas/f142/f142_rw.cpp
+++ b/src/schemas/f142/f142_rw.cpp
@@ -236,14 +236,14 @@ HDFWriterModule::init_hdf(hdf5::node::Group &HDFGroup,
       LOG(Sev::Error,
           "Could not create a writer implementation for value_type {}",
           TypeName);
-      return HDFWriterModule::InitResult::ERROR_IO;
+      return HDFWriterModule::InitResult::ERROR;
     }
     if (CreateMethod == CreateWriterTypedBaseMethod::CREATE) {
       for (auto const &Info : DatasetInfoList) {
         Info.Ptr = h5::h5d_chunked_1d<uint64_t>::create(HDFGroup, Info.Name,
                                                         Info.ChunkBytes);
         if (Info.Ptr.get() == nullptr) {
-          return HDFWriterModule::InitResult::ERROR_IO;
+          return HDFWriterModule::InitResult::ERROR;
         }
       }
       auto AttributesJson = nlohmann::json::parse(*HDFAttributes);
@@ -252,7 +252,7 @@ HDFWriterModule::init_hdf(hdf5::node::Group &HDFGroup,
       for (auto const &Info : DatasetInfoList) {
         Info.Ptr = h5::h5d_chunked_1d<uint64_t>::open(HDFGroup, Info.Name);
         if (Info.Ptr.get() == nullptr) {
-          return HDFWriterModule::InitResult::ERROR_IO;
+          return HDFWriterModule::InitResult::ERROR;
         }
         Info.Ptr->buffer_init(Info.BufferSize, Info.BufferPacketMaxSize);
       }

--- a/src/schemas/f142/f142_rw.cpp
+++ b/src/schemas/f142/f142_rw.cpp
@@ -268,8 +268,7 @@ HDFWriterModule::init_hdf(hdf5::node::Group &HDFGroup,
 
 /// \brief  Inspect the incoming FlatBuffer from the message and write the
 /// content to datasets.
-HDFWriterModule::WriteResult
-HDFWriterModule::write(FlatbufferMessage const &Message) {
+void HDFWriterModule::write(FlatbufferMessage const &Message) {
   auto FlatBuffer = get_fbuf(Message.data());
   if (!ValueWriter) {
     auto Now = CLOCK::now();
@@ -317,7 +316,6 @@ HDFWriterModule::write(FlatbufferMessage const &Message) {
       }
     }
   }
-  return HDFWriterModule::WriteResult::OK;
 }
 
 /// Implement HDFWriterModule interface, just flushing.

--- a/src/schemas/f142/f142_rw.h
+++ b/src/schemas/f142/f142_rw.h
@@ -56,7 +56,7 @@ public:
                       CreateWriterTypedBaseMethod CreateMethod);
 
   /// Write an incoming message which should contain a flatbuffer.
-  WriteResult write(FlatbufferMessage const &Message) override;
+  void write(FlatbufferMessage const &Message) override;
 
   /// Flush underlying buffers.
   int32_t flush() override;

--- a/src/schemas/hs00/Writer.cpp
+++ b/src/schemas/hs00/Writer.cpp
@@ -29,7 +29,7 @@ Writer::reopen(hdf5::node::Group &HDFGroup) {
   }
   TheWriterUntyped = WriterUntyped::createFromHDF(HDFGroup);
   if (!TheWriterUntyped) {
-    return FileWriter::HDFWriterModule::InitResult::ERROR_IO;
+    return FileWriter::HDFWriterModule::InitResult::ERROR;
   }
   return FileWriter::HDFWriterModule::InitResult::OK;
 }

--- a/src/schemas/hs00/Writer.cpp
+++ b/src/schemas/hs00/Writer.cpp
@@ -34,14 +34,12 @@ Writer::reopen(hdf5::node::Group &HDFGroup) {
   return FileWriter::HDFWriterModule::InitResult::OK;
 }
 
-FileWriter::HDFWriterModule::WriteResult
-Writer::write(FlatbufferMessage const &Message) {
+void Writer::write(FlatbufferMessage const &Message) {
   if (!TheWriterUntyped) {
     throw std::runtime_error("TheWriterUntyped is not initialized. Make sure "
                              "that you call parse_config() before.");
   }
-  auto Result = TheWriterUntyped->write(Message, DoFlushEachWrite);
-  return Result;
+  TheWriterUntyped->write(Message, DoFlushEachWrite);
 }
 
 int32_t Writer::flush() {

--- a/src/schemas/hs00/Writer.cpp
+++ b/src/schemas/hs00/Writer.cpp
@@ -41,9 +41,6 @@ Writer::write(FlatbufferMessage const &Message) {
                              "that you call parse_config() before.");
   }
   auto Result = TheWriterUntyped->write(Message, DoFlushEachWrite);
-  if (!Result.is_OK()) {
-    LOG(Sev::Error, "hs00 write error: {}", Result.to_str());
-  }
   return Result;
 }
 

--- a/src/schemas/hs00/Writer.cpp
+++ b/src/schemas/hs00/Writer.cpp
@@ -18,7 +18,7 @@ Writer::init_hdf(hdf5::node::Group &HDFGroup, std::string const &) {
                              "that you call parse_config() before.");
   }
   TheWriterUntyped->createHDFStructure(HDFGroup, ChunkBytes);
-  return FileWriter::HDFWriterModule::InitResult::OK();
+  return FileWriter::HDFWriterModule::InitResult::OK;
 }
 
 FileWriter::HDFWriterModule::InitResult
@@ -29,9 +29,9 @@ Writer::reopen(hdf5::node::Group &HDFGroup) {
   }
   TheWriterUntyped = WriterUntyped::createFromHDF(HDFGroup);
   if (!TheWriterUntyped) {
-    return FileWriter::HDFWriterModule::InitResult::ERROR_IO();
+    return FileWriter::HDFWriterModule::InitResult::ERROR_IO;
   }
-  return FileWriter::HDFWriterModule::InitResult::OK();
+  return FileWriter::HDFWriterModule::InitResult::OK;
 }
 
 FileWriter::HDFWriterModule::WriteResult

--- a/src/schemas/hs00/Writer.h
+++ b/src/schemas/hs00/Writer.h
@@ -18,7 +18,7 @@ public:
   InitResult init_hdf(hdf5::node::Group &HDFGroup,
                       std::string const &HDFAttributes) override;
   InitResult reopen(hdf5::node::Group &HDFGroup) override;
-  WriteResult write(FlatbufferMessage const &Message) override;
+  void write(FlatbufferMessage const &Message) override;
   int32_t flush() override;
   int32_t close() override;
 

--- a/src/schemas/hs00/WriterTyped.h
+++ b/src/schemas/hs00/WriterTyped.h
@@ -41,8 +41,7 @@ public:
   /// \param ChunkBytes
   void createHDFStructure(hdf5::node::Group &Group, size_t ChunkBytes) override;
 
-  HDFWriterModule::WriteResult write(FlatbufferMessage const &Message,
-                                     bool DoFlushEachWrite) override;
+  void write(FlatbufferMessage const &Message, bool DoFlushEachWrite) override;
 
   ~WriterTyped() override;
   int close() override;
@@ -304,7 +303,7 @@ void WriterTyped<DataType, EdgeType, ErrorType>::createHDFStructure(
 template <typename DataType> Array getMatchingFlatbufferType(DataType *);
 
 template <typename DataType, typename EdgeType, typename ErrorType>
-HDFWriterModule::WriteResult WriterTyped<DataType, EdgeType, ErrorType>::write(
+void WriterTyped<DataType, EdgeType, ErrorType>::write(
     FlatbufferMessage const &Message, bool DoFlushEachWrite) {
   using HDFWriterModuleRegistry::WriterException;
 
@@ -499,7 +498,6 @@ HDFWriterModule::WriteResult WriterTyped<DataType, EdgeType, ErrorType>::write(
     Dataset.link().file().flush(hdf5::file::Scope::GLOBAL);
   }
   LOG(Sev::Debug, "hs00 -------------------------------   DONE");
-  return HDFWriterModule::WriteResult::OK;
 }
 } // namespace hs00
 } // namespace Schemas

--- a/src/schemas/hs00/WriterTyped.h
+++ b/src/schemas/hs00/WriterTyped.h
@@ -306,48 +306,47 @@ template <typename DataType> Array getMatchingFlatbufferType(DataType *);
 template <typename DataType, typename EdgeType, typename ErrorType>
 HDFWriterModule::WriteResult WriterTyped<DataType, EdgeType, ErrorType>::write(
     FlatbufferMessage const &Message, bool DoFlushEachWrite) {
+  using HDFWriterModuleRegistry::WriterException;
+
   if (!Dataset.is_valid()) {
-    return HDFWriterModule::WriteResult::ERROR_WITH_MESSAGE("invalid dataset");
+    throw WriterException("invalid dataset");
   }
   auto Dims = hdf5::dataspace::Simple(Dataset.dataspace()).current_dimensions();
   if (Dims.empty()) {
-    return HDFWriterModule::WriteResult::ERROR_WITH_MESSAGE("Dims is empty");
+    throw WriterException("Dims is empty");
   }
   auto EvMsg = GetEventHistogram(Message.data());
   uint64_t Timestamp = EvMsg->timestamp();
   if (Timestamp == 0) {
-    return HDFWriterModule::WriteResult::ERROR_WITH_MESSAGE("Timestamp == 0");
+    throw WriterException("Timestamp == 0");
   }
   if (EvMsg->data_type() != getMatchingFlatbufferType<DataType>(nullptr)) {
-    return HDFWriterModule::WriteResult::ERROR_WITH_MESSAGE(
+    throw WriterException(
         "EvMsg->data_type() != getMatchingFlatbufferType<DataType>(nullptr)");
   }
   auto DataUnion = static_cast<FlatbufferDataType const *>(EvMsg->data());
   if (!DataUnion) {
-    return HDFWriterModule::WriteResult::ERROR_WITH_MESSAGE("!DataUnion");
+    throw WriterException("!DataUnion");
   }
   auto DataPtr = DataUnion->value();
   if (!DataPtr) {
-    return HDFWriterModule::WriteResult::ERROR_WITH_MESSAGE("!DataPtr");
+    throw WriterException("!DataPtr");
   }
   flatbuffers::Vector<ErrorType> const *ErrorsPtr = nullptr;
   auto ErrorsUnion = static_cast<FlatbufferErrorType const *>(EvMsg->errors());
   if (ErrorsUnion) {
     if (EvMsg->errors_type() != getMatchingFlatbufferType<ErrorType>(nullptr)) {
-      return HDFWriterModule::WriteResult::ERROR_WITH_MESSAGE(
-          "EvMsg->errors_type() != "
-          "getMatchingFlatbufferType<ErrorType>(nullptr)");
+      throw WriterException("EvMsg->errors_type() != "
+                            "getMatchingFlatbufferType<ErrorType>(nullptr)");
     }
     ErrorsPtr = ErrorsUnion->value();
   }
   auto MsgShape = EvMsg->current_shape();
   if (!MsgShape) {
-    return HDFWriterModule::WriteResult::ERROR_WITH_MESSAGE(
-        "Missing current_shape");
+    throw WriterException("Missing current_shape");
   }
   if (MsgShape->size() != Dims.size() - 1) {
-    return HDFWriterModule::WriteResult::ERROR_WITH_MESSAGE(
-        "Wrong size of shape");
+    throw WriterException("Wrong size of shape");
   }
   std::vector<uint32_t> TheOffsets;
   TheOffsets.resize(MsgShape->size());
@@ -357,8 +356,7 @@ HDFWriterModule::WriteResult WriterTyped<DataType, EdgeType, ErrorType>::write(
       for (size_t I = 0; I < TheOffsets.size(); ++I) {
         auto X = MsgOffset->data()[I];
         if (X + MsgShape->data()[I] > Dims.at(I + 1)) {
-          return HDFWriterModule::WriteResult::ERROR_WITH_MESSAGE(
-              "Shape not consistent");
+          throw WriterException("Shape not consistent");
         }
         TheOffsets.at(I) = X;
       }
@@ -369,19 +367,18 @@ HDFWriterModule::WriteResult WriterTyped<DataType, EdgeType, ErrorType>::write(
     ExpectedLinearDataSize *= MsgShape->data()[i];
   }
   if (ExpectedLinearDataSize != DataPtr->size()) {
-    return HDFWriterModule::WriteResult::ERROR_WITH_MESSAGE(
-        "Unexpected data size");
+    throw WriterException("Unexpected data size");
   }
   if (ErrorsPtr) {
     if (ExpectedLinearDataSize != ErrorsPtr->size()) {
-      return HDFWriterModule::WriteResult::ERROR_WITH_MESSAGE(
-          "Unexpected errors size");
+      throw WriterException("Unexpected errors size");
     }
   }
   if (Timestamp + 40l * 1000000000l < LargestTimestampSeen) {
-    return HDFWriterModule::WriteResult::ERROR_WITH_MESSAGE(
+    throw WriterException(
         fmt::format("Old histogram: Timestamp: {}  LargestTimestampSeen: {}",
-                    Timestamp, LargestTimestampSeen));
+                    Timestamp, LargestTimestampSeen)
+            .c_str());
   }
   if (LargestTimestampSeen < Timestamp) {
     LargestTimestampSeen = Timestamp;
@@ -411,8 +408,7 @@ HDFWriterModule::WriteResult WriterTyped<DataType, EdgeType, ErrorType>::write(
                             MsgShape->data() + MsgShape->size()));
   auto &Record = HistogramRecords[Timestamp];
   if (!Record.hasEmptySlice(TheSlice)) {
-    return HDFWriterModule::WriteResult::ERROR_WITH_MESSAGE(
-        "Slice already at least partially filled");
+    throw WriterException("Slice already at least partially filled");
   }
   Record.addSlice(TheSlice);
   hdf5::dataspace::Simple DSPMem;
@@ -503,7 +499,7 @@ HDFWriterModule::WriteResult WriterTyped<DataType, EdgeType, ErrorType>::write(
     Dataset.link().file().flush(hdf5::file::Scope::GLOBAL);
   }
   LOG(Sev::Debug, "hs00 -------------------------------   DONE");
-  return HDFWriterModule::WriteResult::OK();
+  return HDFWriterModule::WriteResult::OK;
 }
 } // namespace hs00
 } // namespace Schemas

--- a/src/schemas/hs00/WriterTyped.h
+++ b/src/schemas/hs00/WriterTyped.h
@@ -308,7 +308,7 @@ void WriterTyped<DataType, EdgeType, ErrorType>::write(
   using HDFWriterModuleRegistry::WriterException;
 
   if (!Dataset.is_valid()) {
-    throw WriterException("invalid dataset");
+    throw WriterException("Invalid dataset");
   }
   auto Dims = hdf5::dataspace::Simple(Dataset.dataspace()).current_dimensions();
   if (Dims.empty()) {
@@ -376,8 +376,7 @@ void WriterTyped<DataType, EdgeType, ErrorType>::write(
   if (Timestamp + 40l * 1000000000l < LargestTimestampSeen) {
     throw WriterException(
         fmt::format("Old histogram: Timestamp: {}  LargestTimestampSeen: {}",
-                    Timestamp, LargestTimestampSeen)
-            .c_str());
+                    Timestamp, LargestTimestampSeen));
   }
   if (LargestTimestampSeen < Timestamp) {
     LargestTimestampSeen = Timestamp;

--- a/src/schemas/hs00/WriterUntyped.h
+++ b/src/schemas/hs00/WriterUntyped.h
@@ -27,8 +27,8 @@ public:
   virtual void createHDFStructure(hdf5::node::Group &Group,
                                   size_t ChunkBytes) = 0;
 
-  virtual HDFWriterModule::WriteResult write(FlatbufferMessage const &Message,
-                                             bool DoFlushEachWrite) = 0;
+  virtual void write(FlatbufferMessage const &Message,
+                     bool DoFlushEachWrite) = 0;
 
   virtual ~WriterUntyped() = default;
   virtual int close() = 0;

--- a/src/schemas/senv/FastSampleEnvironmentWriter.cpp
+++ b/src/schemas/senv/FastSampleEnvironmentWriter.cpp
@@ -115,7 +115,7 @@ std::vector<std::uint64_t> GenerateTimeStamps(std::uint64_t OriginTimeStamp,
   return ReturnVector;
 }
 
-FileWriterBase::WriteResult FastSampleEnvironmentWriter::write(
+void FastSampleEnvironmentWriter::write(
     const FileWriter::FlatbufferMessage &Message) {
   auto FbPointer = GetSampleEnvironmentData(Message.data());
   auto TempDataPtr = FbPointer->Values()->data();
@@ -123,7 +123,7 @@ FileWriterBase::WriteResult FastSampleEnvironmentWriter::write(
   if (TempDataSize == 0) {
     LOG(Sev::Warning,
         "Received a flatbuffer with zero (0) data elements in it.");
-    return FileWriterBase::WriteResult::OK;
+    return;
   }
   ArrayAdapter<const std::uint16_t> CArray(TempDataPtr, TempDataSize);
   auto CueIndexValue = Value.dataspace().size();
@@ -143,7 +143,6 @@ FileWriterBase::WriteResult FastSampleEnvironmentWriter::write(
         FbPointer->PacketTimestamp(), FbPointer->TimeDelta(), TempDataSize));
     Timestamp.appendArray(TempTimeStamps);
   }
-  return FileWriterBase::WriteResult::OK;
 }
 
 std::int32_t FastSampleEnvironmentWriter::flush() { return 0; }

--- a/src/schemas/senv/FastSampleEnvironmentWriter.cpp
+++ b/src/schemas/senv/FastSampleEnvironmentWriter.cpp
@@ -81,7 +81,7 @@ FastSampleEnvironmentWriter::init_hdf(hdf5::node::Group &HDFGroup,
     LOG(Sev::Error, "Unable to initialise fast sample environment data tree in "
                     "HDF file with error message: \"{}\"",
         E.what());
-    return HDFWriterModule::InitResult::ERROR_IO;
+    return HDFWriterModule::InitResult::ERROR;
   }
   return FileWriterBase::InitResult::OK;
 }
@@ -100,7 +100,7 @@ FastSampleEnvironmentWriter::reopen(hdf5::node::Group &HDFGroup) {
     LOG(Sev::Error,
         "Failed to reopen datasets in HDF file with error message: \"{}\"",
         std::string(E.what()));
-    return HDFWriterModule::InitResult::ERROR_IO;
+    return HDFWriterModule::InitResult::ERROR;
   }
   return FileWriterBase::InitResult::OK;
 }

--- a/src/schemas/senv/FastSampleEnvironmentWriter.cpp
+++ b/src/schemas/senv/FastSampleEnvironmentWriter.cpp
@@ -81,9 +81,9 @@ FastSampleEnvironmentWriter::init_hdf(hdf5::node::Group &HDFGroup,
     LOG(Sev::Error, "Unable to initialise fast sample environment data tree in "
                     "HDF file with error message: \"{}\"",
         E.what());
-    return HDFWriterModule::InitResult::ERROR_IO();
+    return HDFWriterModule::InitResult::ERROR_IO;
   }
-  return FileWriterBase::InitResult::OK();
+  return FileWriterBase::InitResult::OK;
 }
 
 FileWriterBase::InitResult
@@ -100,9 +100,9 @@ FastSampleEnvironmentWriter::reopen(hdf5::node::Group &HDFGroup) {
     LOG(Sev::Error,
         "Failed to reopen datasets in HDF file with error message: \"{}\"",
         std::string(E.what()));
-    return HDFWriterModule::InitResult::ERROR_IO();
+    return HDFWriterModule::InitResult::ERROR_IO;
   }
-  return FileWriterBase::InitResult::OK();
+  return FileWriterBase::InitResult::OK;
 }
 
 std::vector<std::uint64_t> GenerateTimeStamps(std::uint64_t OriginTimeStamp,

--- a/src/schemas/senv/FastSampleEnvironmentWriter.cpp
+++ b/src/schemas/senv/FastSampleEnvironmentWriter.cpp
@@ -123,7 +123,7 @@ FileWriterBase::WriteResult FastSampleEnvironmentWriter::write(
   if (TempDataSize == 0) {
     LOG(Sev::Warning,
         "Received a flatbuffer with zero (0) data elements in it.");
-    return FileWriterBase::WriteResult::OK();
+    return FileWriterBase::WriteResult::OK;
   }
   ArrayAdapter<const std::uint16_t> CArray(TempDataPtr, TempDataSize);
   auto CueIndexValue = Value.dataspace().size();
@@ -143,7 +143,7 @@ FileWriterBase::WriteResult FastSampleEnvironmentWriter::write(
         FbPointer->PacketTimestamp(), FbPointer->TimeDelta(), TempDataSize));
     Timestamp.appendArray(TempTimeStamps);
   }
-  return FileWriterBase::WriteResult::OK();
+  return FileWriterBase::WriteResult::OK;
 }
 
 std::int32_t FastSampleEnvironmentWriter::flush() { return 0; }

--- a/src/schemas/senv/FastSampleEnvironmentWriter.h
+++ b/src/schemas/senv/FastSampleEnvironmentWriter.h
@@ -42,7 +42,7 @@ public:
 
   InitResult reopen(hdf5::node::Group &HDFGroup) override;
 
-  WriteResult write(FlatbufferMessage const &Message) override;
+  void write(FlatbufferMessage const &Message) override;
 
   int32_t flush() override;
 

--- a/src/schemas/template/TemplateWriter.h
+++ b/src/schemas/template/TemplateWriter.h
@@ -275,11 +275,6 @@ public:
   ///
   /// \param[in] Message The structure containing a pointer to a buffer
   /// containing data received from the Kafka broker and the size of the buffer.
-  ///
-  /// \return An instance of WriteResult. Note that these instances can only be
-  /// constructed using a set of static member functions defined in
-  /// HDFWriterModule.h. In the current implementation, returning a write result
-  /// with a timestamp only has an effect on the log messages being generated.
   void write(FileWriter::FlatbufferMessage const &Message) override {
     std::cout << "WriterClass::write()\n";
   }

--- a/src/schemas/template/TemplateWriter.h
+++ b/src/schemas/template/TemplateWriter.h
@@ -282,7 +282,7 @@ public:
   /// with a timestamp only has an effect on the log messages being generated.
   WriteResult write(FileWriter::FlatbufferMessage const &Message) override {
     std::cout << "WriterClass::write()\n";
-    return WriteResult::OK();
+    return WriteResult::OK;
   }
 
   /// \brief Provides no functionality and is never called.

--- a/src/schemas/template/TemplateWriter.h
+++ b/src/schemas/template/TemplateWriter.h
@@ -280,9 +280,8 @@ public:
   /// constructed using a set of static member functions defined in
   /// HDFWriterModule.h. In the current implementation, returning a write result
   /// with a timestamp only has an effect on the log messages being generated.
-  WriteResult write(FileWriter::FlatbufferMessage const &Message) override {
+  void write(FileWriter::FlatbufferMessage const &Message) override {
     std::cout << "WriterClass::write()\n";
-    return WriteResult::OK;
   }
 
   /// \brief Provides no functionality and is never called.

--- a/src/schemas/template/TemplateWriter.h
+++ b/src/schemas/template/TemplateWriter.h
@@ -218,7 +218,7 @@ public:
   InitResult init_hdf(hdf5::node::Group &HDFGroup,
                       std::string const &HDFAttributes) override {
     std::cout << "WriterClass::init_hdf()\n";
-    return InitResult::OK();
+    return InitResult::OK;
   }
 
   /// \brief Re-open datasets that have been created when calling
@@ -251,7 +251,7 @@ public:
   /// InitResult::ERROR_IO() and InitResult::ERROR_INCOMPLETE_CONFIGURATION().
   InitResult reopen(hdf5::node::Group &HDFGroup) override {
     std::cout << "WriterClass::reopen()\n";
-    return InitResult::OK();
+    return InitResult::OK;
   }
 
   /// \brief Implements the data writing functionality of the file writing

--- a/src/tests/AreaDetectorTest.cpp
+++ b/src/tests/AreaDetectorTest.cpp
@@ -312,13 +312,15 @@ TEST_F(AreaDetectorWriter, WriterDefaultValuesTest) {
   EXPECT_EQ(ChunkDims, (hdf5::Dimensions{64, 1, 1}));
 }
 
+using WriteResult = FileWriter::HDFWriterModule_detail::WriteResult;
+
 TEST_F(AreaDetectorWriter, WriterWriteTest) {
   FileWriter::FlatbufferMessage Message(RawData.get(), FileSize);
   ADWriterStandIn Temp;
   Temp.init_hdf(UsedGroup, "{}");
   Temp.reopen(UsedGroup);
-  EXPECT_TRUE(Temp.write(Message).is_OK());
-  EXPECT_TRUE(Temp.write(Message).is_OK());
+  EXPECT_TRUE(Temp.write(Message) == WriteResult::OK);
+  EXPECT_TRUE(Temp.write(Message) == WriteResult::OK);
   EXPECT_EQ(2, Temp.Timestamp.dataspace().size());
 }
 
@@ -332,7 +334,7 @@ TEST_F(AreaDetectorWriter, WriterCueCounterTest) {
   Writer.init_hdf(UsedGroup, "{}");
   Writer.reopen(UsedGroup);
   for (int i = 0; i < 5; i++) {
-    EXPECT_TRUE(Writer.write(Message).is_OK());
+    EXPECT_TRUE(Writer.write(Message) == WriteResult::OK);
     if (i < 2) {
       EXPECT_EQ(0, Writer.CueTimestampIndex.dataspace().size());
       EXPECT_EQ(0, Writer.CueTimestamp.dataspace().size());
@@ -368,7 +370,7 @@ TEST_F(AreaDetectorWriter, WriterCueIndexTest) {
     FileWriter::FlatbufferMessage Message(
         reinterpret_cast<char *>(builder.GetBufferPointer()),
         builder.GetSize());
-    EXPECT_TRUE(Writer.write(Message).is_OK());
+    EXPECT_TRUE(Writer.write(Message) == WriteResult::OK);
   }
   std::vector<std::uint64_t> CueIndexValues(
       Writer.CueTimestampIndex.dataspace().size());
@@ -388,7 +390,7 @@ TEST_F(AreaDetectorWriter, WriterDimensionsTest) {
   ADWriterStandIn Writer;
   Writer.init_hdf(UsedGroup, "{}");
   Writer.reopen(UsedGroup);
-  EXPECT_TRUE(Writer.write(Message).is_OK());
+  EXPECT_TRUE(Writer.write(Message) == WriteResult::OK);
   auto Dataspace = hdf5::dataspace::Simple(Writer.Values->dataspace());
   EXPECT_EQ((hdf5::Dimensions{1, 10, 12}), Dataspace.current_dimensions());
 }
@@ -543,7 +545,7 @@ bool WriteTest(hdf5::node::Group &UsedGroup, FB_Tables::DType FBType) {
   Writer.parse_config(JsonConfig.dump(), "");
   Writer.init_hdf(UsedGroup, "{}");
   Writer.reopen(UsedGroup);
-  if (Writer.write(Message).is_ERR()) {
+  if (Writer.write(Message) != WriteResult::OK) {
     return false;
   }
   std::vector<Type> dataFromFile(testData.size());

--- a/src/tests/AreaDetectorTest.cpp
+++ b/src/tests/AreaDetectorTest.cpp
@@ -152,12 +152,14 @@ TEST_F(AreaDetectorWriter, WriterInitTest) {
   EXPECT_TRUE(FoundAttribute);
 }
 
+using FileWriter::HDFWriterModule_detail::InitResult;
+
 TEST_F(AreaDetectorWriter, WriterAttributeExists) {
   auto ClassAttribute = UsedGroup.attributes.create<std::string>("NX_class");
   ClassAttribute.write("NXlog");
   {
     ADWriterStandIn Temp;
-    EXPECT_TRUE(Temp.init_hdf(UsedGroup, "{}").is_ERR());
+    EXPECT_TRUE(Temp.init_hdf(UsedGroup, "{}") != InitResult::OK);
   }
 }
 
@@ -167,12 +169,12 @@ TEST_F(AreaDetectorWriter, WriterInitFail) {
     Temp.init_hdf(UsedGroup, "{}");
   }
   ADWriterStandIn Writer;
-  EXPECT_TRUE(Writer.init_hdf(UsedGroup, "{}").is_ERR());
+  EXPECT_TRUE(Writer.init_hdf(UsedGroup, "{}") != InitResult::OK);
 }
 
 TEST_F(AreaDetectorWriter, WriterReOpenFail) {
   ADWriterStandIn Writer;
-  EXPECT_TRUE(Writer.reopen(UsedGroup).is_ERR());
+  EXPECT_TRUE(Writer.reopen(UsedGroup) != InitResult::OK);
 }
 
 TEST_F(AreaDetectorWriter, WriterInitInt8) {

--- a/src/tests/AreaDetectorTest.cpp
+++ b/src/tests/AreaDetectorTest.cpp
@@ -312,8 +312,6 @@ TEST_F(AreaDetectorWriter, WriterDefaultValuesTest) {
   EXPECT_EQ(ChunkDims, (hdf5::Dimensions{64, 1, 1}));
 }
 
-using WriteResult = FileWriter::HDFWriterModule_detail::WriteResult;
-
 TEST_F(AreaDetectorWriter, WriterWriteTest) {
   FileWriter::FlatbufferMessage Message(RawData.get(), FileSize);
   ADWriterStandIn Temp;

--- a/src/tests/AreaDetectorTest.cpp
+++ b/src/tests/AreaDetectorTest.cpp
@@ -595,5 +595,6 @@ TEST_F(AreaDetectorWriter, WriterCharTest) {
 }
 
 TEST_F(AreaDetectorWriter, WriterWrongFBTypeTest) {
-  EXPECT_FALSE(WriteTest<char>(UsedGroup, FB_Tables::DType(9999)));
+  EXPECT_THROW(WriteTest<char>(UsedGroup, FB_Tables::DType(9999)),
+               FileWriter::HDFWriterModuleRegistry::WriterException);
 }

--- a/src/tests/DemuxerTests.cpp
+++ b/src/tests/DemuxerTests.cpp
@@ -37,7 +37,7 @@ public:
     return InitResult::OK;
   }
   WriteResult write(FlatbufferMessage const &Message) override {
-    return WriteResult::OK();
+    return WriteResult::OK;
   }
   std::int32_t flush() override { return 0; }
 

--- a/src/tests/DemuxerTests.cpp
+++ b/src/tests/DemuxerTests.cpp
@@ -31,10 +31,10 @@ public:
                     std::string const &ConfigurationModule) override {}
   InitResult init_hdf(hdf5::node::Group &HDFGroup,
                       std::string const &HDFAttributes) override {
-    return InitResult::OK();
+    return InitResult::OK;
   }
   InitResult reopen(hdf5::node::Group &HDFGrup) override {
-    return InitResult::OK();
+    return InitResult::OK;
   }
   WriteResult write(FlatbufferMessage const &Message) override {
     return WriteResult::OK();

--- a/src/tests/DemuxerTests.cpp
+++ b/src/tests/DemuxerTests.cpp
@@ -36,9 +36,7 @@ public:
   InitResult reopen(hdf5::node::Group &HDFGrup) override {
     return InitResult::OK;
   }
-  WriteResult write(FlatbufferMessage const &Message) override {
-    return WriteResult::OK;
-  }
+  void write(FlatbufferMessage const &Message) override {}
   std::int32_t flush() override { return 0; }
 
   std::int32_t close() override { return 0; }

--- a/src/tests/EventHistogramWriterTests.cpp
+++ b/src/tests/EventHistogramWriterTests.cpp
@@ -374,13 +374,15 @@ wrapBuilder(std::unique_ptr<flatbuffers::FlatBufferBuilder> const &Builder) {
       Builder->GetSize());
 }
 
+using FileWriter::HDFWriterModule_detail::InitResult;
+
 TEST_F(EventHistogramWriter, WriterInitHDF) {
   auto File = createFile("Test.EventHistogramWriter.WriterInitHDF",
                          FileCreationLocation::Default);
   auto Group = File.root();
   auto Writer = Writer::create();
   Writer->parse_config(createTestWriterTypedJson().dump(), "{}");
-  ASSERT_TRUE(Writer->init_hdf(Group, "{}").is_OK());
+  ASSERT_TRUE(Writer->init_hdf(Group, "{}") == InitResult::OK);
 }
 
 TEST_F(EventHistogramWriter, WriterReopen) {
@@ -389,10 +391,10 @@ TEST_F(EventHistogramWriter, WriterReopen) {
   auto Group = File.root();
   auto Writer = Writer::create();
   Writer->parse_config(createTestWriterTypedJson().dump(), "{}");
-  ASSERT_TRUE(Writer->init_hdf(Group, "{}").is_OK());
+  ASSERT_TRUE(Writer->init_hdf(Group, "{}") == InitResult::OK);
   Writer = Writer::create();
   Writer->parse_config(createTestWriterTypedJson().dump(), "{}");
-  ASSERT_TRUE(Writer->reopen(Group).is_OK());
+  ASSERT_TRUE(Writer->reopen(Group) == InitResult::OK);
 }
 
 TEST_F(EventHistogramWriter, WriteFullHistogramFromMultipleMessages) {
@@ -402,10 +404,10 @@ TEST_F(EventHistogramWriter, WriteFullHistogramFromMultipleMessages) {
   auto Group = File.root();
   auto Writer = Writer::create();
   Writer->parse_config(createTestWriterTypedJson().dump(), "{}");
-  ASSERT_TRUE(Writer->init_hdf(Group, "{}").is_OK());
+  ASSERT_TRUE(Writer->init_hdf(Group, "{}") == InitResult::OK);
   Writer = Writer::create();
   Writer->parse_config(createTestWriterTypedJson().dump(), "{}");
-  ASSERT_TRUE(Writer->reopen(Group).is_OK());
+  ASSERT_TRUE(Writer->reopen(Group) == InitResult::OK);
   std::vector<uint32_t> DimLengths{4, 2, 2};
   for (size_t i = 0; i < 4; ++i) {
     auto M = createTestMessage(0, i, DimLengths);
@@ -429,10 +431,10 @@ TEST_F(EventHistogramWriter, WriteMultipleHistograms) {
   auto Group = File.root();
   auto Writer = Writer::create();
   Writer->parse_config(createTestWriterTypedJson().dump(), "{}");
-  ASSERT_TRUE(Writer->init_hdf(Group, "{}").is_OK());
+  ASSERT_TRUE(Writer->init_hdf(Group, "{}") == InitResult::OK);
   Writer = Writer::create();
   Writer->parse_config(createTestWriterTypedJson().dump(), "{}");
-  ASSERT_TRUE(Writer->reopen(Group).is_OK());
+  ASSERT_TRUE(Writer->reopen(Group) == InitResult::OK);
   std::vector<uint32_t> DimLengths{4, 2, 2};
   size_t HistogramID = 0;
   for (size_t i = 0; i < 3; ++i) {
@@ -476,10 +478,10 @@ TEST_F(EventHistogramWriter, WriteManyHistograms) {
   auto Group = File.root();
   auto Writer = Writer::create();
   Writer->parse_config(createTestWriterTypedJson().dump(), "{}");
-  ASSERT_TRUE(Writer->init_hdf(Group, "{}").is_OK());
+  ASSERT_TRUE(Writer->init_hdf(Group, "{}") == InitResult::OK);
   Writer = Writer::create();
   Writer->parse_config(createTestWriterTypedJson().dump(), "{}");
-  ASSERT_TRUE(Writer->reopen(Group).is_OK());
+  ASSERT_TRUE(Writer->reopen(Group) == InitResult::OK);
   std::vector<uint32_t> DimLengths{4, 2, 2};
   for (size_t HistogramID = 0; HistogramID < 18; ++HistogramID) {
     for (size_t i = 0; i < 4; ++i) {
@@ -522,10 +524,10 @@ TEST_F(EventHistogramWriter, WriteAMORExample) {
   }
   std::string JsonBulk(V1.data(), V1.data() + V1.size());
   Writer->parse_config(JsonBulk, "{}");
-  ASSERT_TRUE(Writer->init_hdf(Group, "{}").is_OK());
+  ASSERT_TRUE(Writer->init_hdf(Group, "{}") == InitResult::OK);
   Writer = Writer::create();
   Writer->parse_config(JsonBulk, "{}");
-  ASSERT_TRUE(Writer->reopen(Group).is_OK());
+  ASSERT_TRUE(Writer->reopen(Group) == InitResult::OK);
   auto M = FileWriter::FlatbufferMessage(
       reinterpret_cast<const char *>(V2.data()), V2.size());
   auto X = Writer->write(M);

--- a/src/tests/EventHistogramWriterTests.cpp
+++ b/src/tests/EventHistogramWriterTests.cpp
@@ -413,11 +413,7 @@ TEST_F(EventHistogramWriter, WriteFullHistogramFromMultipleMessages) {
   std::vector<uint32_t> DimLengths{4, 2, 2};
   for (size_t i = 0; i < 4; ++i) {
     auto M = createTestMessage(0, i, DimLengths);
-    auto X = Writer->write(wrapBuilder(M));
-    //    if (X!=WriteResult::OK) {
-    //      throw std::runtime_error(X.to_str());
-    //    }
-    ASSERT_TRUE(X == WriteResult::OK);
+    ASSERT_NO_THROW(Writer->write(wrapBuilder(M)));
   }
   auto Histograms = Group.get_dataset("histograms");
   hdf5::dataspace::Simple Dataspace(Histograms.dataspace());
@@ -441,29 +437,17 @@ TEST_F(EventHistogramWriter, WriteMultipleHistograms) {
   size_t HistogramID = 0;
   for (size_t i = 0; i < 3; ++i) {
     auto M = createTestMessage(HistogramID, i, DimLengths);
-    auto X = Writer->write(wrapBuilder(M));
-    if (X != WriteResult::OK) {
-      throw std::runtime_error("Error");
-    }
-    ASSERT_TRUE(X == WriteResult::OK);
+    ASSERT_NO_THROW(Writer->write(wrapBuilder(M)));
   }
   ++HistogramID;
   for (size_t i = 0; i < 4; ++i) {
     auto M = createTestMessage(HistogramID, i, DimLengths);
-    auto X = Writer->write(wrapBuilder(M));
-    if (X != WriteResult::OK) {
-      throw std::runtime_error("Error");
-    }
-    ASSERT_TRUE(X == WriteResult::OK);
+    ASSERT_NO_THROW(Writer->write(wrapBuilder(M)));
   }
   ++HistogramID;
   for (size_t i = 1; i < 4; ++i) {
     auto M = createTestMessage(HistogramID, i, DimLengths);
-    auto X = Writer->write(wrapBuilder(M));
-    if (X != WriteResult::OK) {
-      throw std::runtime_error("Error");
-    }
-    ASSERT_TRUE(X == WriteResult::OK);
+    ASSERT_NO_THROW(Writer->write(wrapBuilder(M)));
   }
   Writer->close();
   auto Histograms = Group.get_dataset("histograms");
@@ -488,11 +472,7 @@ TEST_F(EventHistogramWriter, WriteManyHistograms) {
   for (size_t HistogramID = 0; HistogramID < 18; ++HistogramID) {
     for (size_t i = 0; i < 4; ++i) {
       auto M = createTestMessage(HistogramID, i, DimLengths);
-      auto X = Writer->write(wrapBuilder(M));
-      if (X != WriteResult::OK) {
-        throw std::runtime_error("Error");
-      }
-      ASSERT_TRUE(X == WriteResult::OK);
+      ASSERT_NO_THROW(Writer->write(wrapBuilder(M)));
     }
   }
   Writer->close();
@@ -532,9 +512,5 @@ TEST_F(EventHistogramWriter, WriteAMORExample) {
   ASSERT_TRUE(Writer->reopen(Group) == InitResult::OK);
   auto M = FileWriter::FlatbufferMessage(
       reinterpret_cast<const char *>(V2.data()), V2.size());
-  auto X = Writer->write(M);
-  if (X != WriteResult::OK) {
-    throw std::runtime_error("Error");
-  }
-  ASSERT_TRUE(X == WriteResult::OK);
+  ASSERT_NO_THROW(Writer->write(M));
 }

--- a/src/tests/EventHistogramWriterTests.cpp
+++ b/src/tests/EventHistogramWriterTests.cpp
@@ -397,8 +397,6 @@ TEST_F(EventHistogramWriter, WriterReopen) {
   ASSERT_TRUE(Writer->reopen(Group) == InitResult::OK);
 }
 
-using WriteResult = FileWriter::HDFWriterModule_detail::WriteResult;
-
 TEST_F(EventHistogramWriter, WriteFullHistogramFromMultipleMessages) {
   auto File = createFile(
       "Test.EventHistogramWriter.WriteFullHistogramFromMultipleMessages",

--- a/src/tests/EventHistogramWriterTests.cpp
+++ b/src/tests/EventHistogramWriterTests.cpp
@@ -397,6 +397,8 @@ TEST_F(EventHistogramWriter, WriterReopen) {
   ASSERT_TRUE(Writer->reopen(Group) == InitResult::OK);
 }
 
+using WriteResult = FileWriter::HDFWriterModule_detail::WriteResult;
+
 TEST_F(EventHistogramWriter, WriteFullHistogramFromMultipleMessages) {
   auto File = createFile(
       "Test.EventHistogramWriter.WriteFullHistogramFromMultipleMessages",
@@ -412,10 +414,10 @@ TEST_F(EventHistogramWriter, WriteFullHistogramFromMultipleMessages) {
   for (size_t i = 0; i < 4; ++i) {
     auto M = createTestMessage(0, i, DimLengths);
     auto X = Writer->write(wrapBuilder(M));
-    if (!X.is_OK()) {
-      throw std::runtime_error(X.to_str());
-    }
-    ASSERT_TRUE(X.is_OK());
+    //    if (X!=WriteResult::OK) {
+    //      throw std::runtime_error(X.to_str());
+    //    }
+    ASSERT_TRUE(X == WriteResult::OK);
   }
   auto Histograms = Group.get_dataset("histograms");
   hdf5::dataspace::Simple Dataspace(Histograms.dataspace());
@@ -440,28 +442,28 @@ TEST_F(EventHistogramWriter, WriteMultipleHistograms) {
   for (size_t i = 0; i < 3; ++i) {
     auto M = createTestMessage(HistogramID, i, DimLengths);
     auto X = Writer->write(wrapBuilder(M));
-    if (!X.is_OK()) {
-      throw std::runtime_error(X.to_str());
+    if (X != WriteResult::OK) {
+      throw std::runtime_error("Error");
     }
-    ASSERT_TRUE(X.is_OK());
+    ASSERT_TRUE(X == WriteResult::OK);
   }
   ++HistogramID;
   for (size_t i = 0; i < 4; ++i) {
     auto M = createTestMessage(HistogramID, i, DimLengths);
     auto X = Writer->write(wrapBuilder(M));
-    if (!X.is_OK()) {
-      throw std::runtime_error(X.to_str());
+    if (X != WriteResult::OK) {
+      throw std::runtime_error("Error");
     }
-    ASSERT_TRUE(X.is_OK());
+    ASSERT_TRUE(X == WriteResult::OK);
   }
   ++HistogramID;
   for (size_t i = 1; i < 4; ++i) {
     auto M = createTestMessage(HistogramID, i, DimLengths);
     auto X = Writer->write(wrapBuilder(M));
-    if (!X.is_OK()) {
-      throw std::runtime_error(X.to_str());
+    if (X != WriteResult::OK) {
+      throw std::runtime_error("Error");
     }
-    ASSERT_TRUE(X.is_OK());
+    ASSERT_TRUE(X == WriteResult::OK);
   }
   Writer->close();
   auto Histograms = Group.get_dataset("histograms");
@@ -487,10 +489,10 @@ TEST_F(EventHistogramWriter, WriteManyHistograms) {
     for (size_t i = 0; i < 4; ++i) {
       auto M = createTestMessage(HistogramID, i, DimLengths);
       auto X = Writer->write(wrapBuilder(M));
-      if (!X.is_OK()) {
-        throw std::runtime_error(X.to_str());
+      if (X != WriteResult::OK) {
+        throw std::runtime_error("Error");
       }
-      ASSERT_TRUE(X.is_OK());
+      ASSERT_TRUE(X == WriteResult::OK);
     }
   }
   Writer->close();
@@ -531,8 +533,8 @@ TEST_F(EventHistogramWriter, WriteAMORExample) {
   auto M = FileWriter::FlatbufferMessage(
       reinterpret_cast<const char *>(V2.data()), V2.size());
   auto X = Writer->write(M);
-  if (!X.is_OK()) {
-    throw std::runtime_error(X.to_str());
+  if (X != WriteResult::OK) {
+    throw std::runtime_error("Error");
   }
-  ASSERT_TRUE(X.is_OK());
+  ASSERT_TRUE(X == WriteResult::OK);
 }

--- a/src/tests/FastSampleEnvironmentWriterTests.cpp
+++ b/src/tests/FastSampleEnvironmentWriterTests.cpp
@@ -131,6 +131,8 @@ TEST_F(FastSampleEnvironmentWriter, ReopenFileSuccess) {
   EXPECT_TRUE(Writer.reopen(UsedGroup) == InitResult::OK);
 }
 
+using WriteResult = FileWriter::HDFWriterModule_detail::WriteResult;
+
 TEST_F(FastSampleEnvironmentWriter, WriteDataOnce) {
   size_t BufferSize;
   std::unique_ptr<std::int8_t[]> Buffer = GenerateFlatbufferData(BufferSize);
@@ -139,7 +141,7 @@ TEST_F(FastSampleEnvironmentWriter, WriteDataOnce) {
   EXPECT_TRUE(Writer.reopen(UsedGroup) == InitResult::OK);
   FileWriter::FlatbufferMessage TestMsg(
       reinterpret_cast<const char *>(Buffer.get()), BufferSize);
-  EXPECT_TRUE(Writer.write(TestMsg).is_OK());
+  EXPECT_TRUE(Writer.write(TestMsg) == WriteResult::OK);
   auto RawValuesDataset = UsedGroup.get_dataset("raw_value");
   auto TimestampDataset = UsedGroup.get_dataset("time");
   auto CueIndexDataset = UsedGroup.get_dataset("cue_index");
@@ -179,8 +181,8 @@ TEST_F(FastSampleEnvironmentWriter, WriteDataTwice) {
   EXPECT_TRUE(Writer.reopen(UsedGroup) == InitResult::OK);
   FileWriter::FlatbufferMessage TestMsg(
       reinterpret_cast<const char *>(Buffer.get()), BufferSize);
-  EXPECT_TRUE(Writer.write(TestMsg).is_OK());
-  EXPECT_TRUE(Writer.write(TestMsg).is_OK());
+  EXPECT_TRUE(Writer.write(TestMsg) == WriteResult::OK);
+  EXPECT_TRUE(Writer.write(TestMsg) == WriteResult::OK);
   auto RawValuesDataset = UsedGroup.get_dataset("raw_value");
   auto TimestampDataset = UsedGroup.get_dataset("time");
   auto CueIndexDataset = UsedGroup.get_dataset("cue_index");
@@ -223,7 +225,7 @@ TEST_F(FastSampleEnvironmentWriter, WriteNoElements) {
   EXPECT_TRUE(Writer.reopen(UsedGroup) == InitResult::OK);
   FileWriter::FlatbufferMessage TestMsg(
       reinterpret_cast<const char *>(Buffer.get()), BufferSize);
-  EXPECT_TRUE(Writer.write(TestMsg).is_OK());
+  EXPECT_TRUE(Writer.write(TestMsg) == WriteResult::OK);
   auto RawValuesDataset = UsedGroup.get_dataset("raw_value");
   auto TimestampDataset = UsedGroup.get_dataset("time");
   auto CueIndexDataset = UsedGroup.get_dataset("cue_index");
@@ -248,7 +250,7 @@ TEST_F(FastSampleEnvironmentWriter, WriteDataWithNoTimestampsInFB) {
   EXPECT_TRUE(Writer.reopen(UsedGroup) == InitResult::OK);
   FileWriter::FlatbufferMessage TestMsg(
       reinterpret_cast<const char *>(Buffer.get()), BufferSize);
-  EXPECT_TRUE(Writer.write(TestMsg).is_OK());
+  EXPECT_TRUE(Writer.write(TestMsg) == WriteResult::OK);
   auto RawValuesDataset = UsedGroup.get_dataset("raw_value");
   auto TimestampDataset = UsedGroup.get_dataset("time");
   auto CueIndexDataset = UsedGroup.get_dataset("cue_index");

--- a/src/tests/FastSampleEnvironmentWriterTests.cpp
+++ b/src/tests/FastSampleEnvironmentWriterTests.cpp
@@ -131,8 +131,6 @@ TEST_F(FastSampleEnvironmentWriter, ReopenFileSuccess) {
   EXPECT_TRUE(Writer.reopen(UsedGroup) == InitResult::OK);
 }
 
-using WriteResult = FileWriter::HDFWriterModule_detail::WriteResult;
-
 TEST_F(FastSampleEnvironmentWriter, WriteDataOnce) {
   size_t BufferSize;
   std::unique_ptr<std::int8_t[]> Buffer = GenerateFlatbufferData(BufferSize);

--- a/src/tests/FastSampleEnvironmentWriterTests.cpp
+++ b/src/tests/FastSampleEnvironmentWriterTests.cpp
@@ -141,7 +141,7 @@ TEST_F(FastSampleEnvironmentWriter, WriteDataOnce) {
   EXPECT_TRUE(Writer.reopen(UsedGroup) == InitResult::OK);
   FileWriter::FlatbufferMessage TestMsg(
       reinterpret_cast<const char *>(Buffer.get()), BufferSize);
-  EXPECT_TRUE(Writer.write(TestMsg) == WriteResult::OK);
+  EXPECT_NO_THROW(Writer.write(TestMsg));
   auto RawValuesDataset = UsedGroup.get_dataset("raw_value");
   auto TimestampDataset = UsedGroup.get_dataset("time");
   auto CueIndexDataset = UsedGroup.get_dataset("cue_index");
@@ -181,8 +181,8 @@ TEST_F(FastSampleEnvironmentWriter, WriteDataTwice) {
   EXPECT_TRUE(Writer.reopen(UsedGroup) == InitResult::OK);
   FileWriter::FlatbufferMessage TestMsg(
       reinterpret_cast<const char *>(Buffer.get()), BufferSize);
-  EXPECT_TRUE(Writer.write(TestMsg) == WriteResult::OK);
-  EXPECT_TRUE(Writer.write(TestMsg) == WriteResult::OK);
+  EXPECT_NO_THROW(Writer.write(TestMsg));
+  EXPECT_NO_THROW(Writer.write(TestMsg));
   auto RawValuesDataset = UsedGroup.get_dataset("raw_value");
   auto TimestampDataset = UsedGroup.get_dataset("time");
   auto CueIndexDataset = UsedGroup.get_dataset("cue_index");
@@ -225,7 +225,7 @@ TEST_F(FastSampleEnvironmentWriter, WriteNoElements) {
   EXPECT_TRUE(Writer.reopen(UsedGroup) == InitResult::OK);
   FileWriter::FlatbufferMessage TestMsg(
       reinterpret_cast<const char *>(Buffer.get()), BufferSize);
-  EXPECT_TRUE(Writer.write(TestMsg) == WriteResult::OK);
+  EXPECT_NO_THROW(Writer.write(TestMsg));
   auto RawValuesDataset = UsedGroup.get_dataset("raw_value");
   auto TimestampDataset = UsedGroup.get_dataset("time");
   auto CueIndexDataset = UsedGroup.get_dataset("cue_index");
@@ -250,7 +250,7 @@ TEST_F(FastSampleEnvironmentWriter, WriteDataWithNoTimestampsInFB) {
   EXPECT_TRUE(Writer.reopen(UsedGroup) == InitResult::OK);
   FileWriter::FlatbufferMessage TestMsg(
       reinterpret_cast<const char *>(Buffer.get()), BufferSize);
-  EXPECT_TRUE(Writer.write(TestMsg) == WriteResult::OK);
+  EXPECT_NO_THROW(Writer.write(TestMsg));
   auto RawValuesDataset = UsedGroup.get_dataset("raw_value");
   auto TimestampDataset = UsedGroup.get_dataset("time");
   auto CueIndexDataset = UsedGroup.get_dataset("cue_index");

--- a/src/tests/FastSampleEnvironmentWriterTests.cpp
+++ b/src/tests/FastSampleEnvironmentWriterTests.cpp
@@ -99,10 +99,12 @@ public:
   hdf5::node::Group UsedGroup;
 };
 
+using FileWriter::HDFWriterModule_detail::InitResult;
+
 TEST_F(FastSampleEnvironmentWriter, InitFile) {
   {
     senv::FastSampleEnvironmentWriter Writer;
-    EXPECT_TRUE(Writer.init_hdf(UsedGroup, "{}").is_OK());
+    EXPECT_TRUE(Writer.init_hdf(UsedGroup, "{}") == InitResult::OK);
   }
   ASSERT_TRUE(RootGroup.has_group(NXLogGroup));
   auto TestGroup = RootGroup.get_group(NXLogGroup);
@@ -114,27 +116,27 @@ TEST_F(FastSampleEnvironmentWriter, InitFile) {
 
 TEST_F(FastSampleEnvironmentWriter, ReopenFileFailure) {
   senv::FastSampleEnvironmentWriter Writer;
-  EXPECT_FALSE(Writer.reopen(UsedGroup).is_OK());
+  EXPECT_FALSE(Writer.reopen(UsedGroup) == InitResult::OK);
 }
 
 TEST_F(FastSampleEnvironmentWriter, InitFileFail) {
   senv::FastSampleEnvironmentWriter Writer;
-  EXPECT_TRUE(Writer.init_hdf(UsedGroup, "{}").is_OK());
-  EXPECT_FALSE(Writer.init_hdf(UsedGroup, "{}").is_OK());
+  EXPECT_TRUE(Writer.init_hdf(UsedGroup, "{}") == InitResult::OK);
+  EXPECT_FALSE(Writer.init_hdf(UsedGroup, "{}") == InitResult::OK);
 }
 
 TEST_F(FastSampleEnvironmentWriter, ReopenFileSuccess) {
   senv::FastSampleEnvironmentWriter Writer;
-  EXPECT_TRUE(Writer.init_hdf(UsedGroup, "{}").is_OK());
-  EXPECT_TRUE(Writer.reopen(UsedGroup).is_OK());
+  EXPECT_TRUE(Writer.init_hdf(UsedGroup, "{}") == InitResult::OK);
+  EXPECT_TRUE(Writer.reopen(UsedGroup) == InitResult::OK);
 }
 
 TEST_F(FastSampleEnvironmentWriter, WriteDataOnce) {
   size_t BufferSize;
   std::unique_ptr<std::int8_t[]> Buffer = GenerateFlatbufferData(BufferSize);
   senv::FastSampleEnvironmentWriter Writer;
-  EXPECT_TRUE(Writer.init_hdf(UsedGroup, "{}").is_OK());
-  EXPECT_TRUE(Writer.reopen(UsedGroup).is_OK());
+  EXPECT_TRUE(Writer.init_hdf(UsedGroup, "{}") == InitResult::OK);
+  EXPECT_TRUE(Writer.reopen(UsedGroup) == InitResult::OK);
   FileWriter::FlatbufferMessage TestMsg(
       reinterpret_cast<const char *>(Buffer.get()), BufferSize);
   EXPECT_TRUE(Writer.write(TestMsg).is_OK());
@@ -173,8 +175,8 @@ TEST_F(FastSampleEnvironmentWriter, WriteDataTwice) {
   size_t BufferSize;
   std::unique_ptr<std::int8_t[]> Buffer = GenerateFlatbufferData(BufferSize);
   senv::FastSampleEnvironmentWriter Writer;
-  EXPECT_TRUE(Writer.init_hdf(UsedGroup, "{}").is_OK());
-  EXPECT_TRUE(Writer.reopen(UsedGroup).is_OK());
+  EXPECT_TRUE(Writer.init_hdf(UsedGroup, "{}") == InitResult::OK);
+  EXPECT_TRUE(Writer.reopen(UsedGroup) == InitResult::OK);
   FileWriter::FlatbufferMessage TestMsg(
       reinterpret_cast<const char *>(Buffer.get()), BufferSize);
   EXPECT_TRUE(Writer.write(TestMsg).is_OK());
@@ -217,8 +219,8 @@ TEST_F(FastSampleEnvironmentWriter, WriteNoElements) {
       1;
   *ValueLengthPtr = 0;
   senv::FastSampleEnvironmentWriter Writer;
-  EXPECT_TRUE(Writer.init_hdf(UsedGroup, "{}").is_OK());
-  EXPECT_TRUE(Writer.reopen(UsedGroup).is_OK());
+  EXPECT_TRUE(Writer.init_hdf(UsedGroup, "{}") == InitResult::OK);
+  EXPECT_TRUE(Writer.reopen(UsedGroup) == InitResult::OK);
   FileWriter::FlatbufferMessage TestMsg(
       reinterpret_cast<const char *>(Buffer.get()), BufferSize);
   EXPECT_TRUE(Writer.write(TestMsg).is_OK());
@@ -242,8 +244,8 @@ TEST_F(FastSampleEnvironmentWriter, WriteDataWithNoTimestampsInFB) {
       1;
   *TimestampsLengthPtr = 0;
   senv::FastSampleEnvironmentWriter Writer;
-  EXPECT_TRUE(Writer.init_hdf(UsedGroup, "{}").is_OK());
-  EXPECT_TRUE(Writer.reopen(UsedGroup).is_OK());
+  EXPECT_TRUE(Writer.init_hdf(UsedGroup, "{}") == InitResult::OK);
+  EXPECT_TRUE(Writer.reopen(UsedGroup) == InitResult::OK);
   FileWriter::FlatbufferMessage TestMsg(
       reinterpret_cast<const char *>(Buffer.get()), BufferSize);
   EXPECT_TRUE(Writer.write(TestMsg).is_OK());

--- a/src/tests/SourceTests.cpp
+++ b/src/tests/SourceTests.cpp
@@ -32,10 +32,10 @@ public:
                     std::string const &ConfigurationModule) override {}
   InitResult init_hdf(hdf5::node::Group &HDFGroup,
                       std::string const &HDFAttributes) override {
-    return InitResult::OK();
+    return InitResult::OK;
   }
   InitResult reopen(hdf5::node::Group &HDFGrup) override {
-    return InitResult::OK();
+    return InitResult::OK;
   }
   WriteResult write(FlatbufferMessage const &Message) override {
     return WriteResult::OK();

--- a/src/tests/SourceTests.cpp
+++ b/src/tests/SourceTests.cpp
@@ -96,7 +96,7 @@ TEST_F(SourceTests, ProcessMessageReturnsErrorIfWriterModuleReturnsError) {
   std::string ModuleName("ev42");
   auto WriterModule = std::make_unique<WriterModuleMock>();
   REQUIRE_CALL(*WriterModule, write(ANY(FlatbufferMessage const &)))
-      .RETURN(FileWriter::HDFWriterModule::WriteResult::ERROR_IO);
+      .THROW(FileWriter::HDFWriterModuleRegistry::WriterException("IO Error"));
   Source TestSource(SourceName, ModuleName, std::move(WriterModule));
   TestSource.setTopic(TopicName);
   flatbuffers::FlatBufferBuilder Builder;

--- a/src/tests/SourceTests.cpp
+++ b/src/tests/SourceTests.cpp
@@ -38,7 +38,7 @@ public:
     return InitResult::OK;
   }
   WriteResult write(FlatbufferMessage const &Message) override {
-    return WriteResult::OK();
+    return WriteResult::OK;
   }
   std::int32_t flush() override { return 0; }
   std::int32_t close() override { return 0; }
@@ -78,7 +78,7 @@ TEST_F(SourceTests, ProcessMessagePassesMessageToWriterModule) {
   std::string ModuleName("ev42");
   auto WriterModule = std::make_unique<WriterModuleMock>();
   REQUIRE_CALL(*WriterModule, write(ANY(FlatbufferMessage const &)))
-      .RETURN(FileWriter::HDFWriterModule::WriteResult::OK());
+      .RETURN(FileWriter::HDFWriterModule::WriteResult::OK);
   Source TestSource(SourceName, ModuleName, std::move(WriterModule));
   TestSource.setTopic(TopicName);
   flatbuffers::FlatBufferBuilder Builder;
@@ -96,7 +96,7 @@ TEST_F(SourceTests, ProcessMessageReturnsErrorIfWriterModuleReturnsError) {
   std::string ModuleName("ev42");
   auto WriterModule = std::make_unique<WriterModuleMock>();
   REQUIRE_CALL(*WriterModule, write(ANY(FlatbufferMessage const &)))
-      .RETURN(FileWriter::HDFWriterModule::WriteResult::ERROR_IO());
+      .RETURN(FileWriter::HDFWriterModule::WriteResult::ERROR_IO);
   Source TestSource(SourceName, ModuleName, std::move(WriterModule));
   TestSource.setTopic(TopicName);
   flatbuffers::FlatBufferBuilder Builder;

--- a/src/tests/SourceTests.cpp
+++ b/src/tests/SourceTests.cpp
@@ -37,16 +37,14 @@ public:
   InitResult reopen(hdf5::node::Group &HDFGrup) override {
     return InitResult::OK;
   }
-  WriteResult write(FlatbufferMessage const &Message) override {
-    return WriteResult::OK;
-  }
+  void write(FlatbufferMessage const &Message) override {}
   std::int32_t flush() override { return 0; }
   std::int32_t close() override { return 0; }
 };
 
 class WriterModuleMock : public WriterModuleDummy {
 public:
-  MAKE_MOCK1(write, WriteResult(FlatbufferMessage const &), override);
+  MAKE_MOCK1(write, void(FlatbufferMessage const &), override);
 };
 
 TEST_F(SourceTests, ConstructorSetsMembers) {
@@ -77,8 +75,7 @@ TEST_F(SourceTests, ProcessMessagePassesMessageToWriterModule) {
   std::string TopicName("TestTopicName");
   std::string ModuleName("ev42");
   auto WriterModule = std::make_unique<WriterModuleMock>();
-  REQUIRE_CALL(*WriterModule, write(ANY(FlatbufferMessage const &)))
-      .RETURN(FileWriter::HDFWriterModule::WriteResult::OK);
+  REQUIRE_CALL(*WriterModule, write(ANY(FlatbufferMessage const &)));
   Source TestSource(SourceName, ModuleName, std::move(WriterModule));
   TestSource.setTopic(TopicName);
   flatbuffers::FlatBufferBuilder Builder;

--- a/src/tests/StreamerTest.cpp
+++ b/src/tests/StreamerTest.cpp
@@ -236,7 +236,7 @@ public:
   MAKE_MOCK2(init_hdf, InitResult(hdf5::node::Group &, std::string const &),
              override);
   MAKE_MOCK1(reopen, InitResult(hdf5::node::Group &), override);
-  MAKE_MOCK1(write, WriteResult(FlatbufferMessage const &), override);
+  MAKE_MOCK1(write, void(FlatbufferMessage const &), override);
   MAKE_MOCK0(flush, int32_t(), override);
   MAKE_MOCK0(close, int32_t(), override);
 };

--- a/src/tests/TemplateWriterTests.cpp
+++ b/src/tests/TemplateWriterTests.cpp
@@ -16,8 +16,7 @@ TEST(TemplateTests, WriterReturnValues) {
               FileWriter::HDFWriterModule_detail::InitResult::OK);
   EXPECT_TRUE(SomeWriter.reopen(SomeGroup) ==
               FileWriter::HDFWriterModule_detail::InitResult::OK);
-  EXPECT_TRUE(SomeWriter.write(FileWriter::FlatbufferMessage()) ==
-              FileWriter::HDFWriterModule_detail::WriteResult::OK);
+  EXPECT_NO_THROW(SomeWriter.write(FileWriter::FlatbufferMessage()));
   EXPECT_EQ(SomeWriter.flush(), 0);
   EXPECT_EQ(SomeWriter.close(), 0);
 }

--- a/src/tests/TemplateWriterTests.cpp
+++ b/src/tests/TemplateWriterTests.cpp
@@ -16,7 +16,8 @@ TEST(TemplateTests, WriterReturnValues) {
               FileWriter::HDFWriterModule_detail::InitResult::OK);
   EXPECT_TRUE(SomeWriter.reopen(SomeGroup) ==
               FileWriter::HDFWriterModule_detail::InitResult::OK);
-  EXPECT_TRUE(SomeWriter.write(FileWriter::FlatbufferMessage()).is_OK());
+  EXPECT_TRUE(SomeWriter.write(FileWriter::FlatbufferMessage()) ==
+              FileWriter::HDFWriterModule_detail::WriteResult::OK);
   EXPECT_EQ(SomeWriter.flush(), 0);
   EXPECT_EQ(SomeWriter.close(), 0);
 }

--- a/src/tests/TemplateWriterTests.cpp
+++ b/src/tests/TemplateWriterTests.cpp
@@ -12,8 +12,10 @@ TEST(TemplateTests, ReaderReturnValues) {
 TEST(TemplateTests, WriterReturnValues) {
   TemplateWriter::WriterClass SomeWriter;
   hdf5::node::Group SomeGroup;
-  EXPECT_TRUE(SomeWriter.init_hdf(SomeGroup, "{}").is_OK());
-  EXPECT_TRUE(SomeWriter.reopen(SomeGroup).is_OK());
+  EXPECT_TRUE(SomeWriter.init_hdf(SomeGroup, "{}") ==
+              FileWriter::HDFWriterModule_detail::InitResult::OK);
+  EXPECT_TRUE(SomeWriter.reopen(SomeGroup) ==
+              FileWriter::HDFWriterModule_detail::InitResult::OK);
   EXPECT_TRUE(SomeWriter.write(FileWriter::FlatbufferMessage()).is_OK());
   EXPECT_EQ(SomeWriter.flush(), 0);
   EXPECT_EQ(SomeWriter.close(), 0);

--- a/src/tests/WriterRegistration.cpp
+++ b/src/tests/WriterRegistration.cpp
@@ -26,9 +26,7 @@ public:
   InitResult reopen(hdf5::node::Group &HDFGrup) override {
     return InitResult::OK;
   }
-  WriteResult write(FlatbufferMessage const &Message) override {
-    return WriteResult::OK;
-  }
+  void write(FlatbufferMessage const &Message) override {}
   std::int32_t flush() override { return 0; }
 
   std::int32_t close() override { return 0; }

--- a/src/tests/WriterRegistration.cpp
+++ b/src/tests/WriterRegistration.cpp
@@ -21,10 +21,10 @@ public:
                     std::string const &ConfigurationModule) override {}
   InitResult init_hdf(hdf5::node::Group &HDFGroup,
                       std::string const &HDFAttributes) override {
-    return InitResult::OK();
+    return InitResult::OK;
   }
   InitResult reopen(hdf5::node::Group &HDFGrup) override {
-    return InitResult::OK();
+    return InitResult::OK;
   }
   WriteResult write(FlatbufferMessage const &Message) override {
     return WriteResult::OK();

--- a/src/tests/WriterRegistration.cpp
+++ b/src/tests/WriterRegistration.cpp
@@ -27,7 +27,7 @@ public:
     return InitResult::OK;
   }
   WriteResult write(FlatbufferMessage const &Message) override {
-    return WriteResult::OK();
+    return WriteResult::OK;
   }
   std::int32_t flush() override { return 0; }
 


### PR DESCRIPTION
### Issue

*[DM-1153](https://jira.esss.lu.se/secure/RapidBoard.jspa?rapidView=659&projectKey=DM&view=detail&selectedIssue=DM-1153)*

### Description of work

- turned `InitResult`(`HDFWriterModule.h`) into `enum class`.

- deleted WriteResult:
 Earlier when writing was successful an `OK` status was retured.
 On error, one of few variants(some were unused) was returned. All kinds of errors were caught and handled in a single `if(X.isError())`. A `timestamp` and error string could be returned, timestamp was populated, but never used. Error message was used.
I created custom `WriterException` which is thrown in places where any kind of error status was returned before. It's handled in place where errors where previously handled.
On success methods just finish - they are void now.

Many tests had to be updated.


### Nominate for Group Code Review

- [ ] Nominate for code review 

