### PR TITLE
Allow setting units on value dataset with f142

### DIFF
--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -11,7 +11,7 @@ trompeloeil/v31@ess-dmsc/stable
 date/4b46deb@ess-dmsc/stable
 spdlog-graylog/1.2.1-dm8@ess-dmsc/testing
 asio/1.13.0@bincrafters/stable
-optional-lite/3.2.0@_/stable
+optional-lite/3.2.0@bincrafters/stable
 
 [generators]
 cmake

--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -11,6 +11,7 @@ trompeloeil/v31@ess-dmsc/stable
 date/4b46deb@ess-dmsc/stable
 spdlog-graylog/1.2.1-dm8@ess-dmsc/testing
 asio/1.13.0@bincrafters/stable
+optional-lite/3.2.0@_/_
 
 [generators]
 cmake

--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -11,7 +11,7 @@ trompeloeil/v31@ess-dmsc/stable
 date/4b46deb@ess-dmsc/stable
 spdlog-graylog/1.2.1-dm8@ess-dmsc/testing
 asio/1.13.0@bincrafters/stable
-optional-lite/3.2.0@_/_
+optional-lite/3.2.0@_/stable
 
 [generators]
 cmake

--- a/conan/conanfile_no_graylog.txt
+++ b/conan/conanfile_no_graylog.txt
@@ -10,6 +10,7 @@ CLI11/1.8.0@cliutils/stable
 trompeloeil/v31@ess-dmsc/stable
 date/4b46deb@ess-dmsc/stable
 spdlog/1.3.1@bincrafters/stable
+optional-lite/3.2.0@_/_
 
 [generators]
 cmake

--- a/conan/conanfile_no_graylog.txt
+++ b/conan/conanfile_no_graylog.txt
@@ -10,7 +10,7 @@ CLI11/1.8.0@cliutils/stable
 trompeloeil/v31@ess-dmsc/stable
 date/4b46deb@ess-dmsc/stable
 spdlog/1.3.1@bincrafters/stable
-optional-lite/3.2.0@_/_
+optional-lite/3.2.0@_/stable
 
 [generators]
 cmake

--- a/conan/conanfile_no_graylog.txt
+++ b/conan/conanfile_no_graylog.txt
@@ -10,7 +10,7 @@ CLI11/1.8.0@cliutils/stable
 trompeloeil/v31@ess-dmsc/stable
 date/4b46deb@ess-dmsc/stable
 spdlog/1.3.1@bincrafters/stable
-optional-lite/3.2.0@_/stable
+optional-lite/3.2.0@bincrafters/stable
 
 [generators]
 cmake

--- a/documentation/writer_module_f142_log_data.md
+++ b/documentation/writer_module_f142_log_data.md
@@ -14,13 +14,16 @@ Example `nexus_structure` to write a scalar `double` value:
           "topic": "the_kafka_topic",
           "source": "the_source_name",
           "writer_module": "f142",
