### PR TITLE
Stopping system tests from rebuilding the image every fixture

### DIFF
--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -52,6 +52,7 @@ common_options = {"--no-deps": False,
                   }
 
 
+@pytest.fixture(scope="session", autouse=True)
 def build_filewriter_image():
     client = docker.from_env()
     print("Building Filewriter image", flush=True)
@@ -75,7 +76,6 @@ def run_containers(cmd, options):
 
 
 def build_and_run(options, request):
-    build_filewriter_image()
     project = project_from_options(os.path.dirname(__file__), options)
     cmd = TopLevelCommand(project)
     start_time = str(int(unix_time_milliseconds(datetime.utcnow())))


### PR DESCRIPTION
### Issue

None

### Description of work

Previously every new fixture would attempt to rebuild the image (because the build step was also in the run step) 

this should mean it only gets built once, so should speed the tests up and make them more robust.

It will also fail immediately now if docker fails to build

### Nominate for Group Code Review

- [ ] Nominate for code review 

