### PR TITLE
Remove potential divide-by-zero error. 

### DIFF
--- a/src/Status.cpp
+++ b/src/Status.cpp
@@ -15,7 +15,7 @@ double average(double Sum, uint64_t N) { return Sum / N; }
 double standardDeviation(double Sum, double SumSquared,
                          uint64_t N) {
   // Avoid divide-by-zero error due to too few messages.
-  if (N <= 1.0) {
+  if (N <= 1) {
     return 0.0;
   }
 

--- a/src/Status.cpp
+++ b/src/Status.cpp
@@ -21,13 +21,12 @@ double standardDeviation(double Sum, double SumSquared,
   
   double Variance = (SumSquared - (Sum * Sum) / N) / (N - 1);
   if (Variance > 0) {
-    // Can be caused by numerical instabilities
     return std::sqrt(Variance);
   }
   return 0.0;
 }
 
-std::pair<double, double> FileWriter::Status::MessageInfo::messageSize() const {
+std::pair<double, double> FileWriter::Status::MessageInfo::messageSizeStats() const {
   // Nan causes failure in JSON
   if (Mbytes == 0) {
     return std::pair<double, double>{};
@@ -51,7 +50,7 @@ void FileWriter::Status::MessageInfo::error() {
   Errors++;
 }
 
-void FileWriter::Status::MessageInfo::reset() {
+void FileWriter::Status::MessageInfo::resetStatistics() {
   Mbytes = MbytesSquare = 0.0;
   Messages = 0;
   Errors = 0;
@@ -59,7 +58,7 @@ void FileWriter::Status::MessageInfo::reset() {
 
 double FileWriter::Status::MessageInfo::getMbytes() const { return Mbytes; }
 
-uint64_t FileWriter::Status::MessageInfo::getMessages() const {
+uint64_t FileWriter::Status::MessageInfo::getNumberMessages() const {
   return Messages;
 }
 
@@ -68,9 +67,9 @@ uint64_t FileWriter::Status::MessageInfo::getErrors() const { return Errors; }
 void FileWriter::Status::StreamMasterInfo::add(
     FileWriter::Status::MessageInfo &Info) {
   Mbytes += Info.getMbytes();
-  Messages += Info.getMessages();
+  Messages += Info.getNumberMessages();
   Errors += Info.getErrors();
-  Info.reset();
+  Info.resetStatistics();
 }
 
 void FileWriter::Status::StreamMasterInfo::setTimeToNextMessage(

--- a/src/Status.cpp
+++ b/src/Status.cpp
@@ -6,12 +6,17 @@
 /// \brief Return the average given the sum of the elements and their number
 /// \param sum the sum of the elements
 /// \param N number of elements
-double average(const double &Sum, const double &N) { return Sum / N; }
+double average(double Sum, double N) { return Sum / N; }
 
 /// Return the unbiased standard deviation computed as \f$\sigma =
 /// \sqrt{\frac{\langle x^2 \rangle - \langle x \rangle^2}{N(N-1)}}\f$
-double standardDeviation(const double &Sum, const double &SumSquared,
-                         const double &N) {
+double standardDeviation(double Sum, double SumSquared,
+                         double N) {
+  // Avoid divide-by-zero error due to too few messages.
+  if (N <= 1.0) {
+    return 0.0;
+  }
+  
   double Variance = (SumSquared - (Sum * Sum) / N) / (N - 1);
   if (Variance > 0) { // can be caused by numerical instabilities
     return std::sqrt(Variance);

--- a/src/Status.cpp
+++ b/src/Status.cpp
@@ -3,29 +3,33 @@
 #include "Status.h"
 #include "logger.h"
 
-/// \brief Return the average given the sum of the elements and their number
-/// \param sum the sum of the elements
-/// \param N number of elements
-double average(double Sum, double N) { return Sum / N; }
+/// \brief Returns the average.
+///
+/// \param sum The sum of the elements.
+/// \param N Number of elements.
+/// \return The average.
+double average(double Sum, uint64_t N) { return Sum / N; }
 
 /// Return the unbiased standard deviation computed as \f$\sigma =
 /// \sqrt{\frac{\langle x^2 \rangle - \langle x \rangle^2}{N(N-1)}}\f$
 double standardDeviation(double Sum, double SumSquared,
-                         double N) {
+                         uint64_t N) {
   // Avoid divide-by-zero error due to too few messages.
   if (N <= 1.0) {
     return 0.0;
   }
   
   double Variance = (SumSquared - (Sum * Sum) / N) / (N - 1);
-  if (Variance > 0) { // can be caused by numerical instabilities
+  if (Variance > 0) {
+    // Can be caused by numerical instabilities
     return std::sqrt(Variance);
   }
   return 0.0;
 }
 
 std::pair<double, double> FileWriter::Status::MessageInfo::messageSize() const {
-  if (Mbytes == 0) { // nan causes failure in JSON
+  // Nan causes failure in JSON
+  if (Mbytes == 0) {
     return std::pair<double, double>{};
   }
   std::pair<double, double> result(
@@ -34,7 +38,7 @@ std::pair<double, double> FileWriter::Status::MessageInfo::messageSize() const {
   return result;
 }
 
-void FileWriter::Status::MessageInfo::newMessage(const double &MessageBytes) {
+void FileWriter::Status::MessageInfo::newMessage(double MessageBytes) {
   std::lock_guard<std::mutex> Lock(Mutex);
   double Size = MessageBytes * 1e-6;
   Mbytes += Size;

--- a/src/Status.cpp
+++ b/src/Status.cpp
@@ -12,8 +12,7 @@ double average(double Sum, uint64_t N) { return Sum / N; }
 
 /// Return the unbiased standard deviation computed as \f$\sigma =
 /// \sqrt{\frac{\langle x^2 \rangle - \langle x \rangle^2}{N(N-1)}}\f$
-double standardDeviation(double Sum, double SumSquared,
-                         uint64_t N) {
+double standardDeviation(double Sum, double SumSquared, uint64_t N) {
   // Avoid divide-by-zero error due to too few messages.
   if (N <= 1) {
     return 0.0;
@@ -26,7 +25,8 @@ double standardDeviation(double Sum, double SumSquared,
   return 0.0;
 }
 
-std::pair<double, double> FileWriter::Status::MessageInfo::messageSizeStats() const {
+std::pair<double, double>
+FileWriter::Status::MessageInfo::messageSizeStats() const {
   // Nan causes failure in JSON
   if (Mbytes == 0) {
     return std::pair<double, double>{};

--- a/src/Status.h
+++ b/src/Status.h
@@ -23,13 +23,12 @@ namespace Status {
 /// \brief Stores cumulative information about received messages: number, size
 /// (in Megabytes) and number of errors.
 ///
-/// Assuming a 1-to-1 mapping between Streamer
-/// and Topic there will be no concurrent updates of the information, so that
-/// members are not required to be atomic. Nevertheless there is concurrency
+/// Assuming a 1-to-1 mapping between Streamer and Topic there will
+/// be no concurrent updates of the information, so that members are
+/// not required to be atomic. Nevertheless there is concurrency
 /// between writes (Streamer) and reads (Report). If no synchronisation
-/// mechanism
-/// would be present there can be a mixing of updated and non-updated
-/// information, which the mutex allows to avoid.
+/// mechanism would be present there can be a mixing of updated and
+/// non-updated information, which the mutex allows to avoid.
 class MessageInfo {
 
 public:
@@ -39,35 +38,33 @@ public:
   /// \brief Increments the number of messages that have been correctly
   /// processed by one unit and the number of processed megabytes accordingly.
   ///
-  /// \param[in]  MessageSize  The message size in bytes
-  void newMessage(const double &MessageBytes);
+  /// \param MessageSize The message size in bytes.
+  void newMessage(double MessageBytes);
 
-  ///  Increments the error count by one unit
+  ///  Increments the error count by one unit.
   void error();
 
-  ///  Reset the counters
+  ///  Reset the counters.
   void reset();
 
   /// \brief Return the average size and relative standard deviation of the
   /// number of messages between two reports.
-  ///
-  /// \param[in] Information The MessageInfo object that stores the data.
   ///
   /// \return A pair containing {average size, standard deviation}.
   std::pair<double, double> messageSize() const;
 
   /// \brief Returns the number of megabytes processed.
   ///
-  /// \return A pair {MB received, \f$\rm{MB received}^2\f$}
+  /// \return The number of messages.
   double getMbytes() const;
 
   /// \brief Returns the number of messages that have been processed
-  /// correctly
+  /// correctly.
   ///
-  /// \return A pair {number of messages, number of messages\f$\ 2\f$}.
+  /// \return The number of messages.
   uint64_t getMessages() const;
 
-  /// \brief Returns the number of messages recognised as error
+  /// \brief Returns the number of messages recognised as error.
   ///
   /// \return The number of messages.
   uint64_t getErrors() const;
@@ -80,8 +77,8 @@ private:
   std::mutex Mutex;
 };
 
-/// \brief Collect information about each stream using a collection of
-/// MessageInfo and reduce this information to give a global overview of the
+/// \brief Collect information about each stream's messages and
+/// reduce this information to give a global overview of the
 /// amount of data that has been processed.
 class StreamMasterInfo {
 
@@ -95,7 +92,7 @@ public:
 
   /// \brief Adds the information collected for a stream.
   ///
-  /// \param info  The MessageInfo object containing all the information.
+  /// \param Info The message information.
   void add(MessageInfo &Info);
 
   /// \brief Sets the estimate time to next message.
@@ -103,28 +100,28 @@ public:
   /// The next message is expected to arrive at [time of last message] +
   /// [ToNextMessage].
   ///
-  /// \param[in]  ToNextMessage  Milliseconds to  next message.
+  /// \param ToNextMessage Time to next message.
   void setTimeToNextMessage(const std::chrono::milliseconds &ToNextMessage);
 
   /// \brief Get the time difference between two consecutive status messages.
   ///
-  /// \return std::chrono::milliseconds from the last message to the next.
+  /// \return Time from the last message to the next.
   const std::chrono::milliseconds getTimeToNextMessage() const;
 
   /// \brief Returns the total execution time.
   ///
-  /// \return Milliseconds since the write command has been issued.
+  /// \return Time since the write command has been issued.
   const std::chrono::milliseconds runTime() const;
 
   /// \brief Returns the total number of megabytes processed for the
   /// current file.
   ///
-  /// \return The pair {MB received, \f$\rm{MB received}^2\f$}.
+  /// \return The number of megabytes.
   double getMbytes() const;
 
   /// \brief Return the number of messages whose information has been stored.
   ///
-  /// \return The pair {number of messages, number of messages\f$\ 2\f$}.
+  /// \return The number of messages.
   uint64_t getMessages() const;
 
   /// \brief  Returns the total number of error in the messages processed
@@ -146,14 +143,6 @@ private:
   std::chrono::system_clock::time_point StartTime;
   std::chrono::milliseconds MillisecondsToNextMessage{0};
 };
-
-/// \brief Return the average size and relative standard deviation of the
-/// number of messages between two reports.
-///
-/// \param[in] Information The MessageInfo object that stores the data.
-///
-/// \return A pair containing {average size, standard deviation}.
-// std::pair<double, double> messageSize(const MessageInfo &Information);
 
 } // namespace Status
 } // namespace FileWriter

--- a/src/Status.h
+++ b/src/Status.h
@@ -44,25 +44,25 @@ public:
   ///  Increments the error count by one unit.
   void error();
 
-  ///  Reset the counters.
-  void reset();
+  ///  Reset the message statistics counters.
+  void resetStatistics();
 
   /// \brief Return the average size and relative standard deviation of the
-  /// number of messages between two reports.
+  /// number of messages.
   ///
   /// \return A pair containing {average size, standard deviation}.
-  std::pair<double, double> messageSize() const;
+  std::pair<double, double> messageSizeStats() const;
 
   /// \brief Returns the number of megabytes processed.
   ///
-  /// \return The number of messages.
+  /// \return The number of megabytes.
   double getMbytes() const;
 
   /// \brief Returns the number of messages that have been processed
   /// correctly.
   ///
   /// \return The number of messages.
-  uint64_t getMessages() const;
+  uint64_t getNumberMessages() const;
 
   /// \brief Returns the number of messages recognised as error.
   ///

--- a/src/StatusWriter.cpp
+++ b/src/StatusWriter.cpp
@@ -14,11 +14,11 @@ nlohmann::json StreamMasterToJson(StreamMasterInfo const &Information) {
 }
 
 nlohmann::json StreamerToJson(MessageInfo const &Information) {
-  std::pair<double, double> Size = Information.messageSize();
+  std::pair<double, double> Size = Information.messageSizeStats();
 
   nlohmann::json Status;
   Status["rates"] = {
-      {"messages", Information.getMessages()},
+      {"messages", Information.getNumberMessages()},
       {"Mbytes", Information.getMbytes()},
       {"errors", Information.getErrors()},
       {"message_size",

--- a/src/tests/StatusTest.cpp
+++ b/src/tests/StatusTest.cpp
@@ -53,7 +53,7 @@ TEST(MessageInfo, addMultipleMessages) {
   double StdDev = 164;
 
   for (auto Msg : MessageSizes) {
-      MsgInfo.newMessage(Msg);
+    MsgInfo.newMessage(Msg);
   }
 
   auto Size = MsgInfo.messageSizeStats();

--- a/src/tests/StatusTest.cpp
+++ b/src/tests/StatusTest.cpp
@@ -115,7 +115,7 @@ TEST(StreamMasterInfo, accumulateInfoFromManyStreamers) {
   EXPECT_DOUBLE_EQ(Info.getErrors(), TotalErrors);
 }
 
-TEST(MessageInfo, resettingTheStatisticsZeroes) {
+TEST(MessageInfo, resettingTheStatisticsZeroesValues) {
   MessageInfo MsgInfo;
 
   std::vector<double> MessageSizes = {600, 470, 170, 430, 300};

--- a/src/tests/StatusTest.cpp
+++ b/src/tests/StatusTest.cpp
@@ -17,7 +17,7 @@ double RandomGaussian() {
 
 TEST(MessageInfo, everythingIsZeroAtInitialisation) {
   MessageInfo MsgInfo;
-  ASSERT_DOUBLE_EQ(MsgInfo.getMessages(), 0u);
+  ASSERT_DOUBLE_EQ(MsgInfo.getNumberMessages(), 0u);
   ASSERT_DOUBLE_EQ(MsgInfo.getMbytes(), 0.0);
   ASSERT_DOUBLE_EQ(MsgInfo.getErrors(), 0u);
 }
@@ -26,9 +26,9 @@ TEST(MessageInfo, addOneMessage) {
   MessageInfo MsgInfo;
   const double NewMessageBytes{1024};
   MsgInfo.newMessage(NewMessageBytes);
-  auto Size = MsgInfo.messageSize();
+  auto Size = MsgInfo.messageSizeStats();
 
-  EXPECT_EQ(MsgInfo.getMessages(), 1u);
+  EXPECT_EQ(MsgInfo.getNumberMessages(), 1u);
   EXPECT_DOUBLE_EQ(MsgInfo.getMbytes(), NewMessageBytes * 1e-6);
   EXPECT_DOUBLE_EQ(Size.first, NewMessageBytes * 1e-6);
   EXPECT_DOUBLE_EQ(Size.second, 0);
@@ -39,28 +39,28 @@ TEST(MessageInfo, addOneError) {
   MessageInfo MsgInfo;
   MsgInfo.error();
 
-  EXPECT_EQ(MsgInfo.getMessages(), 0u);
+  EXPECT_EQ(MsgInfo.getNumberMessages(), 0u);
   EXPECT_DOUBLE_EQ(MsgInfo.getMbytes(), 0.0);
   EXPECT_EQ(MsgInfo.getErrors(), 1u);
 }
 
-TEST(MessageInfo, addManyMessages) {
+TEST(MessageInfo, addMultipleMessages) {
   MessageInfo MsgInfo;
 
-  double TotalMB{0.0}, TotalMBSquare{0.0};
-  for (uint64_t i = 0; i < NumMessages; ++i) {
-    auto MessageBytes = std::fabs(RandomGaussian());
-    TotalMB += MessageBytes * 1e-6;
-    TotalMBSquare += MessageBytes * MessageBytes * 1e-12;
-    MsgInfo.newMessage(MessageBytes);
-  }
-  auto Size = MsgInfo.messageSize();
+  std::vector<double> MessageSizes = {600, 470, 170, 430, 300};
+  // Answers calculated manually.
+  double Average = 394;
+  double StdDev = 164;
 
-  EXPECT_EQ(MsgInfo.getMessages(), NumMessages);
-  EXPECT_NEAR(Size.first, TotalMB / NumMessages, 1e-6);
-  EXPECT_NEAR(Size.second, (TotalMBSquare - (TotalMB * TotalMB) / NumMessages) /
-                               (NumMessages - 1),
-              1e-6);
+  for (auto Msg : MessageSizes) {
+      MsgInfo.newMessage(Msg);
+  }
+
+  auto Size = MsgInfo.messageSizeStats();
+
+  EXPECT_EQ(MsgInfo.getNumberMessages(), MessageSizes.size());
+  EXPECT_NEAR(Size.first, Average * 1e-6, 1e-6);
+  EXPECT_NEAR(Size.second, StdDev * 1e-6, 1e-6);
   EXPECT_EQ(MsgInfo.getErrors(), 0u);
 }
 
@@ -72,6 +72,7 @@ TEST(StreamMasterInfo, addInfoFromOneStreamer) {
   for (uint64_t i = 0; i < NumMessages; ++i) {
     MsgInfo.newMessage(MessageBytes);
   }
+
   for (uint64_t i = 0; i < NumErrors; ++i) {
     MsgInfo.error();
   }
@@ -114,15 +115,19 @@ TEST(StreamMasterInfo, accumulateInfoFromManyStreamers) {
   EXPECT_DOUBLE_EQ(Info.getErrors(), TotalErrors);
 }
 
-TEST(MessageInfo, computeDerivedQuantities) {
-  const std::vector<double> MessagesSize{1.0, 2.0, 3.0, 4.0, 5.0};
+TEST(MessageInfo, resettingTheStatisticsZeroes) {
   MessageInfo MsgInfo;
 
-  for (auto &MessageSize : MessagesSize) {
-    MsgInfo.newMessage(MessageSize * 1e6);
+  std::vector<double> MessageSizes = {600, 470, 170, 430, 300};
+
+  for (auto Msg : MessageSizes) {
+    MsgInfo.newMessage(Msg);
   }
 
-  auto Size = MsgInfo.messageSize();
-  EXPECT_DOUBLE_EQ(Size.first, 3.0);
-  EXPECT_NEAR(Size.second, 1.5811388300841898, 10e-3);
+  MsgInfo.resetStatistics();
+  auto Size = MsgInfo.messageSizeStats();
+
+  EXPECT_DOUBLE_EQ(0, Size.first);
+  EXPECT_DOUBLE_EQ(0, Size.second);
+  EXPECT_EQ(0u, MsgInfo.getErrors());
 }

--- a/src/tests/StatusWriterTests.cpp
+++ b/src/tests/StatusWriterTests.cpp
@@ -196,7 +196,7 @@ TEST(StatFunctions, messageSize) {
   for (size_t i = 0; i < NumMessages; ++i) {
     Message.newMessage(MessageBytes * i);
   }
-  std::pair<double, double> MessageSize = Message.messageSize();
+  std::pair<double, double> MessageSize = Message.messageSizeStats();
   EXPECT_DOUBLE_EQ(MessageSize.first, 0.050688);
   EXPECT_DOUBLE_EQ(MessageSize.second, 0.0297077677833032);
 }


### PR DESCRIPTION
### Issue

DM-1373

### Description of work

Checks for one message, if so returns zero for the standard deviation (test already exists).
Also, no need to pass doubles as const ref.

### Nominate for Group Code Review

- [ ] Nominate for code review 

