### PR TITLE
Minor refactoring

### DIFF
--- a/src/EventLogger.h
+++ b/src/EventLogger.h
@@ -63,7 +63,6 @@ void logEvent(std::shared_ptr<ProducerType> Producer, StatusCode Code,
   Event["message"] = Message;
 
   std::string EventMessage = Event.dump();
-  Producer->produce(reinterpret_cast<unsigned char *>(&EventMessage[0]),
-                    EventMessage.size());
+  Producer->produce(EventMessage);
 }
 }

--- a/src/KafkaW/ProducerTopic.cpp
+++ b/src/KafkaW/ProducerTopic.cpp
@@ -28,9 +28,9 @@ struct Msg_ : public ProducerMessage {
   }
 };
 
-int ProducerTopic::produce(unsigned char *MsgData, size_t MsgSize) {
+int ProducerTopic::produce(const std::string &MsgData) {
   auto MsgPtr = new Msg_;
-  std::copy(MsgData, MsgData + MsgSize, std::back_inserter(MsgPtr->v));
+  std::copy(MsgData.begin(), MsgData.end(), std::back_inserter(MsgPtr->v));
   MsgPtr->finalize();
   std::unique_ptr<ProducerMessage> Msg(MsgPtr);
   return produce(Msg);

--- a/src/KafkaW/ProducerTopic.h
+++ b/src/KafkaW/ProducerTopic.h
@@ -22,7 +22,7 @@ public:
   /// \param MsgSize Size of the data to publish
   /// \return 0 if message is successfully passed to RdKafka to be published, 1
   /// otherwise
-  int produce(unsigned char *MsgData, size_t MsgSize);
+  int produce(const std::string &MsgData);
   int produce(std::unique_ptr<KafkaW::ProducerMessage> &Msg);
   std::string name() const;
 

--- a/src/Master.cpp
+++ b/src/Master.cpp
@@ -152,7 +152,7 @@ void Master::statistics() {
     Status["files"][FilewriterTaskID] = FilewriterTaskStatus;
   }
   auto Buffer = Status.dump();
-  StatusProducer->produce((unsigned char *)Buffer.data(), Buffer.size());
+  StatusProducer->produce(Buffer);
 }
 
 void Master::stop() { Running = false; }

--- a/src/Report.h
+++ b/src/Report.h
@@ -15,11 +15,11 @@ class Report {
 
 public:
   Report() : ReportMs{std::chrono::milliseconds{1000}} {}
-  Report(std::shared_ptr<KafkaW::ProducerTopic> KafkaProducer,
-         std::string JID,
+  Report(std::shared_ptr<KafkaW::ProducerTopic> KafkaProducer, std::string JID,
          const std::chrono::milliseconds &MsBetweenReports =
              std::chrono::milliseconds{1000})
-      : Producer{KafkaProducer}, JobId(std::move(JID)), ReportMs{MsBetweenReports} {}
+      : Producer{KafkaProducer}, JobId(std::move(JID)),
+        ReportMs{MsBetweenReports} {}
   Report(const Report &) = delete;
   Report(Report &&) = default;
   Report &operator=(Report &&) = default;
@@ -67,8 +67,7 @@ private:
     Information.StreamMasterStatus = StreamMasterStatus;
     Reporter.write(Information);
     std::string Value = Reporter.getJson();
-    Producer->produce(reinterpret_cast<unsigned char *>(&Value[0]),
-                      Value.size());
+    Producer->produce(Value);
 
     return StreamMasterError::OK;
   }

--- a/src/Report.h
+++ b/src/Report.h
@@ -12,15 +12,14 @@ namespace FileWriter {
 
 class Report {
   using StreamMasterError = Status::StreamMasterError;
-  using ReportType = FileWriter::Status::StatusWriter;
 
 public:
   Report() : ReportMs{std::chrono::milliseconds{1000}} {}
   Report(std::shared_ptr<KafkaW::ProducerTopic> KafkaProducer,
-         const std::string &JID,
+         std::string JID,
          const std::chrono::milliseconds &MsBetweenReports =
              std::chrono::milliseconds{1000})
-      : Producer{KafkaProducer}, JobId(JID), ReportMs{MsBetweenReports} {}
+      : Producer{KafkaProducer}, JobId(std::move(JID)), ReportMs{MsBetweenReports} {}
   Report(const Report &) = delete;
   Report(Report &&) = default;
   Report &operator=(Report &&) = default;
@@ -52,11 +51,11 @@ private:
     std::this_thread::sleep_for(ReportMs);
     if (!Producer) {
       LOG(Sev::Error,
-          "ProucerTopic error: can't produce StreamMaster status report");
+          "ProducerTopic error: can't produce StreamMaster status report");
       return StreamMasterError::REPORT_ERROR;
     }
 
-    ReportType Reporter;
+    FileWriter::Status::StatusWriter Reporter;
     Reporter.setJobId(JobId);
     for (auto &Element : Streamers) {
       // Writes Streamer information in JSON format

--- a/src/Status.h
+++ b/src/Status.h
@@ -7,13 +7,8 @@
 
 #pragma once
 
-#include <atomic>
-#include <memory>
-#include <mutex>
-#include <vector>
-
 #include <chrono>
-#include <map>
+#include <mutex>
 
 #include "Errors.h"
 

--- a/src/Status.h
+++ b/src/Status.h
@@ -1,9 +1,9 @@
 /// \file
-/// This file contains the declaration of the MessageInfo and StreamMasterInfo
-/// classes. MessageInfo collects information about number and the size of
-/// messages and the number of errors in a stream. StreamMasterInfo contains a
-/// collection of MessageInfo plus other information in order to provide global
-/// information about a StreamMaster instance.
+/// MessageInfo collects information about number and the size of
+/// messages and the number of errors in a stream.
+/// StreamMasterInfo contains a collection of MessageInfo plus other
+/// information in order to provide global information about a
+/// StreamMaster instance.
 
 #pragma once
 
@@ -27,9 +27,6 @@ namespace Status {
 class MessageInfo {
 
 public:
-  MessageInfo() = default;
-  ~MessageInfo() = default;
-
   /// \brief Increments the number of messages that have been correctly
   /// processed by one unit and the number of processed megabytes accordingly.
   ///

--- a/src/StatusWriter.cpp
+++ b/src/StatusWriter.cpp
@@ -1,6 +1,8 @@
 #include "StatusWriter.h"
 #include "Status.h"
 
+#include <chrono>
+
 namespace FileWriter {
 namespace Status {
 

--- a/src/StatusWriter.cpp
+++ b/src/StatusWriter.cpp
@@ -27,7 +27,7 @@ nlohmann::json StreamerToJson(MessageInfo const &Information) {
        {{"average", Size.first}, {"standard_deviation", Size.second}}}};
 
   return Status;
-} // namespace Status
+}
 
 void StatusWriter::setJobId(const std::string &JobId) {
   json["job_id"] = JobId;

--- a/src/StatusWriter.h
+++ b/src/StatusWriter.h
@@ -1,25 +1,18 @@
-/// \file This file contains the declaration of the StatusWriter
-/// class, which reads the information on the current status of a
+/// \file StatusWriter reads the information on the current status of a
 /// StreamMaster, such as number of received messages, number of
 /// errors and execution time and about each Streamer managed by the
 /// StreamMaster such as message frequency and throughput. These
-/// information are then serialized as a JSON message.
+/// data are then serialized as a JSON message.
 
 #pragma once
 
-#include "json.h"
-#include <chrono>
+#include <nlohmann/json.hpp>
 
 namespace FileWriter {
 namespace Status {
 
 class StreamMasterInfo;
 class MessageInfo;
-} // namespace Status
-} // namespace FileWriter
-
-namespace FileWriter {
-namespace Status {
 
 class StatusWriter {
 public:

--- a/src/StatusWriter.h
+++ b/src/StatusWriter.h
@@ -16,7 +16,6 @@ class MessageInfo;
 
 class StatusWriter {
 public:
-  StatusWriter() = default;
   void setJobId(const std::string &JobId);
   void write(StreamMasterInfo &Information);
   void write(MessageInfo &Information, const std::string &Topic);

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -122,8 +122,8 @@ void Logger::dwlog_inner(int level, char const *file, int line,
     if (!g_ServiceID.empty()) {
       Doc["ServiceID"] = g_ServiceID;
     }
-    auto Buffer = Doc.dump();
-    Topic->produce((unsigned char *)Buffer.data(), Buffer.size());
+    std::string Buffer = Doc.dump();
+    Topic->produce(Buffer);
   }
 #ifdef HAVE_GRAYLOG_LOGGER
   if (do_use_graylog_logger.load() and level < 7) {

--- a/src/send-command.cpp
+++ b/src/send-command.cpp
@@ -120,7 +120,7 @@ int main(int argc, char **argv) {
     std::string::size_type n{input.find(':')};
     std::string m1;
     if (n != std::string::npos) {
-      auto result = strtoul(&input[n + 1], NULL, 0);
+      auto result = strtoul(&input[n + 1], nullptr, 0);
       if (result) {
         stop_time = std::chrono::milliseconds{result};
       }

--- a/src/send-command.cpp
+++ b/src/send-command.cpp
@@ -103,34 +103,35 @@ int main(int argc, char **argv) {
   auto producer = std::make_shared<KafkaW::Producer>(opt.BrokerSettings);
   KafkaW::ProducerTopic pt(producer, opt.broker.Topic);
   if (opt.cmd == "new") {
-    auto m1 = make_command(opt.BrokerSettings.Address, opt.teamid);
-    LOG(Sev::Debug, "sending {}", m1);
-    pt.produce((uint8_t *)m1.data(), m1.size());
+    auto NewCommandMsg = make_command(opt.BrokerSettings.Address, opt.teamid);
+    LOG(Sev::Debug, "sending {}", NewCommandMsg);
+    pt.produce(NewCommandMsg);
   } else if (opt.cmd == "exit") {
-    auto m1 = make_command_exit(opt.BrokerSettings.Address, opt.teamid);
-    LOG(Sev::Debug, "sending {}", m1);
-    pt.produce((uint8_t *)m1.data(), m1.size());
+    auto ExitCommandMsg =
+        make_command_exit(opt.BrokerSettings.Address, opt.teamid);
+    LOG(Sev::Debug, "sending {}", ExitCommandMsg);
+    pt.produce(ExitCommandMsg);
   } else if (opt.cmd.substr(0, 5) == "file:") {
-    auto m1 = make_command_from_file(opt.cmd.substr(5));
-    LOG(Sev::Debug, "sending:\n{}", m1);
-    pt.produce((uint8_t *)m1.data(), m1.size());
+    auto CommandMsgFromFile = make_command_from_file(opt.cmd.substr(5));
+    LOG(Sev::Debug, "sending:\n{}", CommandMsgFromFile);
+    pt.produce(CommandMsgFromFile);
   } else if (opt.cmd.substr(0, 5) == "stop:") {
     auto input = opt.cmd.substr(5);
     std::chrono::milliseconds stop_time{0};
     std::string::size_type n{input.find(':')};
-    std::string m1;
+    std::string StopCommandMsg;
     if (n != std::string::npos) {
       auto result = strtoul(&input[n + 1], nullptr, 0);
       if (result) {
         stop_time = std::chrono::milliseconds{result};
       }
-      m1 = make_command_stop(opt.BrokerSettings.Address, input.substr(0, n),
-                             stop_time);
+      StopCommandMsg = make_command_stop(opt.BrokerSettings.Address,
+                                         input.substr(0, n), stop_time);
     } else {
-      m1 = make_command_stop(opt.BrokerSettings.Address, input);
+      StopCommandMsg = make_command_stop(opt.BrokerSettings.Address, input);
     }
-    LOG(Sev::Debug, "sending {}", m1);
-    pt.produce((uint8_t *)m1.data(), m1.size());
+    LOG(Sev::Debug, "sending {}", StopCommandMsg);
+    pt.produce(StopCommandMsg);
   }
   return 0;
 }

--- a/src/tests/EventLogger.cpp
+++ b/src/tests/EventLogger.cpp
@@ -4,9 +4,7 @@
 
 class StringProducer {
 public:
-  void produce(unsigned char *MsgData, size_t MsgSize) {
-    Message = std::string(reinterpret_cast<char *>(MsgData));
-  }
+  void produce(const std::string &MsgData) { Message = MsgData; }
   std::string Message;
 };
 

--- a/src/tests/StatusTest.cpp
+++ b/src/tests/StatusTest.cpp
@@ -17,9 +17,9 @@ double RandomGaussian() {
 
 TEST(MessageInfo, everythingIsZeroAtInitialisation) {
   MessageInfo MsgInfo;
-  ASSERT_DOUBLE_EQ(MsgInfo.getNumberMessages(), 0u);
+  ASSERT_EQ(MsgInfo.getNumberMessages(), 0u);
   ASSERT_DOUBLE_EQ(MsgInfo.getMbytes(), 0.0);
-  ASSERT_DOUBLE_EQ(MsgInfo.getErrors(), 0u);
+  ASSERT_EQ(MsgInfo.getErrors(), 0u);
 }
 
 TEST(MessageInfo, addOneMessage) {

--- a/src/tests/StatusWriterTests.cpp
+++ b/src/tests/StatusWriterTests.cpp
@@ -2,6 +2,7 @@
 
 #include "Status.h"
 #include "StatusWriter.h"
+#include "json.h"
 
 using MessageInfo = FileWriter::Status::MessageInfo;
 using StreamMasterInfo = FileWriter::Status::StreamMasterInfo;


### PR DESCRIPTION
### Description of work

Small refactoring changes for things I came across when looking into another ticket:
- Remove superfluous includes
- Move includes to implementation file from header
- Change produce method to take a string instead of having reinterpret and c-style casts in many places
- Improve erroneous or waffling comments
- Don't use `ASSERT_DOUBLE_EQ` for integer types

### Nominate for Group Code Review

- [ ] Nominate for code review 

