### PR TITLE
Simplify streamer by removing duplicate sources list

### DIFF
--- a/src/DemuxTopic.cpp
+++ b/src/DemuxTopic.cpp
@@ -33,7 +33,7 @@ DemuxTopic::process_message(FlatbufferMessage const &Message) {
     ++messages_processed;
     return ProcessingResult;
   } catch (std::out_of_range &e) {
-    Logger->trace("Source with name \"{}\" and ID \"{}\" is not in list.",
+    Logger->trace(R"(Source with name "{}" and ID "{}" is not in list.)",
                   Message.getSourceName(), Message.getFlatbufferID());
     ++error_no_source_instance;
   }

--- a/src/DemuxTopic.h
+++ b/src/DemuxTopic.h
@@ -58,6 +58,15 @@ public:
     return TopicSources.insert(std::move(v)).first->second;
   }
 
+  /// Removes a source
+  /// for example when the last message before the stop time has been consumed
+  ///
+  /// \param SourceHash Uniquely identifies the source to be removed
+  /// \return True if successful, false if key source hash not found
+  bool removeSource(FlatbufferMessage::SrcHash SourceHash) {
+    return static_cast<bool>(TopicSources.erase(SourceHash));
+  }
+
   /// Counts the number of processed message.
   std::atomic<size_t> messages_processed{0};
 

--- a/src/FileWriterTask.cpp
+++ b/src/FileWriterTask.cpp
@@ -38,20 +38,6 @@ std::atomic<uint32_t> n_FileWriterTask_created{0};
 
 std::vector<DemuxTopic> &FileWriterTask::demuxers() { return Demuxers; }
 
-/// Helper function for creating an ID.
-///
-/// \param ExtraValue Used to help make a unique ID.
-/// \return A "unique" id.
-uint64_t createId(int ExtraValue) {
-  namespace chrono = std::chrono;
-  return (static_cast<uint64_t>(
-              chrono::duration_cast<chrono::nanoseconds>(
-                  chrono::system_clock::now().time_since_epoch())
-                  .count())
-          << 16) +
-         (ExtraValue & 0xffff);
-}
-
 FileWriterTask::~FileWriterTask() {
   Logger->trace("~FileWriterTask");
   Demuxers.clear();

--- a/src/FileWriterTask.cpp
+++ b/src/FileWriterTask.cpp
@@ -52,14 +52,6 @@ uint64_t createId(int ExtraValue) {
          (ExtraValue & 0xffff);
 }
 
-FileWriterTask::FileWriterTask(
-    std::string TaskID,
-    std::shared_ptr<KafkaW::ProducerTopic> StatusProducerPtr)
-    : ServiceId(std::move(TaskID)),
-      StatusProducer(std::move(StatusProducerPtr)), Logger(getLogger()) {
-  Id = createId(++n_FileWriterTask_created);
-}
-
 FileWriterTask::~FileWriterTask() {
   Logger->trace("~FileWriterTask");
   Demuxers.clear();
@@ -142,8 +134,6 @@ void FileWriterTask::reopenFile() {
     throw;
   }
 }
-
-uint64_t FileWriterTask::id() const { return Id; }
 
 std::string FileWriterTask::jobID() const { return JobId; }
 

--- a/src/FileWriterTask.cpp
+++ b/src/FileWriterTask.cpp
@@ -14,7 +14,6 @@
 #include "helper.h"
 #include "logger.h"
 #include <atomic>
-#include <chrono>
 #include <thread>
 
 namespace FileWriter {
@@ -33,8 +32,6 @@ json hdf_parse(std::string const &Structure, SharedLogger Logger) {
   }
 }
 } // namespace
-
-std::atomic<uint32_t> n_FileWriterTask_created{0};
 
 std::vector<DemuxTopic> &FileWriterTask::demuxers() { return Demuxers; }
 

