### PR TITLE
remove "double" from writer modules description

### DIFF
--- a/documentation/writer_module_f142_log_data.md
+++ b/documentation/writer_module_f142_log_data.md
@@ -22,7 +22,7 @@ Example `nexus_structure` to write a scalar `double` value:
 }
 ```
 
-For `double` arrays, we have to specify the `array_size`:
+For arrays, we have to specify the `array_size`:
 
 ```json
 {


### PR DESCRIPTION
### Issue

None

### Description of work

I think the array_size has to be applied to any type of arrays not just doubles so i believe the documentation is incorrect. 

### Nominate for Group Code Review

- [ ] Nominate for code review 

