### PR TITLE
Change NICOS cache writer to conform to NXLog rules

### DIFF
--- a/src/NeXusDataset.cpp
+++ b/src/NeXusDataset.cpp
@@ -12,8 +12,8 @@
 #include "NeXusDataset.h"
 
 namespace NeXusDataset {
-RawValue::RawValue(hdf5::node::Group const &Parent, Mode CMode,
-                   size_t ChunkSize)
+UInt16Value::UInt16Value(hdf5::node::Group const &Parent, Mode CMode,
+                         size_t ChunkSize)
     : ExtensibleDataset<std::uint16_t>(Parent, "raw_value", CMode, ChunkSize) {}
 
 Time::Time(hdf5::node::Group const &Parent, Mode CMode, size_t ChunkSize)
@@ -25,6 +25,11 @@ Time::Time(hdf5::node::Group const &Parent, Mode CMode, size_t ChunkSize)
     UnitAttr.write("ns");
   }
 }
+
+DoubleValue::DoubleValue(hdf5::node::Group const &Parent,
+                         NeXusDataset::Mode CMode, size_t ChunkSize)
+    : NeXusDataset::ExtensibleDataset<double>(Parent, "value", CMode,
+                                              ChunkSize) {}
 
 CueIndex::CueIndex(hdf5::node::Group const &Parent, Mode CMode,
                    size_t ChunkSize)