--- a/src/FileWriterTask.h
+++ b/src/FileWriterTask.h
@@ -38,7 +38,9 @@ public:
   /// \param TaskID The service ID.
   /// \param StatusProducer_ The status producer.
   FileWriterTask(std::string TaskID,
-                 std::shared_ptr<KafkaW::ProducerTopic> StatusProducerPtr);
+                 std::shared_ptr<KafkaW::ProducerTopic> StatusProducerPtr)
+      : ServiceId(std::move(TaskID)),
+        StatusProducer(std::move(StatusProducerPtr)), Logger(getLogger()){};
 
   /// Destructor.
   ~FileWriterTask();
@@ -74,13 +76,6 @@ public:
   /// \return The demux topics.
   std::vector<DemuxTopic> &demuxers();
 
-  /// \brief  Get the unique numeric identifier of this job.
-  ///
-  /// Could maybe be replaced by `JobID`.
-  ///
-  /// \return The unique identifier.
-  uint64_t id() const;
-
   /// \brief  Get the job ID of the file being written.
   ///
   /// \return The job ID.
@@ -111,7 +106,6 @@ private:
   std::vector<DemuxTopic> Demuxers;
   void closeFile();
   void reopenFile();
-  uint64_t Id;
   std::string JobId;
   std::string ServiceId;
   std::shared_ptr<KafkaW::ProducerTopic> StatusProducer;

--- a/src/StreamMaster.cpp
+++ b/src/StreamMaster.cpp
@@ -19,7 +19,6 @@ std::unique_ptr<StreamMaster> StreamMaster::createStreamMaster(
                       std::forward_as_tuple(Broker, Demux.topic(),
                                             Options.StreamerConfiguration,
                                             std::move(Consumer)));
-      Streams[Demux.topic()].setSources(Demux.sources());
     } catch (std::exception &E) {
       getLogger()->critical("{}", E.what());
       logEvent(Producer, StatusCode::Error, Options.ServiceID,

--- a/src/Streamer.h
+++ b/src/Streamer.h
@@ -62,19 +62,6 @@ public:
   /// \return The current status.
   StreamerStatus close();
 
-  /// \brief Sets the sources.
-  ///
-  /// \param SourceList The new source list.
-  void setSources(
-      std::unordered_map<FlatbufferMessage::SrcHash, Source> &SourceList);
-
-  /// \brief Removes the source from the sources list.
-  ///
-  /// \param SourceName The name of the source to be removed.
-  ///
-  /// \return True if success, else false (e.g. the source is not in the list).
-  bool removeSource(FlatbufferMessage::SrcHash Hash);
-
   /// \brief Returns the status of the Streamer.
   ///
   /// See "Error.h".
@@ -97,7 +84,6 @@ protected:
   std::atomic<StreamerStatus> RunStatus{StreamerStatus::NOT_INITIALIZED};
   Status::MessageInfo MessageInfo;
 
-  std::map<FlatbufferMessage::SrcHash, std::string> Sources;
   StreamerOptions Options;
 
   std::future<std::pair<Status::StreamerStatus, ConsumerPtr>>

--- a/src/Streamer.h
+++ b/src/Streamer.h
@@ -93,7 +93,6 @@ public:
 
 protected:
   ConsumerPtr Consumer{nullptr};
-  KafkaW::BrokerSettings Settings;
 
   std::atomic<StreamerStatus> RunStatus{StreamerStatus::NOT_INITIALIZED};
   Status::MessageInfo MessageInfo;

--- a/src/tests/DemuxerTests.cpp
+++ b/src/tests/DemuxerTests.cpp
@@ -165,3 +165,36 @@ TEST_F(DemuxerTest, WrongSourceName) {
   EXPECT_TRUE(TestDemuxer.error_no_flatbuffer_reader.load() == size_t(0));
   EXPECT_TRUE(TestDemuxer.error_no_source_instance.load() == size_t(1));
 }
+
+TEST_F(DemuxerTest, RemovingExistingSourceIsSuccessful) {
+  std::string TestKey("temp");
+  std::string SourceName("SourceName");
+  {
+    FlatbufferReaderRegistry::Registrar<DemuxerDummyReader2> RegisterIt(
+        TestKey);
+  }
+  DemuxTopic TestDemuxer("SomeTopicName");
+  auto Writer = ::std::make_unique<StubWriterModule>();
+  Source DummySource(SourceName, TestKey, std::move(Writer));
+  auto DummySourceHash = DummySource.getHash();
+
+  TestDemuxer.add_source(std::move(DummySource));
+  EXPECT_TRUE(TestDemuxer.removeSource(DummySourceHash));
+}
+
+TEST_F(DemuxerTest, RemovingNonExistingSourceIsUnSuccessful) {
+  std::string TestKey("temp");
+  std::string SourceName("SourceName");
+  {
+    FlatbufferReaderRegistry::Registrar<DemuxerDummyReader2> RegisterIt(
+        TestKey);
+  }
+  DemuxTopic TestDemuxer("SomeTopicName");
+  auto Writer = ::std::make_unique<StubWriterModule>();
+  Source DummySource(SourceName, TestKey, std::move(Writer));
+  auto DummySourceHash = DummySource.getHash();
+
+  EXPECT_FALSE(TestDemuxer.removeSource(DummySourceHash))
+      << "Source was never added so we expect false to be returned when we try "
+         "to remove it";
+}

--- a/src/tests/StreamerTests.cpp
+++ b/src/tests/StreamerTests.cpp
@@ -315,12 +315,7 @@ TEST_F(StreamerProcessTimingTest,
   ALLOW_CALL(*dynamic_cast<WriterModuleStandIn *>(Writer.get()), close())
       .RETURN(0);
   FileWriter::Source TestSource(SourceName, ReaderKey, std::move(Writer));
-  std::unordered_map<FlatbufferMessage::SrcHash, Source> SourceList;
-  std::pair<FlatbufferMessage::SrcHash, Source> TempPair{TestSource.getHash(),
-                                                         std::move(TestSource)};
-  SourceList.insert(std::move(TempPair));
 
-  TestStreamer->setSources(SourceList);
   ConsumerEmptyStandIn *EmptyPollerConsumer =
       new ConsumerEmptyStandIn(BrokerSettings);
   REQUIRE_CALL(*EmptyPollerConsumer, poll())
@@ -334,6 +329,7 @@ TEST_F(StreamerProcessTimingTest,
             Status::StreamerStatus::OK, EmptyPollerConsumer};
       });
   DemuxTopic Demuxer("SomeTopicName");
+  Demuxer.add_source(std::move(TestSource));
   EXPECT_EQ(TestStreamer->pollAndProcess(Demuxer), ProcessMessageResult::ERR);
 }
 
