### PR TITLE
Update Conan and remotes registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG https_proxy
 ARG local_conan_server
 
 # Replace the default profile and remotes with the ones from our Ubuntu build node
-ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/registry.json" "/root/.conan/registry.json"
+ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/remotes.json" "/root/.conan/remotes.json"
 ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/default_profile" "/root/.conan/profiles/default"
 COPY ./conan ../kafka_to_nexus_src/conan
 
@@ -19,7 +19,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y autoremove  \
     && apt-get clean all \
     && rm -rf /var/lib/apt/lists/* \
-    && pip install conan==1.12.1 \
+    && pip install conan==1.15.0 \
     && mkdir kafka_to_nexus \
     && if [ ! -z "$local_conan_server" ]; then conan remote add --insert 0 ess-dmsc-local "$local_conan_server"; fi \
     && cd kafka_to_nexus \


### PR DESCRIPTION
Fixes problem with latest version of Conan, due to filename change of `registry.json` to `remotes.json`.

If system tests pass then this is good to merge.