### PR TITLE
Fix status message reporting

### DIFF
--- a/src/KafkaW/Producer.cpp
+++ b/src/KafkaW/Producer.cpp
@@ -74,6 +74,13 @@ RdKafka::ErrorCode Producer::produce(RdKafka::Topic *Topic, int32_t Partition,
                                      int MessageFlags, void *Payload,
                                      size_t PayloadSize, const void *Key,
                                      size_t KeySize, void *OpaqueMessage) {
+  // Do a non-blocking poll of the local producer (note this is not polling
+  // anything across the network)
+  // NB, if we don't call poll then we haven't handled successful publishing of
+  // each message and the messages therefore never get removed from librdkafka's
+  // producer queue
+  ProducerPtr->poll(0);
+
   return ProducerPtr->produce(Topic, Partition, MessageFlags, Payload,
                               PayloadSize, Key, KeySize, OpaqueMessage);
 }

--- a/src/KafkaW/ProducerTopic.cpp
+++ b/src/KafkaW/ProducerTopic.cpp
@@ -60,7 +60,8 @@ int ProducerTopic::produce(std::unique_ptr<ProducerMessage> &Msg) {
 
   case RdKafka::ERR__QUEUE_FULL:
     ++ProducerStats.local_queue_full;
-    LOG(Sev::Warning, "Producer queue full, outq: {}",
+    LOG(Sev::Warning, "Producer queue full, outq (number of messages + number "
+                      "of unhandled events): {}",
         KafkaProducer->outputQueueLength());
     break;
 

--- a/src/Master.cpp
+++ b/src/Master.cpp
@@ -151,7 +151,7 @@ void Master::statistics() {
     auto FilewriterTaskStatus = StreamMaster->getFileWriterTask().stats();
     Status["files"][FilewriterTaskID] = FilewriterTaskStatus;
   }
-  auto Buffer = Status.dump();
+  std::string Buffer = Status.dump();
   StatusProducer->produce(Buffer);
 }
 


### PR DESCRIPTION
### Issue

DM-1383

The bug is that status message reporting stops after several hours of File Writer runtime. This was observed at V20.

The bug was caused by insufficient calls to `RdKafka::Producer.poll()`. This results in successful publish events not getting handled, therefore RdKafka does not clear the messages from the producer queue, it eventually fills up completely and at that point message publishing fails.

### Description of work

I've added a test to `Producer_tests.cpp` which checks that `poll` is called each time we call `produce`. I've added a non-blocking call to `poll` in `produce`. Note, there is no significant performance hit from this, it only polls the local producer, it does not do anything across the network.

### Nominate for Group Code Review

- [ ] Nominate for code review 