@@ -347,11 +343,6 @@ TEST_F(StreamerProcessTimingTest, MessageBeforeStartTimestamp) {
   ALLOW_CALL(*dynamic_cast<WriterModuleStandIn *>(Writer.get()), close())
       .RETURN(0);
   FileWriter::Source TestSource(SourceName, ReaderKey, std::move(Writer));
-  std::unordered_map<FlatbufferMessage::SrcHash, Source> SourceList;
-  std::pair<FlatbufferMessage::SrcHash, Source> TempPair{TestSource.getHash(),
-                                                         std::move(TestSource)};
-  SourceList.insert(std::move(TempPair));
-  TestStreamer->setSources(SourceList);
   ConsumerEmptyStandIn *EmptyPollerConsumer =
       new ConsumerEmptyStandIn(BrokerSettings);
   REQUIRE_CALL(*EmptyPollerConsumer, poll())
@@ -365,6 +356,7 @@ TEST_F(StreamerProcessTimingTest, MessageBeforeStartTimestamp) {
             Status::StreamerStatus::OK, EmptyPollerConsumer};
       });
   DemuxTopic Demuxer("SomeTopicName");
+  Demuxer.add_source(std::move(TestSource));
   EXPECT_EQ(TestStreamer->pollAndProcess(Demuxer), ProcessMessageResult::OK);
 }
 
