### PR TITLE
Make command parser methods into free functions

### DIFF
--- a/documentation/commands.md
+++ b/documentation/commands.md
@@ -11,19 +11,24 @@ Note: some example commands can be found in the system tests.
 ## Command to start writing
 
 The start command consists of a number of parameters which are defined as key-value pairs in the JSON.
-These are:
 
-- cmd: The command name, must be `FileWriter_new`.
-- job_id: A unique identifier for the request, a UUID for example.
+Required:
+
+- cmd: The command name, must be `filewriter_new`
+- job_id: A unique identifier for the request, a UUID for example
 - broker: The Kafka broker to use for data.
-- start_time: The start time in milliseconds (UNIX epoch) for data to be written from. Optional, if not supplied then the timestamp of the Kafka message containing the start command is used.
-- stop_time: The stop time in milliseconds (UNIX epoch) for data writing to stop. Optional, if not supplied then file writing continues until a stop command is received
-- service_id: The identifier for the instance of the file-writer that should handle this command. Optional, only needed if multiple file-writers present.
-- abort_on_uninitialised_stream: Whether to abort if the stream cannot be initialised. Optional, default is not to abort but carry on.
-- use_hdf_swmr: Whether to use HDF5's Single Writer Multiple Reader (SWMR) capabilities. Optional, default is true. For more on SWMR see [below](Single Writer Multiple Reader).
 - file_attributes: Dictionary specifying the details of the file to be written:
     * file_name: The file name
-- nexus_structure: Defines the structure of the NeXus file to be written.
+- nexus_structure: Defines the structure of the NeXus file to be written
+
+Optional:
+
+- start_time: The start time in milliseconds (UNIX epoch) for data to be written from. If not supplied then the timestamp of the Kafka message containing the start command is used.
+- stop_time: The stop time in milliseconds (UNIX epoch) for data writing to stop. If not supplied then file writing continues until a stop command is received
+- service_id: The identifier for the instance of the file-writer that should handle this command. Only needed if multiple file-writers present.
+- abort_on_uninitialised_stream: Whether to abort if the stream cannot be initialised. Default is not to abort but carry on.
+- use_hdf_swmr: Whether to use HDF5's Single Writer Multiple Reader (SWMR) capabilities. Default is true. For more on SWMR see [below](Single Writer Multiple Reader).
+
 
 An example command with the `nexus_structure` skipped for brevity:
 
@@ -189,12 +194,16 @@ For example:
 ## Command to stop writing
 
 The stop command consists of a number of parameters which are defined as key-value pairs in the JSON.
-These are:
 
-- cmd: The command name, must be `FileWriter_stop`.
-- job_id: A unique identifier for the request, a UUID for example. Should be the same as used in the start command.
-- stop_time: The stop time in milliseconds (UNIX epoch) for data writing to stop. Optional, if not supplied then the Kafka message time is used.
-- service_id: The identifier for the instance of the file-writer that should handle this command. Optional, only needed if multiple file-writers present.
+Required:
+
+- cmd: The command name, must be `filewriter_stop`
+- job_id: A unique identifier for the request, a UUID for example. Should be the same as used in the start command
+
+Optional:
+
+- stop_time: The stop time in milliseconds (UNIX epoch) for data writing to stop. If not supplied then the Kafka message time is used
+- service_id: The identifier for the instance of the file-writer that should handle this command. Only needed if multiple file-writers present
 
 For example:
 
@@ -212,8 +221,8 @@ For example:
 The file-writer can be requested to exit.
 The parameters for the command are:
 
-- cmd: The command name, must be `FileWriter_stop`.
-- service_id: The identifier for the instance of the file-writer that should handle this command. Optional, only needed if multiple file-writers present.
+- cmd: The command name, must be `filewriter_exit`
+- service_id: The identifier for the instance of the file-writer that should handle this command. Optional, only needed if multiple file-writers present
 
 For example:
 