-          "type": "double"
+          "type": "double",
+          "value_units": "cubits"
         }
       }
     ]
   }
 }
 ```
+
+"value_units" is optional; if it is present the writer module creates a units attribute on the value dataset.
 
 For arrays, we have to specify the `array_size`:
 

--- a/src/schemas/f142/f142_rw.cpp
+++ b/src/schemas/f142/f142_rw.cpp
@@ -52,7 +52,7 @@ void makeIt(hdf5::node::Group const &Parent, hdf5::Dimensions const &Shape,
 void initValueDataset(hdf5::node::Group &Parent, Type ElementType,
                       hdf5::Dimensions const &Shape,
                       hdf5::Dimensions const &ChunkSize,
-                      std::string const &ValueUnits) {
+                      nonstd::optional<std::string> const &ValueUnits) {
   using OpenFuncType = std::function<void()>;
   std::map<Type, OpenFuncType> CreateValuesMap{
       {Type::int8, [&]() { makeIt<std::int8_t>(Parent, Shape, ChunkSize); }},
@@ -73,8 +73,8 @@ void initValueDataset(hdf5::node::Group &Parent, Type ElementType,
   };
   CreateValuesMap.at(ElementType)();
 
-  if (!ValueUnits.empty()) {
-    Parent["value"].attributes.create_from<std::string>("units", ValueUnits);
+  if (ValueUnits) {
+    Parent["value"].attributes.create_from<std::string>("units", *ValueUnits);
   }
 }
 
@@ -104,9 +104,9 @@ void f142Writer::parse_config(std::string const &ConfigurationStream) {
     ArraySize = size_t(ArraySizeMaybe.inner());
   }
 
-  if (auto ValueUnitsOptional =
+  if (auto ValueUnitsMaybe =
           find<std::string>("value_units", ConfigurationStreamJson)) {
-    ValueUnits = ValueUnitsOptional.inner();
+    ValueUnits = ValueUnitsMaybe.inner();
   }
 
   try {

--- a/src/schemas/f142/f142_rw.h
+++ b/src/schemas/f142/f142_rw.h
@@ -73,6 +73,7 @@ protected:
   uint64_t ValueIndexInterval = std::numeric_limits<uint64_t>::max();
   size_t ArraySize{1};
   size_t ChunkSize{64 * 1024};
+  std::string ValueUnits;
 };
 
 } // namespace f142

--- a/src/schemas/f142/f142_rw.h
+++ b/src/schemas/f142/f142_rw.h
@@ -13,6 +13,7 @@
 #include <chrono>
 #include <memory>
 #include <nlohmann/json.hpp>
+#include <nonstd/optional.hpp>
 #include <vector>
 
 namespace FileWriter {
@@ -73,7 +74,7 @@ protected:
   uint64_t ValueIndexInterval = std::numeric_limits<uint64_t>::max();
   size_t ArraySize{1};
   size_t ChunkSize{64 * 1024};
-  std::string ValueUnits;
+  nonstd::optional<std::string> ValueUnits;
 };
 
 } // namespace f142

--- a/src/tests/Schema_f142Tests.cpp
+++ b/src/tests/Schema_f142Tests.cpp
@@ -263,6 +263,27 @@ generateFlatbufferMessage(double Value, std::uint64_t Timestamp) {
   return generateFlatbufferMessageBase(ValueFunc, Value::Double, Timestamp);
 }
 
+TEST_F(f142WriteData, ConfigUnitsAttributeOnValueDataset) {
+  f142WriterStandIn TestWriter;
+  const std::string units_string = "parsecs";
+  // GIVEN value_units is specified in the JSON config
+  TestWriter.parse_config(
+      fmt::format(R"({{"value_units": "{}"}})", units_string));
+
+  // WHEN the writer module creates the datasets
+  TestWriter.init_hdf(RootGroup, "");
+  TestWriter.reopen(RootGroup);
+
+  // THEN a units attributes is created on the value dataset with the specified
+  // string
+  std::string attribute_value;
+  EXPECT_NO_THROW(TestWriter.Values.attributes["units"].read(attribute_value))
+      << "Expect units attribute to be present on the value dataset";
+  EXPECT_EQ(attribute_value, units_string) << "Expect units attribute to have "
+                                              "the value specified in the JSON "
+                                              "configuration";
+}
+
 TEST_F(f142WriteData, WriteOneElement) {
   f142WriterStandIn TestWriter;
   TestWriter.init_hdf(RootGroup, "");

--- a/src/tests/Schema_f142Tests.cpp
+++ b/src/tests/Schema_f142Tests.cpp
@@ -284,6 +284,21 @@ TEST_F(f142WriteData, ConfigUnitsAttributeOnValueDataset) {
                                               "configuration";
 }
 
+TEST_F(f142WriteData, UnitsAttributeOnValueDatasetNotCreatedIfNotInConfig) {
+  f142WriterStandIn TestWriter;
+  // GIVEN value_units is not specified in the JSON config
+  TestWriter.parse_config("{}");
+
+  // WHEN the writer module creates the datasets
+  TestWriter.init_hdf(RootGroup, "");
+  TestWriter.reopen(RootGroup);
+
+  // THEN a units attributes is not created on the value dataset
+  EXPECT_FALSE(TestWriter.Values.attributes.exists("units"))
+      << "units attribute should not be created if it was not specified in the "
+         "JSON config";
+}
+
 TEST_F(f142WriteData, WriteOneElement) {
   f142WriterStandIn TestWriter;
   TestWriter.init_hdf(RootGroup, "");

--- a/src/tests/Schema_f142Tests.cpp
+++ b/src/tests/Schema_f142Tests.cpp
@@ -284,6 +284,25 @@ TEST_F(f142WriteData, ConfigUnitsAttributeOnValueDataset) {
                                               "configuration";
 }
 
+TEST_F(f142WriteData, ConfigUnitsAttributeOnValueDatasetIfEmpty) {
+  f142WriterStandIn TestWriter;
+  // GIVEN value_units is specified as an empty string in the JSON config
+  TestWriter.parse_config(R"({{"value_units": ""}})");
+
+  // WHEN the writer module creates the datasets
+  TestWriter.init_hdf(RootGroup, "");
+  TestWriter.reopen(RootGroup);
+
+  // THEN a units attributes is created on the value dataset with an empty
+  // string value
+  std::string attribute_value;
+  EXPECT_NO_THROW(TestWriter.Values.attributes["units"].read(attribute_value))
+      << "Expect units attribute to be present on the value dataset";
+  EXPECT_EQ(attribute_value, "") << "Expect units attribute to have empty "
+                                    "string as the value, as specified in the "
+                                    "JSON configuration";
+}
+
 TEST_F(f142WriteData, UnitsAttributeOnValueDatasetNotCreatedIfNotInConfig) {
   f142WriterStandIn TestWriter;
   // GIVEN value_units is not specified in the JSON config

--- a/src/tests/Schema_f142Tests.cpp
+++ b/src/tests/Schema_f142Tests.cpp
@@ -287,7 +287,7 @@ TEST_F(f142WriteData, ConfigUnitsAttributeOnValueDataset) {
 TEST_F(f142WriteData, ConfigUnitsAttributeOnValueDatasetIfEmpty) {
   f142WriterStandIn TestWriter;
   // GIVEN value_units is specified as an empty string in the JSON config
-  TestWriter.parse_config(R"({{"value_units": ""}})");
+  TestWriter.parse_config(R"({"value_units": ""})");
 
   // WHEN the writer module creates the datasets
   TestWriter.init_hdf(RootGroup, "");


### PR DESCRIPTION
### Issue

DM-1603

### Description of work

Adds unit test, implementation and documentation for an new "value_units" option in the f142 configuration JSON. If this field is present then the f142 writer module creates a units attribute on the value dataset with the specified value.

### Nominate for Group Code Review

- [ ] Nominate for code review 