@@ -394,11 +386,6 @@ TEST_F(StreamerProcessTimingTest, MessageAfterStopTimestamp) {
   ALLOW_CALL(*dynamic_cast<WriterModuleStandIn *>(Writer.get()), close())
       .RETURN(0);
   FileWriter::Source TestSource(SourceName, ReaderKey, std::move(Writer));
-  std::unordered_map<FlatbufferMessage::SrcHash, Source> SourceList;
-  std::pair<FlatbufferMessage::SrcHash, Source> TempPair{TestSource.getHash(),
-                                                         std::move(TestSource)};
-  SourceList.insert(std::move(TempPair));
-  TestStreamer->setSources(SourceList);
   ConsumerEmptyStandIn *EmptyPollerConsumer =
       new ConsumerEmptyStandIn(BrokerSettings);
   REQUIRE_CALL(*EmptyPollerConsumer, poll())
@@ -412,6 +399,7 @@ TEST_F(StreamerProcessTimingTest, MessageAfterStopTimestamp) {
             Status::StreamerStatus::OK, EmptyPollerConsumer};
       });
   DemuxTopic Demuxer("SomeTopicName");
+  Demuxer.add_source(std::move(TestSource));
   EXPECT_EQ(TestStreamer->pollAndProcess(Demuxer), ProcessMessageResult::STOP);
 }
 
@@ -432,11 +420,6 @@ TEST_F(StreamerProcessTimingTest, MessageTimeout) {
   ALLOW_CALL(*dynamic_cast<WriterModuleStandIn *>(Writer.get()), close())
       .RETURN(0);
   FileWriter::Source TestSource(SourceName, ReaderKey, std::move(Writer));
-  std::unordered_map<FlatbufferMessage::SrcHash, Source> SourceList;
-  std::pair<FlatbufferMessage::SrcHash, Source> TempPair{TestSource.getHash(),
-                                                         std::move(TestSource)};
-  SourceList.insert(std::move(TempPair));
-  TestStreamer->setSources(SourceList);
   ConsumerEmptyStandIn *EmptyPollerConsumer =
       new ConsumerEmptyStandIn(BrokerSettings);
   int CallCounter{0};
@@ -457,6 +440,7 @@ TEST_F(StreamerProcessTimingTest, MessageTimeout) {
             Status::StreamerStatus::OK, EmptyPollerConsumer};
       });
   DemuxerStandIn Demuxer("SomeTopicName");
+  Demuxer.add_source(std::move(TestSource));
   REQUIRE_CALL(Demuxer, process_message(_))
       .RETURN(ProcessMessageResult::OK)
       .TIMES(1);
@@ -476,11 +460,6 @@ TEST_F(StreamerProcessTimingTest, EmptyMessageAfterStop) {
   ALLOW_CALL(*dynamic_cast<WriterModuleStandIn *>(Writer.get()), close())
       .RETURN(0);
   FileWriter::Source TestSource(SourceName, ReaderKey, std::move(Writer));
-  std::unordered_map<FlatbufferMessage::SrcHash, Source> SourceList;
-  std::pair<FlatbufferMessage::SrcHash, Source> TempPair{TestSource.getHash(),
-                                                         std::move(TestSource)};
-  SourceList.insert(std::move(TempPair));
-  TestStreamer->setSources(SourceList);
   ConsumerEmptyStandIn *EmptyPollerConsumer =
       new ConsumerEmptyStandIn(BrokerSettings);
   REQUIRE_CALL(*EmptyPollerConsumer, poll())
@@ -493,6 +472,7 @@ TEST_F(StreamerProcessTimingTest, EmptyMessageAfterStop) {
             Status::StreamerStatus::OK, EmptyPollerConsumer};
       });
   DemuxerStandIn Demuxer("SomeTopicName");
+  Demuxer.add_source(std::move(TestSource));
   REQUIRE_CALL(Demuxer, process_message(_)).TIMES(0);
   EXPECT_EQ(TestStreamer->pollAndProcess(Demuxer), ProcessMessageResult::STOP);
 }
