### PR TITLE
Slimming down docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,13 @@
 .gitignore
 ansible
 /system-tests/output-files/
+/build-script/
+/documentation/
+/system-tests/
+.clang-format
+.gitignore
+codecov.yml
+*.md
+*.conf
+Jenkinsfile
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,14 @@ ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/ma
 COPY ./conan ../kafka_to_nexus_src/conan
 
 # Install packages - We don't want to purge kafkacat and tzdata after building
+# boost_regex package fails to build with more recent versions of conan so we're using 1.12.1
 RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get update -y \
     && apt-get --no-install-recommends -y install build-essential git python python-pip cmake python-setuptools autoconf libtool automake kafkacat tzdata \
     && apt-get -y autoremove  \
     && apt-get clean all \
     && rm -rf /var/lib/apt/lists/* \
-    && pip install conan \
+    && pip install conan==1.12.1 \
     && mkdir kafka_to_nexus \
     && if [ ! -z "$local_conan_server" ]; then conan remote add --insert 0 ess-dmsc-local "$local_conan_server"; fi \
     && cd kafka_to_nexus \
@@ -27,7 +28,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 COPY ./ ../kafka_to_nexus_src/
 
 RUN cd kafka_to_nexus \
-    && cmake -DCONAN="MANUAL" -DCMAKE_BUILD_TYPE=Release -DUSE_GRAYLOG_LOGGER=True ../kafka_to_nexus_src \
+    && cmake -DCONAN="MANUAL" --target="kafka-to-nexus" -DCMAKE_BUILD_TYPE=Release -DUSE_GRAYLOG_LOGGER=True -DRUN_DOXYGEN="FALSE" ../kafka_to_nexus_src \
     && make -j8 \
     && mkdir /output-files \
     && conan remove "*" -s -f \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,39 @@
 FROM ubuntu:18.04
 
-ENV DEBIAN_FRONTEND=noninteractive
-
 ARG http_proxy
 
 ARG https_proxy
 
 ARG local_conan_server
 
-ENV BUILD_PACKAGES "build-essential git python python-pip cmake python-setuptools autoconf libtool automake"
-
-# Install packages - We don't want to purge kafkacat and tzdata after building
-RUN apt-get update -y && \
-    apt-get --no-install-recommends -y install $BUILD_PACKAGES kafkacat tzdata && \
-    apt-get -y autoremove && \
-    apt-get clean all && \
-    rm -rf /var/lib/apt/lists/* && \
-    pip install conan && \
-    conan profile new default && \
-    mkdir kafka_to_nexus
-
 # Replace the default profile and remotes with the ones from our Ubuntu build node
 ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/registry.json" "/root/.conan/registry.json"
 ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/default_profile" "/root/.conan/profiles/default"
-
-# Add local Conan server
-RUN if [ ! -z "$local_conan_server" ]; then conan remote add --insert 0 ess-dmsc-local "$local_conan_server"; fi
-
 COPY ./conan ../kafka_to_nexus_src/conan
-RUN cd kafka_to_nexus && conan install --build=outdated ../kafka_to_nexus_src/conan/conanfile.txt
-COPY ./src ../kafka_to_nexus_src/src
-COPY ./cmake ../kafka_to_nexus_src/cmake
-COPY ./Doxygen.conf ./CMakeLists.txt ../kafka_to_nexus_src/
-COPY docker_launch.sh /
 
-RUN cd kafka_to_nexus && \
-    cmake -DCONAN="MANUAL" -DCMAKE_BUILD_TYPE=Release -DUSE_GRAYLOG_LOGGER=True ../kafka_to_nexus_src && \
-    make -j8 && mkdir /output-files && conan remove "*" -s -f && apt purge -y $BUILD_PACKAGES && rm -rf ../../kafka_to_nexus_src/* && rm -rf /tmp/* /var/tmp/*
+# Install packages - We don't want to purge kafkacat and tzdata after building
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update -y \
+    && apt-get --no-install-recommends -y install build-essential git python python-pip cmake python-setuptools autoconf libtool automake kafkacat tzdata \
+    && apt-get -y autoremove  \
+    && apt-get clean all \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install conan \
+    && mkdir kafka_to_nexus \
+    && if [ ! -z "$local_conan_server" ]; then conan remote add --insert 0 ess-dmsc-local "$local_conan_server"; fi \
+    && cd kafka_to_nexus \
+    && conan install --build=outdated ../kafka_to_nexus_src/conan/conanfile.txt
 
-CMD ["./docker_launch.sh"]
+COPY ./ ../kafka_to_nexus_src/
+
+RUN cd kafka_to_nexus \
+    && cmake -DCONAN="MANUAL" -DCMAKE_BUILD_TYPE=Release -DUSE_GRAYLOG_LOGGER=True ../kafka_to_nexus_src \
+    && make -j8 \
+    && mkdir /output-files \
+    && conan remove "*" -s -f \
+    && apt purge -y build-essential git python python-pip cmake python-setuptools autoconf libtool automake \
+    && mv ../../kafka_to_nexus_src/docker_launch.sh /docker_launch.sh \
+    && rm -rf ../../kafka_to_nexus_src/* \
+    && rm -rf /tmp/* /var/tmp/*
+
+CMD ["/docker_launch.sh"]


### PR DESCRIPTION
### Issue

relates to DM-1406

### Description of work

I have bundled steps into layers as more layers in the docker image means more space when building. This approach shouldn't take any longer than usual. The image will rebuild when the conanfile updates, however as this only happens every so often and it already causes the build time to increase I don't think this is an issue.

When merged: create and push new image to docker hub

### Nominate for Group Code Review

- [ ] Nominate for code review 

