### PR TITLE
DM-1168 use system_clock for status writing

### DIFF
--- a/src/StatusWriter.cpp
+++ b/src/StatusWriter.cpp
@@ -35,7 +35,7 @@ void StatusWriter::write(StreamMasterInfo &Information) {
   json["next_message_eta_ms"] = Information.getTimeToNextMessage().count();
   json["stream_master"] = StreamMasterToJson(Information);
   json["timestamp"] = std::chrono::duration_cast<std::chrono::milliseconds>(
-                          std::chrono::steady_clock::now().time_since_epoch())
+                          std::chrono::system_clock::now().time_since_epoch())
                           .count();
 }
 

--- a/src/tests/StatusWriterTests.cpp
+++ b/src/tests/StatusWriterTests.cpp
@@ -63,7 +63,7 @@ TEST(StatusWriter, emptyWriterHasDefaultFields) {
 
 int64_t getTimestampMs() {
   return std::chrono::duration_cast<std::chrono::milliseconds>(
-             std::chrono::steady_clock::now().time_since_epoch())
+             std::chrono::system_clock::now().time_since_epoch())
       .count();
 };
 


### PR DESCRIPTION
### Issue

*[DM-1287](https://jira.esss.lu.se/browse/DM-1287)*

### Description of work
Status messages now contain timestamp defined using system_clock instead of steady_clock.
