### PR TITLE
Fix NX_class attribute in f142

### DIFF
--- a/src/schemas/f142/f142_rw.cpp
+++ b/src/schemas/f142/f142_rw.cpp
@@ -244,7 +244,7 @@ HDFWriterModule::init_hdf(hdf5::node::Group &HDFGroup,
       } else {
         auto ClassAttribute =
             HDFGroup.attributes.create<std::string>("NX_class");
-        ClassAttribute.write("NXevent_data");
+        ClassAttribute.write("NXlog");
       }
       for (auto const &Info : DatasetInfoList) {
         Info.H5Ptr = h5::h5d_chunked_1d<uint64_t>::create(HDFGroup, Info.Name,


### PR DESCRIPTION
### Issue

Fixing bug introduced in DM-1550.

### Description of work

In #448 f142 writer module created `NXevent_data` where it should be `NXlog`. 
Fixing this here.

