### PR TITLE
Gitignore pycache directories and log files output by system tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /build*/
 /cmake-build-*/
 .idea/
+*__pycache__*
 *.user
 pipeline.gdsl
 *.yml~

--- a/system-tests/logs/.gitignore
+++ b/system-tests/logs/.gitignore
@@ -1,0 +1,2 @@
+# ignore system-test log files
+*.txt

--- a/system-tests/logs/.gitkeep
+++ b/system-tests/logs/.gitkeep
@@ -1,1 +1,0 @@
-This file retains this otherwise empty directory in git so that it can be used as a file output directory in the docker-compose script.


### PR DESCRIPTION
Gitignore log files output during system-tests and also `__pycache__` directories