### PR TITLE
Change options from JSON to CLI

### DIFF
--- a/documentation/commands.md
+++ b/documentation/commands.md
@@ -26,8 +26,6 @@ Optional:
 - start_time: The start time in milliseconds (UNIX epoch) for data to be written from. If not supplied then the timestamp of the Kafka message containing the start command is used.
 - stop_time: The stop time in milliseconds (UNIX epoch) for data writing to stop. If not supplied then file writing continues until a stop command is received
 - service_id: The identifier for the instance of the file-writer that should handle this command. Only needed if multiple file-writers present.
-- abort_on_uninitialised_stream: Whether to abort if the stream cannot be initialised. Default is not to abort but carry on.
-- use_hdf_swmr: Whether to use HDF5's Single Writer Multiple Reader (SWMR) capabilities. Default is true. For more on SWMR see [below](Single Writer Multiple Reader).
 
 
 An example command with the `nexus_structure` skipped for brevity:
@@ -40,8 +38,6 @@ An example command with the `nexus_structure` skipped for brevity:
   "start_time": 1547198055000,
   "stop_time": 1547200800000,
   "service_id": "filewriter1",
-  "abort_on_uninitialised_stream": false,
-  "use_hdf_swmr": true,
   "file_attributes": {
     "file_name": "my_nexus_file.h5"
   } ,
