### PR TITLE
Improve/fix URI code and related error messages

### DIFF
--- a/src/CLIOptions.cpp
+++ b/src/CLIOptions.cpp
@@ -15,9 +15,9 @@ CLI::Option *uriOption(CLI::App &App, const std::string &Name, uri::URI &URIArg,
   return Opt;
 }
 
-CLI::Option *addUriOption(CLI::App &App, std::string const &Name, uri::URI &URIArg,
-                       std::string const &Description = "",
-                       bool Defaulted = false) {
+CLI::Option *addUriOption(CLI::App &App, std::string const &Name,
+                          uri::URI &URIArg, std::string const &Description = "",
+                          bool Defaulted = false) {
   CLI::callback_t Fun = [&URIArg](CLI::results_t Results) {
     try {
       URIArg.parse(Results[0]);
@@ -41,10 +41,10 @@ CLI::Option *addUriOption(CLI::App &App, std::string const &Name, uri::URI &URIA
 /// \param Description
 /// \param Defaulted
 /// \return
-CLI::Option *addUriOption(CLI::App &App, const std::string &Name, uri::URI &URIArg,
-                       bool &TrueIfOptionGiven,
-                       const std::string &Description = "",
-                       bool Defaulted = false) {
+CLI::Option *addUriOption(CLI::App &App, const std::string &Name,
+                          uri::URI &URIArg, bool &TrueIfOptionGiven,
+                          const std::string &Description = "",
+                          bool Defaulted = false) {
   CLI::callback_t Fun = [&URIArg, &TrueIfOptionGiven](CLI::results_t Results) {
     TrueIfOptionGiven = true;
     try {
@@ -97,17 +97,19 @@ void setCLIOptions(CLI::App &App, MainOpt &MainOptions) {
                  "Specify a json file to set config")
       ->check(CLI::ExistingFile);
 
-  addUriOption(App, "--command-uri", MainOptions.CommandBrokerURI,
-            "<host[:port][/topic]> Kafka broker/topic to listen for commands")
+  addUriOption(
+      App, "--command-uri", MainOptions.CommandBrokerURI,
+      "<host[:port][/topic]> Kafka broker/topic to listen for commands")
       ->required();
   addUriOption(App, "--status-uri", MainOptions.KafkaStatusURI,
-            MainOptions.ReportStatus,
-            "<host[:port][/topic]> Kafka broker/topic to publish status "
-            "updates on");
+               MainOptions.ReportStatus,
+               "<host[:port][/topic]> Kafka broker/topic to publish status "
+               "updates on");
   addUriOption(App, "--kafka-gelf", MainOptions.kafka_gelf,
-                 "<host[:port]/topic> Log to Graylog via Kafka GELF adapter");
-  addUriOption(App, "--graylog-logger-address", MainOptions.GraylogLoggerAddress,
-                 "<host:port> Log to Graylog via graylog_logger library");
+               "<host[:port]/topic> Log to Graylog via Kafka GELF adapter");
+  addUriOption(App, "--graylog-logger-address",
+               MainOptions.GraylogLoggerAddress,
+               "<host:port> Log to Graylog via graylog_logger library");
   App.add_option(
          "-v,--verbosity", log_level,
          "Set logging level. 3 == Error, 7 == Debug. Default: 3 (Error)", true)

--- a/src/CLIOptions.cpp
+++ b/src/CLIOptions.cpp
@@ -15,11 +15,15 @@ CLI::Option *uriOption(CLI::App &App, const std::string &Name, uri::URI &URIArg,
   return Opt;
 }
 
-CLI::Option *addOption(CLI::App &App, std::string const &Name, uri::URI &URIArg,
+CLI::Option *addUriOption(CLI::App &App, std::string const &Name, uri::URI &URIArg,
                        std::string const &Description = "",
                        bool Defaulted = false) {
   CLI::callback_t Fun = [&URIArg](CLI::results_t Results) {
-    URIArg.parse(Results[0]);
+    try {
+      URIArg.parse(Results[0]);
+    } catch (std::runtime_error &E) {
+      return false;
+    }
     return true;
   };
 
@@ -37,13 +41,17 @@ CLI::Option *addOption(CLI::App &App, std::string const &Name, uri::URI &URIArg,
 /// \param Description
 /// \param Defaulted
 /// \return
-CLI::Option *addOption(CLI::App &App, const std::string &Name, uri::URI &URIArg,
+CLI::Option *addUriOption(CLI::App &App, const std::string &Name, uri::URI &URIArg,
                        bool &TrueIfOptionGiven,
                        const std::string &Description = "",
                        bool Defaulted = false) {
   CLI::callback_t Fun = [&URIArg, &TrueIfOptionGiven](CLI::results_t Results) {
     TrueIfOptionGiven = true;
-    URIArg.parse(Results[0]);
+    try {
+      URIArg.parse(Results[0]);
+    } catch (std::runtime_error &E) {
+      return false;
+    }
     return true;
   };
 
@@ -89,16 +97,16 @@ void setCLIOptions(CLI::App &App, MainOpt &MainOptions) {
                  "Specify a json file to set config")
       ->check(CLI::ExistingFile);
 
-  addOption(App, "--command-uri", MainOptions.CommandBrokerURI,
-            "<//host[:port][/topic]> Kafka broker/topic to listen for commands")
+  addUriOption(App, "--command-uri", MainOptions.CommandBrokerURI,
+            "<host[:port][/topic]> Kafka broker/topic to listen for commands")
       ->required();
-  addOption(App, "--status-uri", MainOptions.KafkaStatusURI,
+  addUriOption(App, "--status-uri", MainOptions.KafkaStatusURI,
             MainOptions.ReportStatus,
-            "<//host[:port][/topic]> Kafka broker/topic to publish status "
+            "<host[:port][/topic]> Kafka broker/topic to publish status "
             "updates on");
-  App.add_option("--kafka-gelf", MainOptions.kafka_gelf,
-                 "<//host[:port]/topic> Log to Graylog via Kafka GELF adapter");
-  App.add_option("--graylog-logger-address", MainOptions.GraylogLoggerAddress,
+  addUriOption(App, "--kafka-gelf", MainOptions.kafka_gelf,
+                 "<host[:port]/topic> Log to Graylog via Kafka GELF adapter");
+  addUriOption(App, "--graylog-logger-address", MainOptions.GraylogLoggerAddress,
                  "<host:port> Log to Graylog via graylog_logger library");
   App.add_option(
          "-v,--verbosity", log_level,

--- a/src/CLIOptions.h
+++ b/src/CLIOptions.h
@@ -14,10 +14,11 @@ struct MainOpt;
 
 void setCLIOptions(CLI::App &App, MainOpt &MainOptions);
 
-CLI::Option *addUriOption(CLI::App &App, std::string const &Name, uri::URI &URIArg,
-                       bool &TrueIfOptionGiven, std::string const &Description,
-                       bool Defaulted);
+CLI::Option *addUriOption(CLI::App &App, std::string const &Name,
+                          uri::URI &URIArg, bool &TrueIfOptionGiven,
+                          std::string const &Description, bool Defaulted);
 
 /// Use for adding a URI option
-CLI::Option *addUriOption(CLI::App &App, std::string const &Name, uri::URI &URIArg,
-                       std::string const &Description, bool Defaulted);
+CLI::Option *addUriOption(CLI::App &App, std::string const &Name,
+                          uri::URI &URIArg, std::string const &Description,
+                          bool Defaulted);

--- a/src/CLIOptions.h
+++ b/src/CLIOptions.h
@@ -14,10 +14,10 @@ struct MainOpt;
 
 void setCLIOptions(CLI::App &App, MainOpt &MainOptions);
 
-CLI::Option *addOption(CLI::App &App, std::string const &Name, uri::URI &URIArg,
+CLI::Option *addUriOption(CLI::App &App, std::string const &Name, uri::URI &URIArg,
                        bool &TrueIfOptionGiven, std::string const &Description,
                        bool Defaulted);
 
 /// Use for adding a URI option
-CLI::Option *addOption(CLI::App &App, std::string const &Name, uri::URI &URIArg,
+CLI::Option *addUriOption(CLI::App &App, std::string const &Name, uri::URI &URIArg,
                        std::string const &Description, bool Defaulted);

--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -224,12 +224,9 @@ void CommandHandler::handleNew(std::string const &Command,
              Config.ServiceID, Task->jobID(), "Start job");
   }
 
-  uri::URI Broker("//localhost:9092");
+  uri::URI Broker("localhost:9092");
   if (auto BrokerStringMaybe = find<std::string>("broker", Doc)) {
     auto BrokerString = BrokerStringMaybe.inner();
-    if (BrokerString.substr(0, 2) != "//") {
-      BrokerString = std::string("//") + BrokerString;
-    }
     try {
       Broker.parse(BrokerString);
     } catch (std::runtime_error &e) {

--- a/src/MainOpt.cpp
+++ b/src/MainOpt.cpp
@@ -41,14 +41,14 @@ void MainOpt::findAndAddCommands() {
 
 void setupLoggerFromOptions(MainOpt const &opt) {
   g_ServiceID = opt.ServiceID;
-  if (!opt.kafka_gelf.empty()) {
-    URI uri(opt.kafka_gelf);
+  if (!opt.kafka_gelf.HostPort.empty()) {
+    auto &uri = opt.kafka_gelf;
     log_kafka_gelf_start(uri.HostPort, uri.Topic);
     LOG(Sev::Debug, "Enabled kafka_gelf: //{}/{}", uri.HostPort, uri.Topic);
   }
 
-  if (!opt.GraylogLoggerAddress.empty()) {
-    fwd_graylog_logger_enable(opt.GraylogLoggerAddress);
+  if (!opt.GraylogLoggerAddress.HostPort.empty()) {
+    fwd_graylog_logger_enable(opt.GraylogLoggerAddress.HostPort);
   }
 
   if (!opt.LogFilename.empty()) {

--- a/src/MainOpt.h
+++ b/src/MainOpt.h
@@ -33,10 +33,10 @@ struct MainOpt {
   FileWriter::StreamerOptions StreamerConfiguration;
 
   /// Can optionally log in Graylog GELF format to a Kafka topic.
-  std::string kafka_gelf;
+  uri::URI kafka_gelf;
 
   /// Can optionally use the `graylog_logger` library to log to this address.
-  std::string GraylogLoggerAddress;
+  uri::URI GraylogLoggerAddress;
 
   /// Used for logging to file
   std::string LogFilename;
@@ -57,7 +57,7 @@ struct MainOpt {
   int parseJsonCommands();
 
   /// Kafka broker and topic where file writer commands are published.
-  uri::URI CommandBrokerURI{"//localhost:9092/kafka-to-nexus.command"};
+  uri::URI CommandBrokerURI{"localhost:9092/kafka-to-nexus.command"};
 
   /// \brief Path for HDF output.
   ///
@@ -72,7 +72,7 @@ struct MainOpt {
   bool ReportStatus = false;
 
   /// Kafka topic where status updates are to be published.
-  uri::URI KafkaStatusURI{"//localhost:9092/kafka-to-nexus.status"};
+  uri::URI KafkaStatusURI{"localhost:9092/kafka-to-nexus.status"};
 
   /// \brief std::chrono::milliseconds interval to publish status of `Master`
   /// (e.g.

--- a/src/URI.cpp
+++ b/src/URI.cpp
@@ -16,7 +16,8 @@ void URI::parse(const std::string &URIString) {
       R"(\s*((([^:/?#]+)://)|(//)|())((([^/?#:]+)+)(:(\d+))?)/?([a-zA-Z0-9._-]+)?\s*)");
   std::regex_match(URIString, Matches, Regex);
   if (!Matches[6].matched) {
-    throw std::runtime_error("Unable to extract host from the URI: \"" + URIString + "\".");
+    throw std::runtime_error("Unable to extract host from the URI: \"" +
+                             URIString + "\".");
   }
   HostPort = Matches[6].str();
   if (Matches[10].matched) {

--- a/src/URI.cpp
+++ b/src/URI.cpp
@@ -13,17 +13,17 @@ void URI::parse(const std::string &URIString) {
   // host is mandatory however scheme and port are optional. Uses capture groups
   // for each component of the URI and ignores any paths
   std::regex Regex(
-      R"(\s*(([^:/?#]+):)?//((([^/?#:]+)+)(:(\d+))?)/?([a-zA-Z0-9._-]+)?\s*)");
+      R"(\s*((([^:/?#]+)://)|(//)|())((([^/?#:]+)+)(:(\d+))?)/?([a-zA-Z0-9._-]+)?\s*)");
   std::regex_match(URIString, Matches, Regex);
-  if (!Matches[4].matched) {
-    throw std::runtime_error("Host not found when trying to parse URI");
+  if (!Matches[6].matched) {
+    throw std::runtime_error("Unable to extract host from the URI: \"" + URIString + "\".");
   }
-  HostPort = Matches.str(3);
-  if (Matches[7].matched) {
-    Port = static_cast<uint32_t>(std::stoi(Matches.str(7)));
+  HostPort = Matches[6].str();
+  if (Matches[10].matched) {
+    Port = static_cast<uint32_t>(std::stoi(Matches[10].str()));
   }
-  if (Matches[8].matched) {
-    Topic = Matches.str(8);
+  if (Matches[11].matched) {
+    Topic = Matches[11].str();
   }
 }
 } // namespace uri

--- a/src/URI.cpp
+++ b/src/URI.cpp
@@ -1,6 +1,5 @@
 #include "URI.h"
 #include "logger.h"
-#include <iostream>
 #include <regex>
 
 namespace uri {

--- a/src/URI.h
+++ b/src/URI.h
@@ -8,6 +8,7 @@ namespace uri {
 
 /// \brief Thin parser for URIs.
 struct URI {
+  URI() = default;
   /// Creates and parses the given URI
   explicit URI(const std::string &URIString);
 
@@ -25,7 +26,7 @@ struct URI {
   /// If the path can be a valid Kafka topic name, then it is non-empty.
   std::string Topic;
 
-  /// The URI string //<host>:<port>/<topic>
-  std::string getURIString() const { return "//" + HostPort + "/" + Topic; }
+  /// The URI string <host>:<port>/<topic>
+  std::string getURIString() const { return HostPort + "/" + Topic; }
 };
 } // namespace uri

--- a/src/send-command.cpp
+++ b/src/send-command.cpp
@@ -93,10 +93,10 @@ int main(int argc, char **argv) {
       "(optional): stop:<jobid>[:<timestamp>]\n"
       "                              Terminate the filewriter process: exit");
   addUriOption(App, "--broker", opt.broker,
-            "<host[:port]/topic>\n"
-            "                              Host, port, topic where the "
-            "command should be sent to.",
-            false);
+               "<host[:port]/topic>\n"
+               "                              Host, port, topic where the "
+               "command should be sent to.",
+               false);
   CLI11_PARSE(App, argc, argv);
 
   opt.BrokerSettings.Address = opt.broker.HostPort;

--- a/src/send-command.cpp
+++ b/src/send-command.cpp
@@ -92,8 +92,8 @@ int main(int argc, char **argv) {
       "                              Stop writing file-with-id and timestamp "
       "(optional): stop:<jobid>[:<timestamp>]\n"
       "                              Terminate the filewriter process: exit");
-  addOption(App, "--broker", opt.broker,
-            "<//host[:port]/topic>\n"
+  addUriOption(App, "--broker", opt.broker,
+            "<host[:port]/topic>\n"
             "                              Host, port, topic where the "
             "command should be sent to.",
             false);

--- a/src/tests/URITests.cpp
+++ b/src/tests/URITests.cpp
@@ -8,60 +8,60 @@ TEST(URI, host_only_gives_hostport_plus_default_port) {
   ASSERT_EQ(TestURI.HostPort, "myhost");
   ASSERT_EQ(TestURI.Port, (uint32_t)0);
 }
-  
-  TEST(URI, host_only) {
-    URI TestURI("myhost");
-    ASSERT_EQ(TestURI.HostPort, "myhost");
-    ASSERT_EQ(TestURI.Port, (uint32_t)0);
-  }
+
+TEST(URI, host_only) {
+  URI TestURI("myhost");
+  ASSERT_EQ(TestURI.HostPort, "myhost");
+  ASSERT_EQ(TestURI.Port, (uint32_t)0);
+}
 
 TEST(URI, ip_only_gives_hostport_plus_default_port) {
   URI TestURI("//127.0.0.1");
   ASSERT_EQ(TestURI.HostPort, "127.0.0.1");
   ASSERT_EQ(TestURI.Port, (uint32_t)0);
 }
-  
-  TEST(URI, ip_only) {
-    URI TestURI("127.0.0.1");
-    ASSERT_EQ(TestURI.HostPort, "127.0.0.1");
-    ASSERT_EQ(TestURI.Port, (uint32_t)0);
-  }
+
+TEST(URI, ip_only) {
+  URI TestURI("127.0.0.1");
+  ASSERT_EQ(TestURI.HostPort, "127.0.0.1");
+  ASSERT_EQ(TestURI.Port, (uint32_t)0);
+}
 
 TEST(URI, host_with_port_gives_hostport_and_port) {
   URI TestURI("//myhost:345");
   ASSERT_EQ(TestURI.HostPort, "myhost:345");
   ASSERT_EQ(TestURI.Port, (uint32_t)345);
 }
-  
-  TEST(URI, host_and_port) {
-    URI TestURI("myhost:345");
-    ASSERT_EQ(TestURI.HostPort, "myhost:345");
-    ASSERT_EQ(TestURI.Port, (uint32_t)345);
-  }
+
+TEST(URI, host_and_port) {
+  URI TestURI("myhost:345");
+  ASSERT_EQ(TestURI.HostPort, "myhost:345");
+  ASSERT_EQ(TestURI.Port, (uint32_t)345);
+}
 
 TEST(URI, getURIString_host_with_port_and_topic_gives_hostport_and_topic) {
   std::string TestURIString = "myhost:345/mytopic";
   URI TestURI("//" + TestURIString);
   ASSERT_EQ(TestURI.getURIString(), TestURIString);
 }
-  
-  TEST(URI, host_and_port_and_topic) {
-    std::string TestURIString = "myhost:345/mytopic";
-    URI TestURI(TestURIString);
-    ASSERT_EQ(TestURI.getURIString(), TestURIString);
-  }
+
+TEST(URI, host_and_port_and_topic) {
+  std::string TestURIString = "myhost:345/mytopic";
+  URI TestURI(TestURIString);
+  ASSERT_EQ(TestURI.getURIString(), TestURIString);
+}
 
 TEST(URI, ip_with_port_gives_hostport_with_port) {
   URI TestURI("//127.0.0.1:345");
   ASSERT_EQ(TestURI.HostPort, "127.0.0.1:345");
   ASSERT_EQ(TestURI.Port, (uint32_t)345);
 }
-  
-  TEST(URI, ip_and_port) {
-    URI TestURI("//127.0.0.1:345");
-    ASSERT_EQ(TestURI.HostPort, "127.0.0.1:345");
-    ASSERT_EQ(TestURI.Port, (uint32_t)345);
-  }
+
+TEST(URI, ip_and_port) {
+  URI TestURI("//127.0.0.1:345");
+  ASSERT_EQ(TestURI.HostPort, "127.0.0.1:345");
+  ASSERT_EQ(TestURI.Port, (uint32_t)345);
+}
 
 TEST(URI, scheme_ignored_host_port_path_parsed) {
   URI TestURI("kafka://my_host.com:8080/maybe");
@@ -73,10 +73,10 @@ TEST(URI, scheme_ignored_host_port_path_parsed) {
 TEST(URI, path_after_topic_throws_runtime_error) {
   ASSERT_THROW(URI("//my.Host:99/some/longer"), std::runtime_error);
 }
-  
-  TEST(URI, path_after_topic_throws_runtime_error_alt) {
-    ASSERT_THROW(URI("my.Host:99/some/longer"), std::runtime_error);
-  }
+
+TEST(URI, path_after_topic_throws_runtime_error_alt) {
+  ASSERT_THROW(URI("my.Host:99/some/longer"), std::runtime_error);
+}
 
 TEST(URI, host_with_topic_no_port_gives_hostport_topic_and_default_port) {
   URI TestURI("//my.Host/the-topic");
@@ -99,18 +99,16 @@ TEST(URI, scheme_double_colon_throws_runtime_error) {
 TEST(URI, no_host_given_throws_runtime_error) {
   ASSERT_THROW(URI("//:9092"), std::runtime_error);
 }
-  
-  TEST(URI, no_host) {
-    ASSERT_THROW(URI(":9092"), std::runtime_error);
-  }
+
+TEST(URI, no_host) { ASSERT_THROW(URI(":9092"), std::runtime_error); }
 
 TEST(URI, port_double_colon_throws_runtime_error) {
   ASSERT_THROW(URI("//my.Host::789"), std::runtime_error);
 }
-  
-  TEST(URI, double_colon_throws) {
-    ASSERT_THROW(URI("my.Host::789"), std::runtime_error);
-  }
+
+TEST(URI, double_colon_throws) {
+  ASSERT_THROW(URI("my.Host::789"), std::runtime_error);
+}
 
 TEST(URI, host_and_port_with_spaces_still_parsed_correctly) {
   URI TestURI("  //some:123     ");

--- a/src/tests/URITests.cpp
+++ b/src/tests/URITests.cpp
@@ -8,30 +8,60 @@ TEST(URI, host_only_gives_hostport_plus_default_port) {
   ASSERT_EQ(TestURI.HostPort, "myhost");
   ASSERT_EQ(TestURI.Port, (uint32_t)0);
 }
+  
+  TEST(URI, host_only) {
+    URI TestURI("myhost");
+    ASSERT_EQ(TestURI.HostPort, "myhost");
+    ASSERT_EQ(TestURI.Port, (uint32_t)0);
+  }
 
 TEST(URI, ip_only_gives_hostport_plus_default_port) {
   URI TestURI("//127.0.0.1");
   ASSERT_EQ(TestURI.HostPort, "127.0.0.1");
   ASSERT_EQ(TestURI.Port, (uint32_t)0);
 }
+  
+  TEST(URI, ip_only) {
+    URI TestURI("127.0.0.1");
+    ASSERT_EQ(TestURI.HostPort, "127.0.0.1");
+    ASSERT_EQ(TestURI.Port, (uint32_t)0);
+  }
 
 TEST(URI, host_with_port_gives_hostport_and_port) {
   URI TestURI("//myhost:345");
   ASSERT_EQ(TestURI.HostPort, "myhost:345");
   ASSERT_EQ(TestURI.Port, (uint32_t)345);
 }
+  
+  TEST(URI, host_and_port) {
+    URI TestURI("myhost:345");
+    ASSERT_EQ(TestURI.HostPort, "myhost:345");
+    ASSERT_EQ(TestURI.Port, (uint32_t)345);
+  }
 
 TEST(URI, getURIString_host_with_port_and_topic_gives_hostport_and_topic) {
-  std::string TestURIString = "//myhost:345/mytopic";
-  URI TestURI(TestURIString);
+  std::string TestURIString = "myhost:345/mytopic";
+  URI TestURI("//" + TestURIString);
   ASSERT_EQ(TestURI.getURIString(), TestURIString);
 }
+  
+  TEST(URI, host_and_port_and_topic) {
+    std::string TestURIString = "myhost:345/mytopic";
+    URI TestURI(TestURIString);
+    ASSERT_EQ(TestURI.getURIString(), TestURIString);
+  }
 
 TEST(URI, ip_with_port_gives_hostport_with_port) {
   URI TestURI("//127.0.0.1:345");
   ASSERT_EQ(TestURI.HostPort, "127.0.0.1:345");
   ASSERT_EQ(TestURI.Port, (uint32_t)345);
 }
+  
+  TEST(URI, ip_and_port) {
+    URI TestURI("//127.0.0.1:345");
+    ASSERT_EQ(TestURI.HostPort, "127.0.0.1:345");
+    ASSERT_EQ(TestURI.Port, (uint32_t)345);
+  }
 
 TEST(URI, scheme_ignored_host_port_path_parsed) {
   URI TestURI("kafka://my_host.com:8080/maybe");
@@ -43,6 +73,10 @@ TEST(URI, scheme_ignored_host_port_path_parsed) {
 TEST(URI, path_after_topic_throws_runtime_error) {
   ASSERT_THROW(URI("//my.Host:99/some/longer"), std::runtime_error);
 }
+  
+  TEST(URI, path_after_topic_throws_runtime_error_alt) {
+    ASSERT_THROW(URI("my.Host:99/some/longer"), std::runtime_error);
+  }
 
 TEST(URI, host_with_topic_no_port_gives_hostport_topic_and_default_port) {
   URI TestURI("//my.Host/the-topic");
@@ -65,10 +99,18 @@ TEST(URI, scheme_double_colon_throws_runtime_error) {
 TEST(URI, no_host_given_throws_runtime_error) {
   ASSERT_THROW(URI("//:9092"), std::runtime_error);
 }
+  
+  TEST(URI, no_host) {
+    ASSERT_THROW(URI(":9092"), std::runtime_error);
+  }
 
 TEST(URI, port_double_colon_throws_runtime_error) {
   ASSERT_THROW(URI("//my.Host::789"), std::runtime_error);
 }
+  
+  TEST(URI, double_colon_throws) {
+    ASSERT_THROW(URI("my.Host::789"), std::runtime_error);
+  }
 
 TEST(URI, host_and_port_with_spaces_still_parsed_correctly) {
   URI TestURI("  //some:123     ");
@@ -81,6 +123,6 @@ TEST(URI, topic_picked_up_when_after_port) {
   ASSERT_EQ(TestURI.HostPort, "localhost:9092");
   ASSERT_EQ(TestURI.Port, 9092u);
   ASSERT_EQ(TestURI.Topic, "TEST_writerCommand");
-  ASSERT_EQ(TestURI.getURIString(), "//localhost:9092/TEST_writerCommand");
+  ASSERT_EQ(TestURI.getURIString(), "localhost:9092/TEST_writerCommand");
 }
 } // namespace uri


### PR DESCRIPTION
### Issue

* Part of closing DM-1444
* Closes DM-384

### Description of work

* Made the  forward slashes ("//") in URIs optional.
* Added some unit tests.
* Improved the exception error message when failing to parse host name.
* Made the CLI11 library write out an error message on poorly formatted address strings.
* Removed references to the forward slashes from the help text.
* Additional deletion of the use of forward slashes.
* Improved some function names.

### Nominate for Group Code Review

- [ ] Nominate for code review 
