### PR TITLE
Update librdkafka to 1.2.0

### DIFF
--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -3,7 +3,7 @@ gtest/1.8.1@bincrafters/stable
 fmt/5.3.0@bincrafters/stable
 flatbuffers/1.10.0@google/stable
 h5cpp/e99b997@ess-dmsc/test
-librdkafka/1.1.0@ess-dmsc/stable
+librdkafka/1.2.0@ess-dmsc/stable
 jsonformoderncpp/3.6.1@vthiery/stable
 streaming-data-types/358b661@ess-dmsc/stable
 CLI11/1.8.0@cliutils/stable

--- a/conan/conanfile_no_graylog.txt
+++ b/conan/conanfile_no_graylog.txt
@@ -3,7 +3,7 @@ gtest/1.8.1@bincrafters/stable
 fmt/5.3.0@bincrafters/stable
 flatbuffers/1.10.0@google/stable
 h5cpp/e99b997@ess-dmsc/test
-librdkafka/1.1.0@ess-dmsc/stable
+librdkafka/1.2.0@ess-dmsc/stable
 jsonformoderncpp/3.6.1@vthiery/stable
 streaming-data-types/358b661@ess-dmsc/stable
 CLI11/1.8.0@cliutils/stable


### PR DESCRIPTION
### Description of work

Update librdkafka to 1.2.0, which the forwarder is already on.
No changes other than to the conanfiles were necessary.


