### PR TITLE
DM-1524 - Moving check for Command JSON filename to just after parsing

### DIFF
--- a/src/MainOpt.cpp
+++ b/src/MainOpt.cpp
@@ -16,10 +16,6 @@ void MainOpt::init() {
 }
 
 int MainOpt::parseJsonCommands() {
-  if (CommandsJsonFilename.empty()) {
-    getLogger()->warn("JSON command filename is empty");
-    return -1;
-  }
   auto jsontxt = readFileIntoVector(CommandsJsonFilename);
   using nlohmann::json;
   try {

--- a/src/kafka-to-nexus.cpp
+++ b/src/kafka-to-nexus.cpp
@@ -36,7 +36,7 @@ int main(int argc, char **argv) {
   setupLoggerFromOptions(*Options);
   auto Logger = getLogger();
 
-  if (not Options->CommandsJsonFilename.empty()) {
+  if (!Options->CommandsJsonFilename.empty()) {
     Options->parseJsonCommands();
   }
 
@@ -79,7 +79,7 @@ int main(int argc, char **argv) {
     }
   });
 
-  while (not Master.runLoopExited()) {
+  while (!Master.runLoopExited()) {
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
     if (GotSignal) {
       Logger->debug("SIGNAL {}", SignalId);

--- a/src/kafka-to-nexus.cpp
+++ b/src/kafka-to-nexus.cpp
@@ -35,7 +35,10 @@ int main(int argc, char **argv) {
   CLI11_PARSE(App, argc, argv);
   setupLoggerFromOptions(*Options);
   auto Logger = getLogger();
-  Options->parseJsonCommands();
+
+  if (not Options->CommandsJsonFilename.empty()) {
+    Options->parseJsonCommands();
+  }
 
   if (Options->ListWriterModules) {
     fmt::print("Registered writer/reader classes\n");

--- a/src/tests/MainOpt.cpp
+++ b/src/tests/MainOpt.cpp
@@ -3,16 +3,11 @@
 #include <nlohmann/json.hpp>
 using nlohmann::json;
 
-TEST(MainOpt, MainOptTestParseJsonCommandsReturnsErrorIfNoCommandsJson) {
-  MainOpt Mainopt;
-  ASSERT_EQ(-1, Mainopt.parseJsonCommands());
-}
-
 TEST(MainOpt, findAndAddCommandsAddsNoCommandsIfJsonIsEmpty) {
   MainOpt Mainopt;
   Mainopt.CommandsJson = json::parse("{}");
   Mainopt.findAndAddCommands();
-  Mainopt.CommandsFromJson.empty();
+  ASSERT_TRUE(Mainopt.CommandsFromJson.empty());
 }
 
 TEST(MainOpt, findAndAddCommandsAddsCommands) {


### PR DESCRIPTION
### Issue

DM-1524

### Description of work

Moving the check for if the command JSON filename is empty as it was causing a pointless log message that CLI should handle anyway.

### Nominate for Group Code Review

- [ ] Nominate for code review 