--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -179,8 +179,7 @@ extractStreamInformationFromJson(std::unique_ptr<FileWriterTask> const &Task,
 
 void CommandHandler::handleNew(const json &JSONCommand,
                                std::chrono::milliseconds StartTime) {
-  CommandParser Parser;
-  auto StartInfo = Parser.extractStartInformation(JSONCommand, StartTime);
+  auto StartInfo = CommandParser::extractStartInformation(JSONCommand, StartTime);
 
   // Check job is not already running
   if (MasterPtr != nullptr) {

--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -327,9 +327,8 @@ void CommandHandler::handleExit() {
 
 void CommandHandler::handleStreamMasterStop(const json &Command) {
   Logger->trace("{}", Command.dump());
-  CommandParser Parser;
 
-  auto StopInfo = Parser.extractStopInformation(Command);
+  auto StopInfo = CommandParser::extractStopInformation(Command);
 
   if (MasterPtr != nullptr) {
     auto &StreamMaster = MasterPtr->getStreamMasterForJobID(StopInfo.JobID);

--- a/src/CommandHandler.cpp
+++ b/src/CommandHandler.cpp
@@ -179,7 +179,8 @@ extractStreamInformationFromJson(std::unique_ptr<FileWriterTask> const &Task,
 
 void CommandHandler::handleNew(const json &JSONCommand,
                                std::chrono::milliseconds StartTime) {
-  auto StartInfo = CommandParser::extractStartInformation(JSONCommand, StartTime);
+  auto StartInfo =
+      CommandParser::extractStartInformation(JSONCommand, StartTime);
 
   // Check job is not already running
   if (MasterPtr != nullptr) {

--- a/src/CommandParser.cpp
+++ b/src/CommandParser.cpp
@@ -15,9 +15,9 @@
 namespace FileWriter {
 namespace CommandParser {
 
-StartCommandInfo extractStartInformation(
-    const nlohmann::json &JSONCommand,
-    std::chrono::milliseconds DefaultStartTime) {
+StartCommandInfo
+extractStartInformation(const nlohmann::json &JSONCommand,
+                        std::chrono::milliseconds DefaultStartTime) {
   if (extractCommandName(JSONCommand) != StartCommand) {
     throw std::runtime_error("Command was not a start command");
   }
@@ -46,8 +46,7 @@ StartCommandInfo extractStartInformation(
   return Result;
 }
 
-StopCommandInfo
-extractStopInformation(const nlohmann::json &JSONCommand) {
+StopCommandInfo extractStopInformation(const nlohmann::json &JSONCommand) {
   if (extractCommandName(JSONCommand) != StopCommand) {
     throw std::runtime_error("Command was not a stop command");
   }
@@ -67,15 +66,13 @@ extractStopInformation(const nlohmann::json &JSONCommand) {
 }
 
 uri::URI extractBroker(nlohmann::json const &JSONCommand) {
-  std::string Broker =
-      getRequiredValue<std::string>("broker", JSONCommand);
+  std::string Broker = getRequiredValue<std::string>("broker", JSONCommand);
   try {
     uri::URI BrokerInfo{Broker};
     return BrokerInfo;
   } catch (std::runtime_error &e) {
     throw std::runtime_error(
-        fmt::format("Unable to parse broker {} in command message",
-                    Broker));
+        fmt::format("Unable to parse broker {} in command message", Broker));
   }
 }
 
@@ -88,9 +85,8 @@ std::string extractJobID(nlohmann::json const &JSONCommand) {
 }
 
 std::chrono::milliseconds
-extractTime(std::string const &Key,
-                           nlohmann::json const &JSONCommand,
-                           std::chrono::milliseconds const &DefaultTime) {
+extractTime(std::string const &Key, nlohmann::json const &JSONCommand,
+            std::chrono::milliseconds const &DefaultTime) {
   uint64_t RawTime = getOptionalValue(Key, JSONCommand, 0);
   if (RawTime > 0) {
     return std::chrono::milliseconds{RawTime};
@@ -99,8 +95,7 @@ extractTime(std::string const &Key,
   }
 }
 
-std::string
-extractCommandName(const nlohmann::json &JSONCommand) {
+std::string extractCommandName(const nlohmann::json &JSONCommand) {
   auto Cmd = getRequiredValue<std::string>("cmd", JSONCommand);
   std::transform(Cmd.begin(), Cmd.end(), Cmd.begin(), ::tolower);
   return Cmd;

--- a/src/CommandParser.h
+++ b/src/CommandParser.h
@@ -16,6 +16,7 @@
 #include "URI.h"
 #include "json.h"
 #include "logger.h"
+#include "helper.h"
 #include <chrono>
 
 namespace FileWriter {
@@ -38,8 +39,12 @@ struct StopCommandInfo {
   std::string ServiceID;
 };
 
-class CommandParser {
-public:
+namespace CommandParser {
+  static std::string const StartCommand = "filewriter_new";
+  static std::string const StopCommand = "filewriter_stop";
+  static std::string const ExitCommand = "filewriter_exit";
+  static std::string const StopAllWritingCommand = "file_writer_tasks_clear_all";
+
   /// \brief Extract the information from the start command.
   ///
   /// \param JSONCommand The JSON Command.
@@ -47,13 +52,13 @@ public:
   /// \return The start information.
   StartCommandInfo extractStartInformation(
       const nlohmann::json &JSONCommand,
-      std::chrono::milliseconds DefaultStartTime = getCurrentTime());
+      std::chrono::milliseconds DefaultStartTime = getCurrentTimeStampMS());
 
   /// \brief Extract the information from the stop command.
   ///
   /// \param JSONCommand The JSON Command.
   /// \return The stop information.
-  static StopCommandInfo
+  StopCommandInfo
   extractStopInformation(const nlohmann::json &JSONCommand);
 
   /// \brief Extract the command name from the command.
@@ -62,25 +67,39 @@ public:
   ///
   /// \param JSONCommand The JSON Command.
   /// \return The command name.
-  static std::string extractCommandName(const nlohmann::json &JSONCommand);
+  std::string extractCommandName(const nlohmann::json &JSONCommand);
 
-  static std::string const StopCommand;
-  static std::string const StartCommand;
-  static std::string const ExitCommand;
-  static std::string const StopAllWritingCommand;
-
-private:
-  SharedLogger Logger = getLogger();
-
+  /// \brief Extract the broker from the command.
+  ///
+  /// \param JSONCommand The JSON Command.
+  /// \return The broker details.
   uri::URI extractBroker(nlohmann::json const &JSONCommand);
-  static std::string extractJobID(nlohmann::json const &JSONCommand);
-  static std::chrono::duration<long long int, std::milli> getCurrentTime();
-  static std::chrono::milliseconds
+
+  /// \brief Extract the job ID from the command.
+  ///
+  /// \param JSONCommand The JSON Command.
+  /// \return The job ID.
+  std::string extractJobID(nlohmann::json const &JSONCommand);
+
+  /// \brief Extract a value as a time-stamp.
+  ///
+  /// \param Key The key for the value to extract.
+  /// \param JSONCommand The JSON Command.
+  /// \param DefaultTime The time to use if the key does not exist.
+  /// \return The extract (or default) time.
+  std::chrono::milliseconds
   extractTime(std::string const &Key, nlohmann::json const &JSONCommand,
               std::chrono::milliseconds const &DefaultTime);
 
+  /// \brief Extract the specified value.
+  ///
+  /// Throws if the key is not present
+  ///
+  /// \param Key The key for the value to extract.
+  /// \param JSONCommand The JSON Command.
+  /// \return The extracted value.
   template <typename T>
-  static T getRequiredValue(std::string const &Key,
+  T getRequiredValue(std::string const &Key,
                             nlohmann::json const &JSONCommand) {
     if (auto x = find<T>(Key, JSONCommand)) {
       return x.inner();
@@ -90,8 +109,15 @@ private:
         fmt::format("Missing key {} from command JSON", Key));
   }
 
+  /// \brief Extract the specified value or use supplied value.
+  ///
+  ///
+  /// \param Key The key for the value to extract.
+  /// \param JSONCommand The JSON Command.
+  /// \param Default The value to use if the key is not present.
+  /// \return The extracted (or default) value.
   template <typename T>
-  static T getOptionalValue(std::string const &Key,
+  T getOptionalValue(std::string const &Key,
                             nlohmann::json const &JSONCommand,
                             T const &Default) {
     if (auto x = find<T>(Key, JSONCommand)) {
@@ -100,5 +126,5 @@ private:
 
     return Default;
   }
-};
+}
 } // namespace FileWriter

--- a/src/CommandParser.h
+++ b/src/CommandParser.h
@@ -14,9 +14,9 @@
 #pragma once
 
 #include "URI.h"
+#include "helper.h"
 #include "json.h"
 #include "logger.h"
-#include "helper.h"
 #include <chrono>
 
 namespace FileWriter {
@@ -40,91 +40,88 @@ struct StopCommandInfo {
 };
 
 namespace CommandParser {
-  static std::string const StartCommand = "filewriter_new";
-  static std::string const StopCommand = "filewriter_stop";
-  static std::string const ExitCommand = "filewriter_exit";
-  static std::string const StopAllWritingCommand = "file_writer_tasks_clear_all";
+static std::string const StartCommand = "filewriter_new";
+static std::string const StopCommand = "filewriter_stop";
+static std::string const ExitCommand = "filewriter_exit";
+static std::string const StopAllWritingCommand = "file_writer_tasks_clear_all";
 
-  /// \brief Extract the information from the start command.
-  ///
-  /// \param JSONCommand The JSON Command.
-  /// \param DefaultStartTime The start time to use if not supplied in the JSON
-  /// \return The start information.
-  StartCommandInfo extractStartInformation(
-      const nlohmann::json &JSONCommand,
-      std::chrono::milliseconds DefaultStartTime = getCurrentTimeStampMS());
+/// \brief Extract the information from the start command.
+///
+/// \param JSONCommand The JSON Command.
+/// \param DefaultStartTime The start time to use if not supplied in the JSON
+/// \return The start information.
+StartCommandInfo extractStartInformation(
+    const nlohmann::json &JSONCommand,
+    std::chrono::milliseconds DefaultStartTime = getCurrentTimeStampMS());
 
-  /// \brief Extract the information from the stop command.
-  ///
-  /// \param JSONCommand The JSON Command.
-  /// \return The stop information.
-  StopCommandInfo
-  extractStopInformation(const nlohmann::json &JSONCommand);
+/// \brief Extract the information from the stop command.
+///
+/// \param JSONCommand The JSON Command.
+/// \return The stop information.
+StopCommandInfo extractStopInformation(const nlohmann::json &JSONCommand);
 
-  /// \brief Extract the command name from the command.
-  ///
-  /// Note: the command is converted to lower-case.
-  ///
-  /// \param JSONCommand The JSON Command.
-  /// \return The command name.
-  std::string extractCommandName(const nlohmann::json &JSONCommand);
+/// \brief Extract the command name from the command.
+///
+/// Note: the command is converted to lower-case.
+///
+/// \param JSONCommand The JSON Command.
+/// \return The command name.
+std::string extractCommandName(const nlohmann::json &JSONCommand);
 
-  /// \brief Extract the broker from the command.
-  ///
-  /// \param JSONCommand The JSON Command.
-  /// \return The broker details.
-  uri::URI extractBroker(nlohmann::json const &JSONCommand);
+/// \brief Extract the broker from the command.
+///
+/// \param JSONCommand The JSON Command.
+/// \return The broker details.
+uri::URI extractBroker(nlohmann::json const &JSONCommand);
 
-  /// \brief Extract the job ID from the command.
-  ///
-  /// \param JSONCommand The JSON Command.
-  /// \return The job ID.
-  std::string extractJobID(nlohmann::json const &JSONCommand);
+/// \brief Extract the job ID from the command.
+///
+/// \param JSONCommand The JSON Command.
+/// \return The job ID.
+std::string extractJobID(nlohmann::json const &JSONCommand);
 
-  /// \brief Extract a value as a time-stamp.
-  ///
-  /// \param Key The key for the value to extract.
-  /// \param JSONCommand The JSON Command.
-  /// \param DefaultTime The time to use if the key does not exist.
-  /// \return The extract (or default) time.
-  std::chrono::milliseconds
-  extractTime(std::string const &Key, nlohmann::json const &JSONCommand,
-              std::chrono::milliseconds const &DefaultTime);
+/// \brief Extract a value as a time-stamp.
+///
+/// \param Key The key for the value to extract.
+/// \param JSONCommand The JSON Command.
+/// \param DefaultTime The time to use if the key does not exist.
+/// \return The extract (or default) time.
+std::chrono::milliseconds
+extractTime(std::string const &Key, nlohmann::json const &JSONCommand,
+            std::chrono::milliseconds const &DefaultTime);
 
-  /// \brief Extract the specified value.
-  ///
-  /// Throws if the key is not present
-  ///
-  /// \param Key The key for the value to extract.
-  /// \param JSONCommand The JSON Command.
-  /// \return The extracted value.
-  template <typename T>
-  T getRequiredValue(std::string const &Key,
-                            nlohmann::json const &JSONCommand) {
-    if (auto x = find<T>(Key, JSONCommand)) {
-      return x.inner();
-    }
-
-    throw std::runtime_error(
-        fmt::format("Missing key {} from command JSON", Key));
+/// \brief Extract the specified value.
+///
+/// Throws if the key is not present
+///
+/// \param Key The key for the value to extract.
+/// \param JSONCommand The JSON Command.
+/// \return The extracted value.
+template <typename T>
+T getRequiredValue(std::string const &Key, nlohmann::json const &JSONCommand) {
+  if (auto x = find<T>(Key, JSONCommand)) {
+    return x.inner();
   }
 
-  /// \brief Extract the specified value or use supplied value.
-  ///
-  ///
-  /// \param Key The key for the value to extract.
-  /// \param JSONCommand The JSON Command.
-  /// \param Default The value to use if the key is not present.
-  /// \return The extracted (or default) value.
-  template <typename T>
-  T getOptionalValue(std::string const &Key,
-                            nlohmann::json const &JSONCommand,
-                            T const &Default) {
-    if (auto x = find<T>(Key, JSONCommand)) {
-      return x.inner();
-    }
+  throw std::runtime_error(
+      fmt::format("Missing key {} from command JSON", Key));
+}
 
-    return Default;
+/// \brief Extract the specified value or use supplied value.
+///
+///
+/// \param Key The key for the value to extract.
+/// \param JSONCommand The JSON Command.
+/// \param Default The value to use if the key is not present.
+/// \return The extracted (or default) value.
+template <typename T>
+T getOptionalValue(std::string const &Key, nlohmann::json const &JSONCommand,
+                   T const &Default) {
+  if (auto x = find<T>(Key, JSONCommand)) {
+    return x.inner();
   }
+
+  return Default;
+}
 }
 } // namespace FileWriter

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -48,4 +48,3 @@ std::chrono::duration<long long int, std::milli> getCurrentTimeStampMS() {
   return std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::system_clock::now().time_since_epoch());
 }
-

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -43,3 +43,9 @@ std::vector<char> readFileIntoVector(std::string const &FileName) {
   ifs.read(ret.data(), n1);
   return ret;
 }
+
+std::chrono::duration<long long int, std::milli> getCurrentTimeStampMS() {
+  return std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::system_clock::now().time_since_epoch());
+}
+

--- a/src/helper.h
+++ b/src/helper.h
@@ -9,9 +9,9 @@
 
 #pragma once
 
+#include <chrono>
 #include <string>
 #include <vector>
-#include <chrono>
 
 int getpid_wrapper();
 

--- a/src/helper.h
+++ b/src/helper.h
@@ -11,6 +11,7 @@
 
 #include <string>
 #include <vector>
+#include <chrono>
 
 int getpid_wrapper();
 

--- a/src/helper.h
+++ b/src/helper.h
@@ -17,3 +17,5 @@ int getpid_wrapper();
 std::string gethostname_wrapper();
 
 std::vector<char> readFileIntoVector(std::string const &FileName);
+
+std::chrono::duration<long long int, std::milli> getCurrentTimeStampMS();

--- a/src/tests/CommandParserTests.cpp
+++ b/src/tests/CommandParserTests.cpp
@@ -31,8 +31,8 @@ public:
 })"""};
 
   void SetUp() override {
-    StartInfo =
-        FileWriter::CommandParser::extractStartInformation(nlohmann::json::parse(Good_Command));
+    StartInfo = FileWriter::CommandParser::extractStartInformation(
+        nlohmann::json::parse(Good_Command));
   }
 };
 
@@ -87,7 +87,8 @@ TEST(CommandParserSadStartTests, ThrowsIfNoJobID) {
   "nexus_structure": { }
 })""");
 
-  ASSERT_THROW(FileWriter::CommandParser::extractStartInformation(nlohmann::json::parse(Command)),
+  ASSERT_THROW(FileWriter::CommandParser::extractStartInformation(
+                   nlohmann::json::parse(Command)),
                std::runtime_error);
 }
 
@@ -100,7 +101,8 @@ TEST(CommandParserSadStartTests, ThrowsIfNoFileAttributes) {
   "nexus_structure": { }
 })""");
 
-  ASSERT_THROW(FileWriter::CommandParser::extractStartInformation(nlohmann::json::parse(Command)),
+  ASSERT_THROW(FileWriter::CommandParser::extractStartInformation(
+                   nlohmann::json::parse(Command)),
                std::runtime_error);
 }
 
@@ -115,7 +117,8 @@ TEST(CommandParserSadStartTests, ThrowsIfNoFilename) {
   "nexus_structure": { }
 })""");
 
-  ASSERT_THROW(FileWriter::CommandParser::extractStartInformation(nlohmann::json::parse(Command)),
+  ASSERT_THROW(FileWriter::CommandParser::extractStartInformation(
+                   nlohmann::json::parse(Command)),
                std::runtime_error);
 }
 
@@ -130,7 +133,8 @@ TEST(CommandParserSadStartTests, ThrowsIfNoNexusStructure) {
   }
 })""");
 
-  ASSERT_THROW(FileWriter::CommandParser::extractStartInformation(nlohmann::json::parse(Command)),
+  ASSERT_THROW(FileWriter::CommandParser::extractStartInformation(
+                   nlohmann::json::parse(Command)),
                std::runtime_error);
 }
 
@@ -142,7 +146,8 @@ TEST(CommandParserSadStartTests, IfStopCommandPassedToStartMethodThenThrows) {
   "service_id": "filewriter1"
 })""");
 
-  ASSERT_THROW(FileWriter::CommandParser::extractStartInformation(nlohmann::json::parse(Command)),
+  ASSERT_THROW(FileWriter::CommandParser::extractStartInformation(
+                   nlohmann::json::parse(Command)),
                std::runtime_error);
 }
 
@@ -157,7 +162,8 @@ TEST(CommandParserSadStartTests, IfNoBrokerThenThrows) {
   "nexus_structure": { }
 })""");
 
-  ASSERT_THROW(FileWriter::CommandParser::extractStartInformation(nlohmann::json::parse(Command)),
+  ASSERT_THROW(FileWriter::CommandParser::extractStartInformation(
+                   nlohmann::json::parse(Command)),
                std::runtime_error);
 }
 
@@ -173,7 +179,8 @@ TEST(CommandParserSadStartTests, IfBrokerIsWrongFormThenThrows) {
   "nexus_structure": { }
 })""");
 
-  ASSERT_THROW(FileWriter::CommandParser::extractStartInformation(nlohmann::json::parse(Command)),
+  ASSERT_THROW(FileWriter::CommandParser::extractStartInformation(
+                   nlohmann::json::parse(Command)),
                std::runtime_error);
 }
 
@@ -209,8 +216,8 @@ TEST(CommandParserStartTests, IfNoStopTimeThenSetToZero) {
   "nexus_structure": { }
 })""");
 
-  auto StartInfo =
-      FileWriter::CommandParser::extractStartInformation(nlohmann::json::parse(Command));
+  auto StartInfo = FileWriter::CommandParser::extractStartInformation(
+      nlohmann::json::parse(Command));
 
   ASSERT_EQ(std::chrono::milliseconds::zero(), StartInfo.StopTime);
 }
@@ -227,8 +234,8 @@ TEST(CommandParserStartTests, IfNoServiceIdThenIsBlank) {
   "nexus_structure": { }
 })""");
 
-  auto StartInfo =
-      FileWriter::CommandParser::extractStartInformation(nlohmann::json::parse(Command));
+  auto StartInfo = FileWriter::CommandParser::extractStartInformation(
+      nlohmann::json::parse(Command));
 
   ASSERT_EQ("", StartInfo.ServiceID);
 }
@@ -239,7 +246,8 @@ TEST(CommandParserSadStopTests, IfNoJobIdThenThrows) {
   "cmd": "FileWriter_stop"
 })""");
 
-  ASSERT_THROW(FileWriter::CommandParser::extractStopInformation(nlohmann::json::parse(Command)),
+  ASSERT_THROW(FileWriter::CommandParser::extractStopInformation(
+                   nlohmann::json::parse(Command)),
                std::runtime_error);
 }
 
@@ -250,7 +258,8 @@ TEST(CommandParserHappyStopTests, IfJobIdPresentThenExtractedCorrectly) {
   "job_id": "qw3rty"
 })""");
 
-  auto StopInfo = FileWriter::CommandParser::extractStopInformation(nlohmann::json::parse(Command));
+  auto StopInfo = FileWriter::CommandParser::extractStopInformation(
+      nlohmann::json::parse(Command));
 
   ASSERT_EQ("qw3rty", StopInfo.JobID);
 }
@@ -263,7 +272,8 @@ TEST(CommandParserHappyStopTests, IfStopTimePresentThenExtractedCorrectly) {
   "stop_time": 123456790
 })""");
 
-  auto StopInfo = FileWriter::CommandParser::extractStopInformation(nlohmann::json::parse(Command));
+  auto StopInfo = FileWriter::CommandParser::extractStopInformation(
+      nlohmann::json::parse(Command));
 
   ASSERT_EQ(std::chrono::milliseconds{123456790}, StopInfo.StopTime);
 }
@@ -275,7 +285,8 @@ TEST(CommandParserStopTests, IfNoStopTimeThenSetToZero) {
   "job_id": "qw3rty"
 })""");
 
-  auto StopInfo = FileWriter::CommandParser::extractStopInformation(nlohmann::json::parse(Command));
+  auto StopInfo = FileWriter::CommandParser::extractStopInformation(
+      nlohmann::json::parse(Command));
 
   ASSERT_EQ(std::chrono::milliseconds::zero(), StopInfo.StopTime);
 }
@@ -287,7 +298,8 @@ TEST(CommandParserStopTests, IfNoServiceIdThenIsBlank) {
   "job_id": "qw3rty"
 })""");
 
-  auto StopInfo = FileWriter::CommandParser::extractStopInformation(nlohmann::json::parse(Command));
+  auto StopInfo = FileWriter::CommandParser::extractStopInformation(
+      nlohmann::json::parse(Command));
 
   ASSERT_EQ("", StopInfo.ServiceID);
 }
@@ -300,7 +312,8 @@ TEST(CommandParserStopTests, IfServiceIdPresentThenExtractedCorrectly) {
   "service_id": "filewriter1"
 })""");
 