@@ -245,23 +241,6 @@ The syntax for including commands is:
   { "some command": "as discussed above" }
 ]
 ```
-
-## Single Writer Multiple Reader
-
-The file-writer can use HDF5's Single Writer Multiple Reader feature (SWMR) which is enable by default.
-
-To read and write HDF files which use the SWMR feature requires HDF5 version 1.10 or higher.
-One can also use the HDF5 tool `h5repack` with the `--high` option to convert the file into a HDF5 1.8 compatible version.  Please refer to see the `h5repack` documentation for more information.
-
-Please note, the HDF documentation warns that:
-
-"The HDF5 file that is accessed by SWMR HDF5 applications must be located on a
-file system that complies with the POSIX `write()` semantics."
-
-Also:
-
-"The writer is not allowed to modify or append to any data items containing
-variable-size datatypes (including string and region references datatypes)."
 
 ## Attributes
 

--- a/src/CLIOptions.cpp
+++ b/src/CLIOptions.cpp
@@ -203,7 +203,7 @@ void setCLIOptions(CLI::App &App, MainOpt &MainOptions) {
   App.add_option("--use-hdf-swmr", MainOptions.UseHdfSwmr,
                  "Write in HDF's Single Writer Multiple Reader (SWMR) mode",
                  true);
-  App.add_option("--abort_on_uninitialised_stream",
+  App.add_option("--abort-on-uninitialised-stream",
                  MainOptions.AbortOnUninitialisedStream,
                  "Writer aborts the whole job if one or more streams are "
                  "misconfigured and fail to start",

--- a/src/CLIOptions.cpp
+++ b/src/CLIOptions.cpp
@@ -200,5 +200,13 @@ void setCLIOptions(CLI::App &App, MainOpt &MainOptions) {
       App, "-S,--kafka-config",
       MainOptions.StreamerConfiguration.BrokerSettings.KafkaConfiguration,
       "LibRDKafka options");
+  App.add_option("--use_hdf_swmr", MainOptions.UseHdfSwmr,
+                 "Write in HDF's Single Writer Multiple Reader (SWMR) mode",
+                 true);
+  App.add_option("--abort_on_uninitialised_stream",
+                 MainOptions.AbortOnUninitialisedStream,
+                 "Writer aborts the whole job if one or more streams are "
+                 "misconfigured and fail to start",
+                 true);
   App.set_config("-c,--config-file", "", "Read configuration from an ini file");
 }

--- a/src/CLIOptions.cpp
+++ b/src/CLIOptions.cpp
@@ -200,7 +200,7 @@ void setCLIOptions(CLI::App &App, MainOpt &MainOptions) {
       App, "-S,--kafka-config",
       MainOptions.StreamerConfiguration.BrokerSettings.KafkaConfiguration,
       "LibRDKafka options");
-  App.add_option("--use_hdf_swmr", MainOptions.UseHdfSwmr,
+  App.add_option("--use-hdf-swmr", MainOptions.UseHdfSwmr,
                  "Write in HDF's Single Writer Multiple Reader (SWMR) mode",
                  true);
   App.add_option("--abort_on_uninitialised_stream",

--- a/src/CommandParser.cpp
+++ b/src/CommandParser.cpp
@@ -37,9 +37,6 @@ extractStartInformation(const nlohmann::json &JSONCommand,
   Result.StartTime = extractTime("start_time", JSONCommand, DefaultStartTime);
   Result.StopTime =
       extractTime("stop_time", JSONCommand, std::chrono::milliseconds::zero());
-  Result.UseSwmr = getOptionalValue<bool>("use_hdf_swmr", JSONCommand, true);
-  Result.AbortOnStreamFailure = getOptionalValue<bool>(
-      "abort_on_uninitialised_stream", JSONCommand, false);
   Result.ServiceID =
       getOptionalValue<std::string>("service_id", JSONCommand, "");
 

--- a/src/CommandParser.h
+++ b/src/CommandParser.h
@@ -26,8 +26,6 @@ struct StartCommandInfo {
   std::string Filename;
   std::string NexusStructure;
   std::string ServiceID;
-  bool UseSwmr;
-  bool AbortOnStreamFailure;
   uri::URI BrokerInfo{"localhost:9092"};
   std::chrono::milliseconds StartTime{0};
   std::chrono::milliseconds StopTime{0};

--- a/src/JobCreator.cpp
+++ b/src/JobCreator.cpp
@@ -142,12 +142,12 @@ std::unique_ptr<IStreamMaster> JobCreator::createFileWritingJob(
            "Start job");
 
   std::vector<StreamHDFInfo> StreamHDFInfoList =
-      initializeHDF(*Task, StartInfo.NexusStructure, StartInfo.UseSwmr);
+      initializeHDF(*Task, StartInfo.NexusStructure, Settings.UseHdfSwmr);
 
   std::vector<StreamSettings> StreamSettingsList =
       extractStreamInformationFromJson(Task, StreamHDFInfoList, Logger);
 
-  if (StartInfo.AbortOnStreamFailure) {
+  if (Settings.AbortOnUninitialisedStream) {
     for (auto const &Item : StreamHDFInfoList) {
       // cppcheck-suppress useStlAlgorithm
       if (!Item.InitialisedOk) {

--- a/src/MainOpt.h
+++ b/src/MainOpt.h
@@ -20,7 +20,6 @@
 
 // POD
 struct MainOpt {
-  bool gtest = false;
   bool use_signal_handler = true;
 
   /// \brief Each running filewriter is identifiable by an id.

--- a/src/MainOpt.h
+++ b/src/MainOpt.h
@@ -22,6 +22,13 @@
 struct MainOpt {
   bool use_signal_handler = true;
 
+  /// Write in HDF's Single Writer Multiple Reader (SWMR) mode
+  bool UseHdfSwmr = true;
+
+  /// If true the filewriter aborts the whole job if one or more streams are
+  /// misconfigured and fail to start
+  bool AbortOnUninitialisedStream = false;
+
   /// \brief Each running filewriter is identifiable by an id.
   ///
   /// This `service_id` is announced in the status updates.

--- a/src/tests/CommandParserTests.cpp
+++ b/src/tests/CommandParserTests.cpp
@@ -24,7 +24,6 @@ public:
   "broker": "somehost:1234",
   "start_time": 123456789000,
   "stop_time": 123456790000,
-  "abort_on_uninitialised_stream": true,
   "service_id": "filewriter1",
   "nexus_structure": { }
 })"""};

--- a/src/tests/CommandParserTests.cpp
+++ b/src/tests/CommandParserTests.cpp
@@ -24,7 +24,6 @@ public:
   "broker": "somehost:1234",
   "start_time": 123456789000,
   "stop_time": 123456790000,
-  "use_hdf_swmr": false,
   "abort_on_uninitialised_stream": true,
   "service_id": "filewriter1",
   "nexus_structure": { }
@@ -44,10 +43,6 @@ TEST_F(CommandParserHappyStartTests, IfFilenamePresentThenExtractedCorrectly) {
   ASSERT_EQ("a-dummy-name-01.h5", StartInfo.Filename);
 }
 
-TEST_F(CommandParserHappyStartTests, IfSwmrPresentThenExtractedCorrectly) {
-  ASSERT_FALSE(StartInfo.UseSwmr);
-}
-
 TEST_F(CommandParserHappyStartTests, IfBrokerPresentThenExtractedCorrectly) {
   ASSERT_EQ("somehost:1234", StartInfo.BrokerInfo.HostPort);
   ASSERT_EQ(1234u, StartInfo.BrokerInfo.Port);
@@ -56,10 +51,6 @@ TEST_F(CommandParserHappyStartTests, IfBrokerPresentThenExtractedCorrectly) {
 TEST_F(CommandParserHappyStartTests,
        IfNexusStructurePresentThenExtractedCorrectly) {
   ASSERT_EQ("{}", StartInfo.NexusStructure);
-}
-
-TEST_F(CommandParserHappyStartTests, IfAbortPresentThenExtractedCorrectly) {
-  ASSERT_TRUE(StartInfo.AbortOnStreamFailure);
 }
 
 TEST_F(CommandParserHappyStartTests, IfStartPresentThenExtractedCorrectly) {

--- a/system-tests/commands/add-command-never-ends.json
+++ b/system-tests/commands/add-command-never-ends.json
@@ -3,7 +3,6 @@
   "broker": "localhost:9092",
   "job_id" : "neverends",
   "service_id": "filewriter1",
-  "use_hdf_swmr": false,
   "file_attributes": {
     "file_name": "output_file_ignores_stop_1.nxs"
   },

--- a/system-tests/commands/add-command-never-ends2.json
+++ b/system-tests/commands/add-command-never-ends2.json
@@ -3,7 +3,6 @@
   "broker": "localhost:9092",
   "job_id" : "neverends",
   "service_id": "filewriter2",
-  "use_hdf_swmr": false,
   "file_attributes": {
     "file_name": "output_file_ignores_stop_2.nxs"
   },

--- a/system-tests/commands/command-write-historical-data.json
+++ b/system-tests/commands/command-write-historical-data.json
@@ -2,7 +2,6 @@
   "cmd": "FileWriter_new",
   "broker": "localhost:9092",
   "job_id": "b294c12a-cd4b-11e8-93f1-484d7e3b68dc",
-  "use_hdf_swmr": false,
   "start_time": STARTTIME,
   "stop_time": STOPTIME,
   "file_attributes": {

--- a/system-tests/commands/commandwithnostoptime.json
+++ b/system-tests/commands/commandwithnostoptime.json
@@ -2,7 +2,6 @@
   "cmd": "FileWriter_new",
   "broker": "localhost:9092",
   "job_id": "a8e31c99-8df9-4123-8060-2e009d84a0df",
-  "use_hdf_swmr": false,
   "file_attributes": {
     "file_name": "output_file_no_stop_time.nxs"
   },

--- a/system-tests/commands/commandwithstoptime.json
+++ b/system-tests/commands/commandwithstoptime.json
@@ -2,7 +2,6 @@
   "cmd": "FileWriter_new",
   "broker": "localhost:9092",
   "job_id": "e094c12a-cd4b-11e8-93f1-484d7e9b68dc",
-  "use_hdf_swmr": false,
   "stop_time": STOPTIME,
   "file_attributes": {
     "file_name": "output_file_with_stop_time.nxs"

--- a/system-tests/commands/example-json-command.json
+++ b/system-tests/commands/example-json-command.json
@@ -2,7 +2,6 @@
   "cmd": "FileWriter_new",
   "broker": "localhost:9092",
   "job_id": "e094c12a-cd4b-11e8-93f1-484d7e9b68dc",
-  "use_hdf_swmr": false,
   "start_time": STARTTIME,
   "file_attributes": {
     "file_name": "output_file.nxs"

--- a/system-tests/commands/longrunning.json
+++ b/system-tests/commands/longrunning.json
@@ -2,7 +2,6 @@
   "cmd": "FileWriter_new",
   "broker": "localhost:9092",
   "job_id": "253ce528-00cb-45c7-966c-131742a24834",
-  "use_hdf_swmr": false,
   "start_time": STARTTIME,
   "file_attributes": {
     "file_name": "output_file_lr.nxs"

--- a/system-tests/commands/static-data-add.json
+++ b/system-tests/commands/static-data-add.json
@@ -2,7 +2,6 @@
   "cmd": "FileWriter_new",
   "broker": "localhost:9092",
   "job_id": "f3c1ad52-f8b2-11e8-8eb2-f2801f1b9fd1",
-  "use_hdf_swmr": false,
   "start_time": STARTTIME,
   "file_attributes": {
     "file_name": "output_file_static.nxs"

--- a/system-tests/config-files/file_writer_config.ini
+++ b/system-tests/config-files/file_writer_config.ini
@@ -2,5 +2,6 @@ hdf-output-prefix="/output-files/"
 command-uri="localhost:9092/TEST_writerCommand"
 status-uri="localhost:9092/TEST_writerStatus"
 status-master-interval=2000
+use-hdf-swmr=false
 verbosity="Trace"
 log-file=/filewriter_logs/filewriter_test_streamed.log

--- a/system-tests/config-files/file_writer_config_static_data.ini
+++ b/system-tests/config-files/file_writer_config_static_data.ini
@@ -2,5 +2,6 @@ hdf-output-prefix="/output-files/"
 command-uri="localhost:9092/TEST_writerCommand"
 status-uri="localhost:9092/TEST_writerStatus"
 status-master-interval=2000
+use-hdf-swmr=false
 verbosity="Trace"
 log-file=/filewriter_logs/filewriter_test_static.log


### PR DESCRIPTION
### Issue

DM-1818

### Description of work
`use_hdf_swmr` and `abort_on_uninitialised_stream` were options that can be specified in the JSON command messages. Given that they will be used with default values per facility they are moved to options set on the command line or in the ini file.
Documentation and system tests have been updated.

### Nominate for Group Code Review

- [ ] Nominate for code review 

