### PR TITLE
Use the Kafka configuration struct populated by CLI11

### DIFF
--- a/src/CommandListener.cpp
+++ b/src/CommandListener.cpp
@@ -14,7 +14,8 @@ using std::string;
 CommandListener::CommandListener(MainOpt &config) : config(config) {}
 
 void CommandListener::start() {
-  KafkaW::BrokerSettings BrokerSettings;
+  KafkaW::BrokerSettings BrokerSettings =
+      config.StreamerConfiguration.BrokerSettings;
   BrokerSettings.PollTimeoutMS = 500;
   BrokerSettings.Address = config.CommandBrokerURI.HostPort;
   BrokerSettings.KafkaConfiguration["group.id"] = fmt::format(

--- a/src/Master.cpp
+++ b/src/Master.cpp
@@ -81,7 +81,8 @@ void Master::run() {
     LOG(Sev::Info, "Publishing status to kafka://{}/{}",
         getMainOpt().KafkaStatusURI.HostPort,
         getMainOpt().KafkaStatusURI.Topic);
-    KafkaW::BrokerSettings BrokerSettings;
+    KafkaW::BrokerSettings BrokerSettings =
+        getMainOpt().StreamerConfiguration.BrokerSettings;
     BrokerSettings.Address = getMainOpt().KafkaStatusURI.HostPort;
     auto producer = std::make_shared<KafkaW::Producer>(BrokerSettings);
     try {


### PR DESCRIPTION
### Issue

DM-1479

### Description of work

Custom Kafka configuration (see https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md) given via the `--kafka-config` command line option was being parsed correctly but then not actually used when constructing producer or consumer configuration.

You can test this is now working by including the following in a config ini file:
```
kafka-config=queue.buffering.max.messages 999
```
and early in the logs after starting the File Writer you should see:
```
KafkaW/BrokerSettings.cpp:10 [7] [ServiceID:kafka-to-nexus--host:jonmd-OptiPlex-7040--pid:9363]: set config: queue.buffering.max.messages = 999
```
 
100000 is the default value, it should have used the value of 999 defined in the configuration file.

### Nominate for Group Code Review

- [ ] Nominate for code review 