@@ -511,11 +491,6 @@ TEST_F(StreamerProcessTimingTest, EmptyMessageBeforeStop) {
   ALLOW_CALL(*dynamic_cast<WriterModuleStandIn *>(Writer.get()), close())
       .RETURN(0);
   FileWriter::Source TestSource(SourceName, ReaderKey, std::move(Writer));
-  std::unordered_map<FlatbufferMessage::SrcHash, Source> SourceList;
-  std::pair<FlatbufferMessage::SrcHash, Source> TempPair{TestSource.getHash(),
-                                                         std::move(TestSource)};
-  SourceList.insert(std::move(TempPair));
-  TestStreamer->setSources(SourceList);
   ConsumerEmptyStandIn *EmptyPollerConsumer =
       new ConsumerEmptyStandIn(BrokerSettings);
   REQUIRE_CALL(*EmptyPollerConsumer, poll())
@@ -528,6 +503,7 @@ TEST_F(StreamerProcessTimingTest, EmptyMessageBeforeStop) {
             Status::StreamerStatus::OK, EmptyPollerConsumer};
       });
   DemuxerStandIn Demuxer("SomeTopicName");
+  Demuxer.add_source(std::move(TestSource));
   REQUIRE_CALL(Demuxer, process_message(_)).TIMES(0);
   EXPECT_EQ(TestStreamer->pollAndProcess(Demuxer), ProcessMessageResult::OK);
 }
@@ -564,11 +540,6 @@ TEST_F(StreamerProcessTimingTest, EmptyMessageSlightlyAfterStop) {
   ALLOW_CALL(*dynamic_cast<WriterModuleStandIn *>(Writer.get()), close())
       .RETURN(0);
   FileWriter::Source TestSource(SourceName, ReaderKey, std::move(Writer));
-  std::unordered_map<FlatbufferMessage::SrcHash, Source> SourceList;
-  std::pair<FlatbufferMessage::SrcHash, Source> TempPair{TestSource.getHash(),
-                                                         std::move(TestSource)};
-  SourceList.insert(std::move(TempPair));
-  TestStreamer->setSources(SourceList);
 
   BrokerSettings.OffsetsForTimesTimeoutMS = 10;
   BrokerSettings.MetadataTimeoutMS = 10;
@@ -584,27 +555,7 @@ TEST_F(StreamerProcessTimingTest, EmptyMessageSlightlyAfterStop) {
             Status::StreamerStatus::OK, EmptyPollerConsumer};
       });
   DemuxerStandIn Demuxer("SomeTopicName");
+  Demuxer.add_source(std::move(TestSource));
   REQUIRE_CALL(Demuxer, process_message(_)).TIMES(0);
   EXPECT_EQ(TestStreamer->pollAndProcess(Demuxer), ProcessMessageResult::OK);
-}
-
-TEST_F(StreamerProcessTest, RemoveSource) {
-  StreamerStandIn TestStreamer(Options);
-  std::string SourceName = "TestName";
-  std::string ReaderKey = "temp";
-  HDFWriterModule::ptr Writer(new WriterModuleStandIn());
-  ALLOW_CALL(*dynamic_cast<WriterModuleStandIn *>(Writer.get()), flush())
-      .RETURN(0);
-  ALLOW_CALL(*dynamic_cast<WriterModuleStandIn *>(Writer.get()), close())
-      .RETURN(0);
-  FileWriter::Source TestSource(SourceName, ReaderKey, std::move(Writer));
-  auto UsedHash = TestSource.getHash();
-  std::unordered_map<FlatbufferMessage::SrcHash, Source> SourceList;
-  std::pair<FlatbufferMessage::SrcHash, Source> TempPair{TestSource.getHash(),
-                                                         std::move(TestSource)};
-  SourceList.insert(std::move(TempPair));
-
-  TestStreamer.setSources(SourceList);
-  EXPECT_TRUE(TestStreamer.removeSource(UsedHash));
-  EXPECT_FALSE(TestStreamer.removeSource(UsedHash));
 }


### PR DESCRIPTION
### Issue

Helps with DM-1616

### Description of work

For each topic there is a single `DemuxTopic` and `Streamer`. For some reason the `Streamer` doesn't own the `DemuxTopic` but it is given a reference to it every time `Streamer::pollAndProcess()` is called. The Streamer maintained its own map of sources for the sole purpose of checking that each incoming message matches one of its sources, but the `DemuxTopic` already has this information....

I think there would be further deduplification if each `Streamer` had, at least shared, ownership of the corresponding `DemuxTopic`. It would also make the relationship between them clearer. I'll likely make a PR for that soon.

### Nominate for Group Code Review

- [ ] Nominate for code review 