-  auto StopInfo = FileWriter::CommandParser::extractStopInformation(nlohmann::json::parse(Command));
+  auto StopInfo = FileWriter::CommandParser::extractStopInformation(
+      nlohmann::json::parse(Command));
 
   ASSERT_EQ("filewriter1", StopInfo.ServiceID);
 }
@@ -316,6 +329,7 @@ TEST(CommandParserSadStopTests, IfStartCommandPassedToStopMethodThenThrows) {
   "nexus_structure": { }
 })""");
 
-  ASSERT_THROW(FileWriter::CommandParser::extractStopInformation(nlohmann::json::parse(Command)),
+  ASSERT_THROW(FileWriter::CommandParser::extractStopInformation(
+                   nlohmann::json::parse(Command)),
                std::runtime_error);
 }

--- a/src/tests/HDFFileTests.cpp
+++ b/src/tests/HDFFileTests.cpp
@@ -45,6 +45,7 @@ void merge_config_into_main_opt(MainOpt &main_opt, string JSONString) {
 json basic_command(string filename) {
   auto Command = json::parse(R""({
     "cmd": "FileWriter_new",
+    "broker": "localhost:9092",
     "nexus_structure": {
       "children": []
     },
@@ -304,6 +305,7 @@ public:
     unlink(hdf_output_filename.c_str());
     auto CommandJSON = json::parse(R""({
       "cmd": "FileWriter_new",
+      "broker": "localhost:9092",
       "nexus_structure": {
         "attributes": {
           "some_top_level_int": 42,
@@ -1095,6 +1097,7 @@ TEST(HDFFile, createStaticDatasetsStrings) {
   auto CommandJSON = json::parse(R""(
 {
   "cmd": "FileWriter_new",
+  "broker": "localhost:9092",
   "file_attributes": {
   },
   "nexus_structure": {

--- a/src/tests/HDFFileTests.cpp
+++ b/src/tests/HDFFileTests.cpp
@@ -279,6 +279,7 @@ public:
       CommandJSON["file_attributes"]["file_name"] = hdf_output_filename;
       CommandJSON["cmd"] = "FileWriter_new";
       CommandJSON["job_id"] = "000000000dataset";
+      CommandJSON["broker"] = "localhost:9092";
     }
 
     auto CommandString = CommandJSON.dump();

--- a/src/tests/HDFFileTests.cpp
+++ b/src/tests/HDFFileTests.cpp
@@ -937,6 +937,7 @@ public:
       CommandJSON["file_attributes"]["file_name"] = "tmp-f142.h5";
       CommandJSON["cmd"] = "FileWriter_new";
       CommandJSON["job_id"] = "unit_test_job_data_f142";
+      CommandJSON["broker"] = "localhost:9092";
     }
 
     auto CommandString = CommandJSON.dump();

--- a/src/tests/HDFFileTests.cpp
+++ b/src/tests/HDFFileTests.cpp
@@ -597,6 +597,7 @@ public:
       CommandJSON["file_attributes"]["file_name"] = filename;
       CommandJSON["cmd"] = "FileWriter_new";
       CommandJSON["job_id"] = "test-ev42";
+      CommandJSON["broker"] = "localhost:9092";
     }
 
     Logger->trace("CommandJSON: {}", CommandJSON.dump());

--- a/src/tests/data/msg-cmd-new-03.json
+++ b/src/tests/data/msg-cmd-new-03.json
@@ -2,6 +2,7 @@
   "file_attributes": {
     "file_name": "a-dummy-name-02.h5"
   },
+  "broker": "localhost:9092"
   "cmd": "FileWriter_new",
   "nexus_structure": {
     "children": [

--- a/src/tests/data/msg-cmd-new-03.json
+++ b/src/tests/data/msg-cmd-new-03.json
@@ -2,7 +2,7 @@
   "file_attributes": {
     "file_name": "a-dummy-name-02.h5"
   },
-  "broker": "localhost:9092"
+  "broker": "localhost:9092",
   "cmd": "FileWriter_new",
   "nexus_structure": {
     "children": [

--- a/src/tests/data/msg-cmd-new-04.json
+++ b/src/tests/data/msg-cmd-new-04.json
@@ -4,6 +4,7 @@
     "file_name": "a-dummy-name-04.h5"
   },
   "cmd": "FileWriter_new",
+  "broker": "localhost:9092",
   "nexus_structure": {
     "children": [
       {


### PR DESCRIPTION
### Issue

N/A

### Description of work

As suggested by @SkyToGround I have made the methods into free functions.

I have also made it a requirement to include the broker details in the "start" command.
I don't think it makes much sense to have it default to localhost when not provided.

### Nominate for Group Code Review

- [ ] Nominate for code review 

