### PR TITLE
Incorrect f142 logging and python dtype in commands

### DIFF
--- a/documentation/commands.md
+++ b/documentation/commands.md
@@ -69,7 +69,7 @@ The following shows an example of adding a group to a structure:
           {
             "type": "stream",
             "stream": {
-              "type": "double",
+              "dtype": "double",
               "writer_module": "f142",
               "source": "my_test_pv",
               "topic": "my_test_topic"
@@ -93,7 +93,7 @@ The stream definition instructs the file-writer that there is data available whi
 The parameters for the stream definition are:
 
 - writer_module: The FlatBuffers schema in the [streaming-data-types](https://github.com/ess-dmsc/streaming-data-types) repository that was used to serialise the data.
-- type: The type of the data. The possible types are defined in the schema declared in the `writer_module`.
+- type/dtype: The type of the data. The possible types are defined in the schema declared in the `writer_module`. Program allows both `type` and `dtype` spellings for better python usability.
 - source: The name of the data source. For example, the EPICS PV name.
 - topic: The Kafka topic where the data can be found.
 

--- a/src/HDFFile.cpp
+++ b/src/HDFFile.cpp
@@ -276,12 +276,9 @@ void HDFFile::writeArrayOfAttributes(hdf5::node::Node const &Node,
             Encoding = hdf5::datatype::CharacterEncoding::ASCII;
           }
         }
-        if (auto AttrType = find<std::string>("type", Attribute)) {
-          DType = AttrType.inner();
-          writeAttrOfSpecifiedType(DType, Node, Name, StringSize, Encoding,
-                                   Values);
-        } else if (auto AttrType = find<std::string>("dtype", Attribute)) {
-          DType = AttrType.inner();
+
+        // get type/dtype
+        if (findType(Attribute, DType)) {
           writeAttrOfSpecifiedType(DType, Node, Name, StringSize, Encoding,
                                    Values);
         } else {
@@ -294,6 +291,18 @@ void HDFFile::writeArrayOfAttributes(hdf5::node::Node const &Node,
       }
     }
   }
+}
+
+bool HDFFile::findType(const nlohmann::basic_json<> Attribute,
+                       std::string &DType) {
+  if (auto AttrType = find<std::string>("type", Attribute)) {
+    DType = AttrType.inner();
+    return true;
+  } else if (auto AttrType = find<std::string>("dtype", Attribute)) {
+    DType = AttrType.inner();
+    return true;
+  } else
+    return false;
 }
 
 void writeAttrStringVariableLength(hdf5::node::Node const &Node,
@@ -668,15 +677,7 @@ void HDFFile::writeDataset(hdf5::node::Group const &Parent,
         return;
       }
     }
-
-    if (auto DatasetTypeObject =
-            find<std::string>("type", DatasetInnerObject)) {
-      DataType = DatasetTypeObject.inner();
-    } else if (auto DatasetTypeObject =
-                   find<std::string>("dtype", DatasetInnerObject)) {
-      DataType = DatasetTypeObject.inner();
-    }
-
+    findType(DatasetInnerObject, DataType);
     // optional, default to scalar
     if (auto DatasetSizeObject = find<json>("size", DatasetInnerObject)) {
       if (DatasetSizeObject.inner().is_array()) {
@@ -741,32 +742,8 @@ void HDFFile::createHDFStructures(
 
     // The HDF object that we will maybe create at the current level.
     hdf5::node::Group hdf_this;
-    if (auto TypeMaybe = find<std::string>("type", *Value)) {
-      auto Type = TypeMaybe.inner();
-      if (Type == "group") {
-        if (auto NameMaybe = find<std::string>("name", *Value)) {
-          auto Name = NameMaybe.inner();
-          try {
-            hdf_this = Parent.create_group(Name, LinkCreationPropertyList);
-            Path.push_back(Name);
-          } catch (...) {
-            LOG(Sev::Critical, "failed to create group  Name: {}", Name);
-          }
-        }
-      }
-      if (Type == "stream") {
-        string pathstr;
-        for (auto &x : Path) {
-          pathstr += "/" + x;
-        }
-
-        HDFStreamInfo.push_back(StreamHDFInfo{pathstr, Value->dump()});
-      }
-      if (Type == "dataset") {
-        writeDataset(Parent, Value);
-      }
-    } else if (auto TypeMaybe = find<std::string>("dtype", *Value)) {
-      auto Type = TypeMaybe.inner();
+    std::string Type;
+    if (findType(*Value, Type)) {
       if (Type == "group") {
         if (auto NameMaybe = find<std::string>("name", *Value)) {
           auto Name = NameMaybe.inner();

--- a/src/HDFFile.cpp
+++ b/src/HDFFile.cpp
@@ -280,6 +280,10 @@ void HDFFile::writeArrayOfAttributes(hdf5::node::Node const &Node,
           DType = AttrType.inner();
           writeAttrOfSpecifiedType(DType, Node, Name, StringSize, Encoding,
                                    Values);
+        } else if (auto AttrType = find<std::string>("dtype", Attribute)) {
+          DType = AttrType.inner();
+          writeAttrOfSpecifiedType(DType, Node, Name, StringSize, Encoding,
+                                   Values);
         } else {
           if (Values.is_array()) {
             LOG(Sev::Warning, "Attributes with array values must specify type")
@@ -668,6 +672,9 @@ void HDFFile::writeDataset(hdf5::node::Group const &Parent,
     if (auto DatasetTypeObject =
             find<std::string>("type", DatasetInnerObject)) {
       DataType = DatasetTypeObject.inner();
+    } else if (auto DatasetTypeObject =
+                   find<std::string>("dtype", DatasetInnerObject)) {
+      DataType = DatasetTypeObject.inner();
     }
 
     // optional, default to scalar
@@ -735,6 +742,30 @@ void HDFFile::createHDFStructures(
     // The HDF object that we will maybe create at the current level.
     hdf5::node::Group hdf_this;
     if (auto TypeMaybe = find<std::string>("type", *Value)) {
+      auto Type = TypeMaybe.inner();
+      if (Type == "group") {
+        if (auto NameMaybe = find<std::string>("name", *Value)) {
+          auto Name = NameMaybe.inner();
+          try {
+            hdf_this = Parent.create_group(Name, LinkCreationPropertyList);
+            Path.push_back(Name);
+          } catch (...) {
+            LOG(Sev::Critical, "failed to create group  Name: {}", Name);
+          }
+        }
+      }
+      if (Type == "stream") {
+        string pathstr;
+        for (auto &x : Path) {
+          pathstr += "/" + x;
+        }
+
+        HDFStreamInfo.push_back(StreamHDFInfo{pathstr, Value->dump()});
+      }
+      if (Type == "dataset") {
+        writeDataset(Parent, Value);
+      }
+    } else if (auto TypeMaybe = find<std::string>("dtype", *Value)) {
       auto Type = TypeMaybe.inner();
       if (Type == "group") {
         if (auto NameMaybe = find<std::string>("name", *Value)) {

--- a/src/HDFFile.h
+++ b/src/HDFFile.h
@@ -63,6 +63,9 @@ private:
   friend class ::T_HDFFile;
   friend class CommandHandler;
 
+  static bool findType(const nlohmann::basic_json<> Attribute,
+                       std::string &DType);
+
   static void checkHDFVersion();
   static std::string H5VersionStringHeadersCompileTime();
 

--- a/src/schemas/f142/f142_rw.cpp
+++ b/src/schemas/f142/f142_rw.cpp
@@ -233,9 +233,13 @@ HDFWriterModule::init_hdf(hdf5::node::Group &HDFGroup,
     ValueWriter = createWriterTypedBase(HDFGroup, ArraySize, TypeName, "value",
                                         CreateMethod);
     if (!ValueWriter) {
+      if (TypeName.empty()) {
+        LOG(Sev::Error,
+            "Could not create a writer implementation for empty TypeName");
+        return HDFWriterModule::InitResult::ERROR;
+      }
       LOG(Sev::Error,
-          "Could not create a writer implementation for value_type {}",
-          TypeName);
+          "Could not create a writer implementation for TypeName {}", TypeName);
       return HDFWriterModule::InitResult::ERROR;
     }
     if (CreateMethod == CreateWriterTypedBaseMethod::CREATE) {

--- a/src/schemas/f142/f142_rw.cpp
+++ b/src/schemas/f142/f142_rw.cpp
@@ -148,6 +148,10 @@ void HDFWriterModule::parse_config(std::string const &ConfigurationStream,
 
   if (auto TypeNameMaybe = find<std::string>("type", ConfigurationStreamJson)) {
     TypeName = TypeNameMaybe.inner();
+    // handle python style dtype
+  } else if (auto TypeNameMaybe =
+                 find<std::string>("dtype", ConfigurationStreamJson)) {
+    TypeName = TypeNameMaybe.inner();
   } else {
     throw std::runtime_error(
         fmt::format("Missing key \"type\" in f142 writer configuration"));

--- a/src/schemas/f142/f142_rw.cpp
+++ b/src/schemas/f142/f142_rw.cpp
@@ -146,13 +146,7 @@ void HDFWriterModule::parse_config(std::string const &ConfigurationStream,
     return;
   }
 
-  if (auto TypeNameMaybe = find<std::string>("type", ConfigurationStreamJson)) {
-    TypeName = TypeNameMaybe.inner();
-    // handle python style dtype
-  } else if (auto TypeNameMaybe =
-                 find<std::string>("dtype", ConfigurationStreamJson)) {
-    TypeName = TypeNameMaybe.inner();
-  } else {
+  if (!findType(ConfigurationStreamJson, TypeName)) {
     throw std::runtime_error(
         fmt::format("Missing key \"type\" in f142 writer configuration"));
   }
@@ -346,6 +340,17 @@ int32_t HDFWriterModule::close() {
   return 0;
 }
 
+bool HDFWriterModule::findType(const nlohmann::basic_json<> Attribute,
+                               std::string &DType) {
+  if (auto AttrType = find<std::string>("type", Attribute)) {
+    DType = AttrType.inner();
+    return true;
+  } else if (auto AttrType = find<std::string>("dtype", Attribute)) {
+    DType = AttrType.inner();
+    return true;
+  } else
+    return false;
+}
 /// Register the writer module.
 static HDFWriterModuleRegistry::Registrar<HDFWriterModule>
     RegisterWriter("f142");

--- a/src/schemas/f142/f142_rw.h
+++ b/src/schemas/f142/f142_rw.h
@@ -8,6 +8,7 @@
 #include <array>
 #include <chrono>
 #include <memory>
+#include <nlohmann/json.hpp>
 #include <vector>
 
 namespace FileWriter {
@@ -107,6 +108,10 @@ public:
   MS ErrorLogMinInterval{500};
   std::chrono::time_point<CLOCK> TimestampLastErrorLog{CLOCK::now() -
                                                        ErrorLogMinInterval};
+
+private:
+  static bool findType(const nlohmann::basic_json<> Attribute,
+                       std::string &DType);
 };
 
 /// \brief  Interface for creating and opening a dataset.

--- a/src/tests/data/msg-cmd-new-03.json
+++ b/src/tests/data/msg-cmd-new-03.json
@@ -6,14 +6,14 @@
   "nexus_structure": {
     "children": [
       {
-        "type": "group",
+        "dtype": "group",
         "name": "for_example_motor_0000",
         "attributes": {
           "NX_class": "NXinstrument"
         },
         "children": [
           {
-            "type": "stream",
+            "dtype": "stream",
             "stream": {
               "topic": "topic.with.multiple.sources",
               "source": "for_example_motor",

--- a/src/tests/data/msg-cmd-new-03.json
+++ b/src/tests/data/msg-cmd-new-03.json
@@ -18,7 +18,7 @@
               "topic": "topic.with.multiple.sources",
               "source": "for_example_motor",
               "module": "f142",
-              "type": "float",
+              "dtype": "float",
               "array_size": 4
             }
           }


### PR DESCRIPTION
### Issue

[DM-1149](https://jira.esss.lu.se/browse/DM-1149)
[DM-1180](https://jira.esss.lu.se/browse/DM-1180)

### Description of work

Two small tickets in one pull request:

- clearer error logging for f142
- json commands with `dtype` instead of `type` are accepted and parsed.

Updated one test json command to cover the functionality.

### Nominate for Group Code Review

- [ ] Nominate for code review 