--- a/src/NeXusDataset.h
+++ b/src/NeXusDataset.h
@@ -18,13 +18,21 @@
 
 namespace NeXusDataset {
 
-class RawValue : public ExtensibleDataset<std::uint16_t> {
+class UInt16Value : public ExtensibleDataset<std::uint16_t> {
 public:
-  RawValue() = default;
+  UInt16Value() = default;
   /// \brief Create the raw_value dataset of NXLog.
   /// \throw std::runtime_error if dataset already exists.
-  RawValue(hdf5::node::Group const &Parent, Mode CMode,
-           size_t ChunkSize = 1024);
+  UInt16Value(hdf5::node::Group const &Parent, Mode CMode,
+              size_t ChunkSize = 1024);
+};
+
+class DoubleValue : public NeXusDataset::ExtensibleDataset<double> {
+public:
+  DoubleValue() = default;
+  /// \brief Create the value dataset of NXLog.
+  DoubleValue(hdf5::node::Group const &Parent, NeXusDataset::Mode CMode,
+              size_t ChunkSize = 1024);
 };
 
 class Time : public ExtensibleDataset<std::uint64_t> {

--- a/src/schemas/f142/f142_rw.cpp
+++ b/src/schemas/f142/f142_rw.cpp
@@ -23,7 +23,7 @@ using nlohmann::json;
 
 using Type = f142Writer::Type;
 
-std::string f142Writer::findDataType(const nlohmann::basic_json<> Attribute) {
+std::string f142Writer::findDataType(nlohmann::basic_json<> const &Attribute) {
   auto toLower = [](auto InString) {
     std::transform(InString.begin(), InString.end(), InString.begin(),
                    [](auto C) { return std::tolower(C); });

--- a/src/schemas/f142/f142_rw.h
+++ b/src/schemas/f142/f142_rw.h
@@ -54,7 +54,7 @@ public:
 
 protected:
   SharedLogger Logger = spdlog::get("filewriterlogger");
-  std::string findDataType(const nlohmann::basic_json<> Attribute);
+  std::string findDataType(nlohmann::basic_json<> const &Attribute);
 
   Type ElementType{Type::float64};
 

--- a/src/schemas/ns10/NicosCacheWriter.cpp
+++ b/src/schemas/ns10/NicosCacheWriter.cpp
@@ -123,7 +123,8 @@ void CacheWriter::write(const FileWriter::FlatbufferMessage &Message) {
     double ConvertedValue = std::stod(Value->str());
     Values.appendElement(ConvertedValue);
   } catch (std::invalid_argument const &Exception) {
-    Logger->error("Could not convert string value to double: '{}'", Value->str());
+    Logger->error("Could not convert string value to double: '{}'",
+                  Value->str());
     throw;
   } catch (std::out_of_range const &Exception) {
     Logger->error("Converted value too big for result type: {}", Value->str());

--- a/src/schemas/ns10/NicosCacheWriter.cpp
+++ b/src/schemas/ns10/NicosCacheWriter.cpp
@@ -52,7 +52,6 @@ CacheWriter::init_hdf(hdf5::node::Group &HDFGroup,
   const int DefaultChunkSize = ChunkSize.at(0);
   try {
     auto &CurrentGroup = HDFGroup;
-    // cppcheck-suppress unusedScopedObject
     NeXusDataset::DoubleValue(      // NOLINT(bugprone-unused-raii)
         CurrentGroup,               // NOLINT(bugprone-unused-raii)
         NeXusDataset::Mode::Create, // NOLINT(bugprone-unused-raii)

--- a/src/schemas/ns10/NicosCacheWriter.cpp
+++ b/src/schemas/ns10/NicosCacheWriter.cpp
@@ -19,18 +19,15 @@ namespace ns10 {
 static FileWriter::HDFWriterModuleRegistry::Registrar<CacheWriter>
     RegisterWriter("ns10");
 
-StringValue::StringValue(hdf5::node::Group const &Parent,
-                         NeXusDataset::Mode CMode, size_t ChunkSize)
-    : NeXusDataset::ExtensibleDataset<std::string>(Parent, "value", CMode,
-                                                   ChunkSize) {}
-
 void CacheWriter::parse_config(std::string const &ConfigurationStream) {
   auto Config = nlohmann::json::parse(ConfigurationStream);
   try {
     CueInterval = Config["cue_interval"].get<uint64_t>();
-  } catch (...) {
-    // Do nothing
+  } catch (std::exception const &Exception) {
+    Logger->warn("Unable to extract cue interval from JSON.");
   }
+
+  Logger->info("Using a cue interval of {}.", CueInterval);
 
   auto JsonChunkSize = Config["chunk_size"];
   if (JsonChunkSize.is_array()) {
@@ -38,17 +35,13 @@ void CacheWriter::parse_config(std::string const &ConfigurationStream) {
   } else if (JsonChunkSize.is_number_integer()) {
     ChunkSize = hdf5::Dimensions{JsonChunkSize.get<hsize_t>()};
   } else {
-    Logger->warn("Unable to extract chunk size, using the default (64). "
-                 "This might be very inefficient.");
+    Logger->warn("Unable to extract chunk size, using the existing value");
   }
   try {
     Sourcename = Config["source"];
-  } catch (...) {
-    Logger->error("Key \"source\" is not specified in json command");
-    return;
+  } catch (std::exception const &Exception) {
+    Logger->error("Key \"source\" is not specified in JSON command");
   }
-
-  Logger->info("Using a cue interval of {}.", CueInterval);
 }
 
 using FileWriterBase = FileWriter::HDFWriterModule;
@@ -60,7 +53,7 @@ CacheWriter::init_hdf(hdf5::node::Group &HDFGroup,
   try {
     auto &CurrentGroup = HDFGroup;
     // cppcheck-suppress unusedScopedObject
-    StringValue(                    // NOLINT(bugprone-unused-raii)
+    NeXusDataset::DoubleValue(      // NOLINT(bugprone-unused-raii)
         CurrentGroup,               // NOLINT(bugprone-unused-raii)
         NeXusDataset::Mode::Create, // NOLINT(bugprone-unused-raii)
         DefaultChunkSize);          // NOLINT(bugprone-unused-raii)
@@ -93,7 +86,7 @@ CacheWriter::init_hdf(hdf5::node::Group &HDFGroup,
 FileWriterBase::InitResult CacheWriter::reopen(hdf5::node::Group &HDFGroup) {
   try {
     auto &CurrentGroup = HDFGroup;
-    Values = StringValue(CurrentGroup, NeXusDataset::Mode::Open);
+    Values = NeXusDataset::DoubleValue(CurrentGroup, NeXusDataset::Mode::Open);
     Timestamp = NeXusDataset::Time(CurrentGroup, NeXusDataset::Mode::Open);
     CueTimestampIndex =
         NeXusDataset::CueIndex(CurrentGroup, NeXusDataset::Mode::Open);
@@ -122,10 +115,20 @@ void CacheWriter::write(const FileWriter::FlatbufferMessage &Message) {
   }
 
   if (Source->str() != Sourcename) {
+    Logger->warn("Invalid source name: {}", Source->str());
     return;
   }
 
-  Values.appendElement(Value->str());
+  try {
+    double ConvertedValue = std::stod(Value->str());
+    Values.appendElement(ConvertedValue);
+  } catch (std::invalid_argument const &Exception) {
+    Logger->error("Could not convert string value to double: '{}'", Value->str());
+    throw;
+  } catch (std::out_of_range const &Exception) {
+    Logger->error("Converted value too big for result type: {}", Value->str());
+    throw;
+  }
 
   Timestamp.appendElement(std::lround(1e9 * CurrentTimestamp));
   if (++CueCounter == CueInterval) {

--- a/src/schemas/ns10/NicosCacheWriter.h
+++ b/src/schemas/ns10/NicosCacheWriter.h
@@ -40,7 +40,7 @@ public:
 protected:
   std::string Sourcename;
   NeXusDataset::DoubleValue Values;
-  hdf5::Dimensions ChunkSize{64};
+  hdf5::Dimensions ChunkSize{1024};
   NeXusDataset::Time Timestamp;
   int CueInterval{1000};
   int CueCounter{0};

--- a/src/schemas/ns10/NicosCacheWriter.h
+++ b/src/schemas/ns10/NicosCacheWriter.h
@@ -21,14 +21,6 @@ namespace FileWriter {
 namespace Schemas {
 namespace ns10 {
 
-/// h5cpp dataset class that writers strings.
-class StringValue : public NeXusDataset::ExtensibleDataset<std::string> {
-public:
-  StringValue() = default;
-  /// \brief Create the value dataset of NXLog.
-  StringValue(hdf5::node::Group const &Parent, NeXusDataset::Mode CMode,
-              size_t ChunkSize = 1024);
-};
 
 class CacheWriter : public FileWriter::HDFWriterModule {
 public:
@@ -48,7 +40,7 @@ public:
 
 protected:
   std::string Sourcename;
-  StringValue Values;
+  NeXusDataset::DoubleValue Values;
   hdf5::Dimensions ChunkSize{64};
   NeXusDataset::Time Timestamp;
   int CueInterval{1000};

--- a/src/schemas/ns10/NicosCacheWriter.h
+++ b/src/schemas/ns10/NicosCacheWriter.h
@@ -21,7 +21,6 @@ namespace FileWriter {
 namespace Schemas {
 namespace ns10 {
 
-
 class CacheWriter : public FileWriter::HDFWriterModule {
 public:
   CacheWriter() = default;

--- a/src/schemas/senv/FastSampleEnvironmentWriter.cpp
+++ b/src/schemas/senv/FastSampleEnvironmentWriter.cpp
@@ -64,7 +64,7 @@ FastSampleEnvironmentWriter::init_hdf(hdf5::node::Group &HDFGroup,
   const int DefaultChunkSize = 1024;
   try {
     auto &CurrentGroup = HDFGroup;
-    NeXusDataset::RawValue(         // NOLINT(bugprone-unused-raii)
+    NeXusDataset::UInt16Value(         // NOLINT(bugprone-unused-raii)
         CurrentGroup,               // NOLINT(bugprone-unused-raii)
         NeXusDataset::Mode::Create, // NOLINT(bugprone-unused-raii)
         DefaultChunkSize);          // NOLINT(bugprone-unused-raii)
@@ -98,7 +98,7 @@ FileWriterBase::InitResult
 FastSampleEnvironmentWriter::reopen(hdf5::node::Group &HDFGroup) {
   try {
     auto &CurrentGroup = HDFGroup;
-    Value = NeXusDataset::RawValue(CurrentGroup, NeXusDataset::Mode::Open);
+    Value = NeXusDataset::UInt16Value(CurrentGroup, NeXusDataset::Mode::Open);
     Timestamp = NeXusDataset::Time(CurrentGroup, NeXusDataset::Mode::Open);
     CueTimestampIndex =
         NeXusDataset::CueIndex(CurrentGroup, NeXusDataset::Mode::Open);

--- a/src/schemas/senv/FastSampleEnvironmentWriter.cpp
+++ b/src/schemas/senv/FastSampleEnvironmentWriter.cpp
@@ -64,7 +64,7 @@ FastSampleEnvironmentWriter::init_hdf(hdf5::node::Group &HDFGroup,
   const int DefaultChunkSize = 1024;
   try {
     auto &CurrentGroup = HDFGroup;
-    NeXusDataset::UInt16Value(         // NOLINT(bugprone-unused-raii)
+    NeXusDataset::UInt16Value(      // NOLINT(bugprone-unused-raii)
         CurrentGroup,               // NOLINT(bugprone-unused-raii)
         NeXusDataset::Mode::Create, // NOLINT(bugprone-unused-raii)
         DefaultChunkSize);          // NOLINT(bugprone-unused-raii)

--- a/src/schemas/senv/FastSampleEnvironmentWriter.h
+++ b/src/schemas/senv/FastSampleEnvironmentWriter.h
@@ -56,7 +56,7 @@ public:
   int32_t close() override;
 
 protected:
-  NeXusDataset::RawValue Value;
+  NeXusDataset::UInt16Value Value;
   NeXusDataset::Time Timestamp;
   NeXusDataset::CueIndex CueTimestampIndex;
   NeXusDataset::CueTimestampZero CueTimestamp;

--- a/src/tests/NeXusDatasetTests.cpp
+++ b/src/tests/NeXusDatasetTests.cpp
@@ -110,7 +110,7 @@ template <class Dataset> void wrongModeOpen(hdf5::node::Group &RootGroup) {
 //--------------------------------------------------
 
 TEST_F(NeXusDatasetCreation, RawValueOpen) {
-  using TypeUnderTest = NeXusDataset::RawValue;
+  using TypeUnderTest = NeXusDataset::UInt16Value;
   std::string DatasetName{"raw_value"};
   defaultDatasetCreation<TypeUnderTest, std::uint16_t>(RootGroup, DatasetName);
   reOpenDataset<TypeUnderTest>(RootGroup, DatasetName);

--- a/src/tests/NicosCacheWriterTests.cpp
+++ b/src/tests/NicosCacheWriterTests.cpp
@@ -95,7 +95,7 @@ TEST_F(NicosCacheReaderTest, ReaderReturnValues) {
       "key": "nicos/device/parameter",
       "writer_module": "ns10",
       "time": 123.456,
-      "value": "a string"
+      "value": "10.01"
     })"_json;
 
   auto Builder = createFlatbufferMessageFromJson(BufferJson);
@@ -199,7 +199,7 @@ TEST_F(NicosCacheWriterTest, WriteTimeStamp) {
     "key": "nicos/device/parameter",
     "writer_module": "ns10",
     "time": 123.456,
-    "value": "a string"
+    "value": "10.01"
   })"_json;
 
   auto Builder = createFlatbufferMessageFromJson(BufferJson);
@@ -229,7 +229,7 @@ TEST_F(NicosCacheWriterTest, WriteValues) {
     "key": "nicos/device/parameter",
     "writer_module": "ns10",
     "time": 123.456,
-    "value": "a string"
+    "value": "10.01"
   })"_json;
 
   auto Builder = createFlatbufferMessageFromJson(BufferJson);
@@ -239,9 +239,9 @@ TEST_F(NicosCacheWriterTest, WriteValues) {
 
   Writer.write(Message);
 
-  std::string storedValues;
-  Writer.Values.read(storedValues);
-  EXPECT_EQ(BufferJson["value"], storedValues);
+  double storedValue;
+  Writer.Values.read(storedValue);
+  EXPECT_EQ(10.01, storedValue);
 }
 
 TEST_F(NicosCacheWriterTest, IgnoreMessagesFromDifferentSource) {
@@ -259,7 +259,7 @@ TEST_F(NicosCacheWriterTest, IgnoreMessagesFromDifferentSource) {
     "key": "nicos/device2/parameter",
     "writer_module": "ns10",
     "time": 123.456,
-    "value": "a string"
+    "value": "10.01"
   })"_json;
 
   auto Builder = createFlatbufferMessageFromJson(BufferJson);
@@ -291,7 +291,7 @@ TEST_F(NicosCacheWriterTest, UpdateCueIndex) {
     "key": "nicos/device/parameter",
     "writer_module": "ns10",
     "time": 123.456,
-    "value": "a string"
+    "value": "10.01"
   })"_json;
 
   for (uint64_t i = 0; i < 10; ++i) {
@@ -304,4 +304,55 @@ TEST_F(NicosCacheWriterTest, UpdateCueIndex) {
 
   uint32_t Index;
   EXPECT_NO_THROW(Writer.CueTimestampIndex.read(Index));
+}
+
+TEST_F(NicosCacheWriterTest, ThrowsIfValueCannotBeCastToDouble) {
+  nlohmann::json JsonConfig = R"({
+    "source" : "nicos/device/parameter"
+  })"_json;
+
+  CacheWriterF Writer;
+  Writer.parse_config(JsonConfig.dump());
+
+  Writer.init_hdf(UsedGroup, "{}");
+  Writer.reopen(UsedGroup);
+
+  nlohmann::json BufferJson = R"({
+    "key": "nicos/device/parameter",
+    "writer_module": "ns10",
+    "time": 123.456,
+    "value": "This is a string"
+  })"_json;
+
+  auto Builder = createFlatbufferMessageFromJson(BufferJson);
+  auto Message = FileWriter::FlatbufferMessage(
+      reinterpret_cast<char *>(Builder->GetBufferPointer()),
+      Builder->GetSize());
+
+  EXPECT_THROW(Writer.write(Message), std::invalid_argument);
+}
+
+TEST_F(NicosCacheWriterTest, ThrowsIfValueDoesNotFitIntoDouble) {
+  nlohmann::json JsonConfig = R"({
+    "source" : "nicos/device/parameter"
+  })"_json;
+
+  CacheWriterF Writer;
+  Writer.parse_config(JsonConfig.dump());
+
+  Writer.init_hdf(UsedGroup, "{}");
+  Writer.reopen(UsedGroup);
+
+  nlohmann::json BufferJson = R"({
+    "key": "nicos/device/parameter",
+    "writer_module": "ns10",
+    "time": 123.456,
+    "value": "2e1024"
+  })"_json;
+
+  auto Builder = createFlatbufferMessageFromJson(BufferJson);
+  auto Message = FileWriter::FlatbufferMessage(
+      reinterpret_cast<char *>(Builder->GetBufferPointer()),
+      Builder->GetSize());
+  EXPECT_THROW(Writer.write(Message), std::out_of_range);
 }

--- a/system-tests/test_filewriter_stop_time.py
+++ b/system-tests/test_filewriter_stop_time.py
@@ -47,7 +47,7 @@ def test_filewriter_clears_stop_time_between_jobs(docker_compose_stop_command):
 
 
 def test_filewriter_can_write_data_when_start_and_stop_time_are_in_the_past(
-    docker_compose_stop_command
+    docker_compose_stop_command,
 ):
     producer = create_producer()
 


### PR DESCRIPTION
### Issue

DM-1375

### Description of work

NICOS cache values are now written to NeXus as doubles. If the value cannot be cast then it is ignored. In the future we should look to move to the typed ns11 schema.
Added some tests and tidied some minor things.

### Nominate for Group Code Review

- [ ] Nominate for code review 

