### PR TITLE
Unpin system test dependency versions

### DIFF
--- a/system-tests/requirements.txt
+++ b/system-tests/requirements.txt
@@ -1,7 +1,7 @@
-pytest>=4.3.0
-confluent-kafka==0.11.5
-docker-compose>=1.20.0
-docker>=3.4.1
-h5py>=2.8.0
+pytest
+confluent-kafka
+docker-compose
+docker
+h5py
 flatbuffers
-black==19.3b0
+black


### PR DESCRIPTION
### Description of work

Unpin the python dependencies in `requirements.txt` as the old package versions were preventing system-tests working on Python 3.7.

### Nominate for Group Code Review

- [ ] Nominate for code review 

