### PR TITLE
Some tidying in preparation for the main work

### DIFF
--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -520,15 +520,6 @@ std::string TruncateCommand(std::string const &Command) {
 
 void CommandHandler::tryToHandle(std::string const &Command,
                                  std::chrono::milliseconds MsgTimestamp) {
-
-  if (MsgTimestamp.count() < 0) {
-    MsgTimestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::system_clock::now().time_since_epoch());
-    Logger->info(
-        "Kafka command doesn't contain timestamp, so using current time.");
-  }
-  Logger->info("Kafka command message timestamp : {}", MsgTimestamp.count());
-
   try {
     handle(Command, MsgTimestamp);
   } catch (...) {
@@ -555,12 +546,6 @@ void CommandHandler::tryToHandle(std::string const &Command,
       }
     }
   }
-}
-
-void CommandHandler::tryToHandle(
-    std::unique_ptr<Msg> Message,
-    std::chrono::milliseconds MsgTimestampMilliseconds) {
-  tryToHandle({(Message->data()), Message->size()}, MsgTimestampMilliseconds);
 }
 
 size_t CommandHandler::getNumberOfFileWriterTasks() const {

--- a/src/CommandHandler.h
+++ b/src/CommandHandler.h
@@ -35,7 +35,7 @@ public:
   CommandHandler(MainOpt &Settings, MasterInterface *Master)
       : Config(Settings), MasterPtr(Master){};
 
-  /// \brief Given a nlohman::json, create a new file writer task.
+  /// \brief Create a new file writer task.
   ///
   /// \param JSONCommand Command for configuring the new task.
   void handleNew(const nlohmann::json &JSONCommand,
@@ -52,21 +52,13 @@ public:
   /// \param Command The command defining which job to stop.
   void handleStreamMasterStop(const nlohmann::json &Command);
 
-  /// \brief Try to handle the message.
-  ///
-  /// \param Msg The message.
-  /// \param MsgTimestamp The rd_kafka_message_timestamp.
-  void tryToHandle(std::unique_ptr<Msg> Message,
-                   std::chrono::milliseconds MsgTimestampMilliseconds =
-                       std::chrono::milliseconds{-1});
-
   /// \brief Try to handle the command.
   ///
   /// \param Command The command to parse.
   /// \param MsgTimestamp The rd_kafka_message_timestamp.
   void tryToHandle(
       std::string const &Command,
-      std::chrono::milliseconds MsgTimestamp = std::chrono::milliseconds{-1});
+      std::chrono::milliseconds MsgTimestamp = std::chrono::milliseconds{0});
 
   /// \brief Get number of active writer tasks.
   ///

--- a/src/MainOpt.h
+++ b/src/MainOpt.h
@@ -14,8 +14,6 @@
 #include <utility>
 #include <vector>
 
-struct rd_kafka_topic_partition_list_s;
-
 // POD
 struct MainOpt {
   bool gtest = false;

--- a/src/Master.cpp
+++ b/src/Master.cpp
@@ -45,8 +45,7 @@ void Master::handle_command_message(std::unique_ptr<Msg> CommandMessage) {
   if (CommandMessage->MetaData.TimestampType !=
       RdKafka::MessageTimestamp::MSG_TIMESTAMP_NOT_AVAILABLE) {
     TimeStamp = CommandMessage->MetaData.Timestamp;
-  }
-  else {
+  } else {
     Logger->info(
         "Kafka command doesn't contain timestamp, so using current time.");
   }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -33,8 +33,7 @@ set(UnitTests_SRC
         helpers/f142_synth.cpp
         ConsumerTests.cpp
         ChopperTimeStampWriterTests.cpp
-        NicosCacheWriterTests.cpp
-        )
+        NicosCacheWriterTests.cpp)
 
 set(UnitTests_INC
         helpers/HDFFileTestHelper.h

--- a/src/tests/CommandHandlerTests.cpp
+++ b/src/tests/CommandHandlerTests.cpp
@@ -17,7 +17,6 @@ protected:
   }
 };
 
-
 TEST_F(CommandHandler_Testing, UseFoundStartStopTime) {
   unlink("a-dummy-name-01.h5");
   std::string CommandString(R"""(

--- a/src/tests/Schema_f142Tests.cpp
+++ b/src/tests/Schema_f142Tests.cpp
@@ -444,7 +444,7 @@ TEST_F(Schema_f142, UninitializedStreamsDoNotGetReopenedOnStartOfWriting) {
   Command["file_attributes"]["file_name"] = Filename;
   Command["job_id"] = Filename;
   auto CommandString = Command.dump();
-  CommandHandler.tryToHandle(CommandString);
+  CommandHandler.tryToHandle(CommandString, std::chrono::milliseconds(0));
 
   // We write to both sources, but afterwards verify that only the data to the
   // first source has been written


### PR DESCRIPTION
### Issue

DM-1388

### Description of work

I have started tidying up some code to make it easier to add the required functionality. 
I would like to do the tidying in stages to keep the PR size(s) down.

For this PR, I have moved the message timestamp stuff up a level to simplify calls to CommandHandler.
Hopefully, it is an improvement but I cannot avoid losing some test coverage without opening a can of worms. 

I would rather keep this PR small and sort the test coverage and worms out later.

### Nominate for Group Code Review

- [ ] Nominate for code review 

