### PR TITLE
Remove convert_edge_type_to_float feature

### DIFF
--- a/src/schemas/hs00/WriterTyped.h
+++ b/src/schemas/hs00/WriterTyped.h
@@ -76,7 +76,6 @@ private:
   std::vector<HistogramRecord> HistogramRecordsFreed;
 
   size_t ChunkBytes = 1 * 1024 * 1024;
-  bool DoConvertEdgeTypeToFloat = false;
 
   uint64_t LargestTimestampSeen = 0;
   size_t MaxNumberHistoric = 4;
@@ -180,11 +179,6 @@ WriterTyped<DataType, EdgeType, ErrorType>::createFromJson(json const &Json) {
   try {
     auto &TheWriterTyped = *TheWriterTypedPtr;
     TheWriterTyped.TheShape = Shape<EdgeType>::createFromJson(Json.at("shape"));
-    try {
-      TheWriterTyped.DoConvertEdgeTypeToFloat =
-          Json.at("convert_edge_type_to_float");
-    } catch (json::out_of_range const &) {
-    }
     TheWriterTyped.CreatedFromJson = Json.dump();
   } catch (json::out_of_range const &) {
     std::throw_with_nested(UnexpectedJsonInput());
@@ -281,9 +275,6 @@ void WriterTyped<DataType, EdgeType, ErrorType>::createHDFStructure(
         hdf5::dataspace::Simple({Dim.getSize() + 1}, {Dim.getSize() + 1});
     auto TypeMem = hdf5::datatype::create<EdgeType>().native_type();
     auto TypeSpace = TypeMem;
-    if (DoConvertEdgeTypeToFloat) {
-      TypeSpace = hdf5::datatype::create<float>().native_type();
-    }
     auto Dataset =
         Group.create_dataset(Dim.getDatasetName(), TypeSpace, SpaceFile, DCPL);
     Dataset.write(Dim.getEdges(), TypeMem, SpaceMem, SpaceFile);

--- a/src/tests/EventHistogramWriterTests.cpp
+++ b/src/tests/EventHistogramWriterTests.cpp
@@ -152,13 +152,10 @@ TEST_F(EventHistogramWriter, SlicePartialOverlap) {
 }
 
 json createTestWriterTypedJson() {
-  // The option 'convert_edge_type_to_float' is a temporary special feature for
-  // AMOR.  Reminder to remove this again after next tests is in issue #304.
   auto Json = json::parse(R""({
     "data_type": "uint64",
     "error_type": "double",
     "edge_type": "float",
-    "convert_edge_type_to_float": false,
     "shape": [
       {
         "size": 1,


### PR DESCRIPTION
### Issue

DM-1194

### Description of work

Schema hs00 implements the special feature `convert_edge_type_to_float` for compatibility with NICOS. This feature is no longer needed, hence removed.
