### PR TITLE
Base docker image on alpine and add gcc 9 build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,4 @@ codecov.yml
 *.conf
 Jenkinsfile
 Dockerfile
+/venv/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ pipeline.gdsl
 *.h~
 *.cxx~
 /system-tests/output-files/*.nxs
+venv
+*.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,9 @@ if(CMAKE_COMPILER_IS_GNUCXX AND COV)
   include(CodeCoverage)
   append_coverage_compiler_flags()
   setup_target_for_coverage_gcovr_xml(NAME coverage
-                                       EXECUTABLE UnitTests
-                                       EXCLUDE src/tests
-                                       DEPENDENCIES UnitTests)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_COVERAGE}")
+                                      EXECUTABLE UnitTests
+                                      EXCLUDE src/tests
+                                      DEPENDENCIES UnitTests)
 endif()
 
 # Use gold linker if available on system (it is faster than default GNU linker)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,15 +15,26 @@ create_version_header(
   ${VERSION_INCLUDE_DIR}/Version.h
 )
 
+# Extra warnings and treat warnings as errors
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror")
 
-if(CMAKE_COMPILER_IS_GNUCXX AND COV)
+set(HTML_COVERAGE_REPORT OFF CACHE BOOL "Generate test coverage report as html, find in <BUILD_DIR>/coverage/index.html")
+if(CMAKE_COMPILER_IS_GNUCXX AND COV OR HTML_COVERAGE_REPORT)
   include(CodeCoverage)
   append_coverage_compiler_flags()
-  setup_target_for_coverage_gcovr_xml(NAME coverage
-                                      EXECUTABLE UnitTests
-                                      EXCLUDE src/tests
-                                      DEPENDENCIES UnitTests)
+  # Exclude tests and Metric sink implementations that do network IO from test coverage
+  set(COVERAGE_EXCLUDE src/tests src/CLIOptions.cpp src/Metrics/Carbon* src/Metrics/Log* src/writer_modules/f142_test/)
+  if (HTML_COVERAGE_REPORT)
+    setup_target_for_coverage_gcovr_html(NAME coverage
+                                         EXECUTABLE UnitTests
+                                         EXCLUDE ${COVERAGE_EXCLUDE}
+                                         DEPENDENCIES UnitTests)
+  else()
+    setup_target_for_coverage_gcovr_xml(NAME coverage
+                                        EXECUTABLE UnitTests
+                                        EXCLUDE ${COVERAGE_EXCLUDE}
+                                        DEPENDENCIES UnitTests)
+  endif()
 endif()
 
 # Use gold linker if available on system (it is faster than default GNU linker)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,11 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Werror")
 
 if(CMAKE_COMPILER_IS_GNUCXX AND COV)
   include(CodeCoverage)
-  setup_target_for_coverage(coverage UnitTests coverage)
+  append_coverage_compiler_flags()
+  setup_target_for_coverage_gcovr_xml(NAME coverage
+                                       EXECUTABLE UnitTests
+                                       EXCLUDE src/tests
+                                       DEPENDENCIES UnitTests)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_COVERAGE}")
 endif()
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,5 +35,5 @@ RUN cd kafka_to_nexus \
     && rm -rf ../../kafka_to_nexus_src/* \
     && rm -rf /tmp/* /var/tmp/* /kafka_to_nexus/src /root/.conan/
 
-COPY ./docker_launch.sh ../docker_launch.sh
+COPY ./docker_launch.sh ../../docker_launch.sh
 CMD ["/docker_launch.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,36 @@
-FROM ubuntu:18.04
+FROM screamingudder/alpine-build-node:1.8.2
 
 ARG http_proxy
 ARG https_proxy
 ARG local_conan_server
 
-# Replace the default profile and remotes with the ones from our Ubuntu build node
-ADD "https://raw.githubusercontent.com/ess-dmsc/docker-ubuntu18.04-build-node/master/files/default_profile" "/root/.conan/profiles/default"
-COPY ./conan ../kafka_to_nexus_src/conan
+USER root
+WORKDIR /home/root
+
+COPY ./conan kafka_to_nexus_src/conan
+
+# Dirty hack to override flatbuffers/1.11.0 with 1.10 as a bug means 1.11 doesn't build on alpine
+# Fixed at HEAD, so can be removed when we have 1.12
+RUN sed '10iflatbuffers/1.10.0@google/stable' kafka_to_nexus_src/conan/conanfile.txt
+
+RUN apk add --no-cache ninja
 
 # Install packages - We don't want to purge kafkacat and tzdata after building
-RUN export DEBIAN_FRONTEND=noninteractive \
-    && apt-get update -y \
-    && apt-get --no-install-recommends -y install gcc-8 g++-8 make git python3 python3-pip cmake python3-setuptools autoconf libtool automake kafkacat tzdata \
-    && apt-get -y autoremove  \
-    && apt-get clean all \
-    && rm -rf /var/lib/apt/lists/* \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8 \
-    && pip3 install --upgrade pip \
-    && pip3 install conan \
+# --build=boost_build required because otherwise we get a version of b2 built against glibc (alpine instead has musl)
+RUN if [ ! -z "$local_conan_server" ]; then conan remote add --insert 0 ess-dmsc-local "$local_conan_server"; fi \
     && mkdir kafka_to_nexus \
-    && conan config install http://github.com/ess-dmsc/conan-configuration.git \
-    && if [ ! -z "$local_conan_server" ]; then conan remote add --insert 0 ess-dmsc-local "$local_conan_server"; fi \
     && cd kafka_to_nexus \
-    && conan install --build=outdated ../kafka_to_nexus_src/conan/conanfile.txt
+    && conan install --build=outdated --build=boost_build ../kafka_to_nexus_src/conan/conanfile.txt
 
 COPY ./cmake ../kafka_to_nexus_src/cmake
 COPY ./src ../kafka_to_nexus_src/src
 COPY ./CMakeLists.txt ../kafka_to_nexus_src/CMakeLists.txt
 
 RUN cd kafka_to_nexus \
-    && cmake -DCONAN="MANUAL" --target="kafka-to-nexus" -DCMAKE_BUILD_TYPE=Release -DUSE_GRAYLOG_LOGGER=True -DRUN_DOXYGEN=False -DBUILD_TESTS=False ../kafka_to_nexus_src \
-    && make -j2 kafka-to-nexus \
+    && cmake -GNinja -DCONAN="MANUAL" --target="kafka-to-nexus" -DCMAKE_BUILD_TYPE=Release -DUSE_GRAYLOG_LOGGER=True -DRUN_DOXYGEN=False -DBUILD_TESTS=False ../kafka_to_nexus_src \
+    && ninja kafka-to-nexus \
     && mkdir /output-files \
     && conan remove "*" -s -f \
-    && apt purge -y git python3 python3-pip cmake python3-setuptools autoconf libtool automake \
     && rm -rf ../../kafka_to_nexus_src/* \
     && rm -rf /tmp/* /var/tmp/* /kafka_to_nexus/src /root/.conan/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,16 +11,17 @@ COPY ./conan kafka_to_nexus_src/conan
 
 # Dirty hack to override flatbuffers/1.11.0 with 1.10 as a bug means 1.11 doesn't build on alpine
 # Fixed at HEAD, so can be removed when we have 1.12
-RUN sed '10iflatbuffers/1.10.0@google/stable' kafka_to_nexus_src/conan/conanfile.txt
+RUN sed -i '10iflatbuffers/1.10.0@google/stable' kafka_to_nexus_src/conan/conanfile.txt
 
 RUN apk add --no-cache ninja
 
 # Install packages - We don't want to purge kafkacat and tzdata after building
-# --build=boost_build required because otherwise we get a version of b2 built against glibc (alpine instead has musl)
+# explicit build of boost_build required because otherwise we get a version of b2 built against glibc (alpine instead has musl)
 RUN if [ ! -z "$local_conan_server" ]; then conan remote add --insert 0 ess-dmsc-local "$local_conan_server"; fi \
     && mkdir kafka_to_nexus \
     && cd kafka_to_nexus \
-    && conan install --build=outdated --build=boost_build ../kafka_to_nexus_src/conan/conanfile.txt
+    && conan install "boost_build/1.69.0@bincrafters/stable" --build \
+    && conan install --build=outdated ../kafka_to_nexus_src/conan/conanfile.txt
 
 COPY ./cmake ../kafka_to_nexus_src/cmake
 COPY ./src ../kafka_to_nexus_src/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM screamingudder/alpine-build-node:2.0.0
+FROM screamingudder/alpine-build-node:2.0.1
 
 ARG http_proxy
 ARG https_proxy
@@ -15,7 +15,6 @@ COPY ./docker_launch.sh ../../docker_launch.sh
 # Install kafkacat to use in detecting when Kafka broker is ready
 # Explicit build of boost_build required because otherwise we get a version of b2 built against glibc (alpine instead has musl)
 RUN sed -i '10iflatbuffers/1.10.0@google/stable' kafka_to_nexus_src/conan/conanfile.txt \
-    && apk del graphviz doxygen valgrind vim flex-dev \
     && apk add --no-cache kafkacat \
     && if [ ! -z "$local_conan_server" ]; then conan remote add --insert 0 ess-dmsc-local "$local_conan_server"; fi \
     && mkdir kafka_to_nexus \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY ./conan kafka_to_nexus_src/conan
 # Fixed at HEAD, so can be removed when we have 1.12
 RUN sed -i '10iflatbuffers/1.10.0@google/stable' kafka_to_nexus_src/conan/conanfile.txt
 
-RUN apk add --no-cache ninja
+RUN apk add --no-cache ninja binutils-gold
 
 # Install packages - We don't want to purge kafkacat and tzdata after building
 # explicit build of boost_build required because otherwise we get a version of b2 built against glibc (alpine instead has musl)

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,6 @@ RUN cd kafka_to_nexus \
     && mkdir /output-files \
     && conan remove "*" -s -f \
     && rm -rf ../../kafka_to_nexus_src/* \
-    && rm -rf /tmp/* /var/tmp/* /kafka_to_nexus/src /root/.conan/
+    && rm -rf /tmp/* /var/tmp/* /home/root/kafka_to_nexus/src /home/root/kafka_to_nexus_src /conan/.conan/
 
 CMD ["/docker_launch.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM screamingudder/alpine-build-node:2.0.0
 ARG http_proxy
 ARG https_proxy
 ARG local_conan_server
+# Set to "yes" to upload conan packages to local_conan_server
+ARG upload_conan_packages
 
 USER root
 WORKDIR /home/root
@@ -13,6 +15,9 @@ COPY ./conan kafka_to_nexus_src/conan
 # Fixed at HEAD, so can be removed when flatbuffers 1.12 is released
 RUN sed -i '10iflatbuffers/1.10.0@google/stable' kafka_to_nexus_src/conan/conanfile.txt
 
+# Install kafkacat to use in detecting when Kafka broker is ready
+RUN apk add --no-cache kafkacat
+
 # Explicit build of boost_build required because otherwise we get a version of b2 built against glibc (alpine instead has musl)
 RUN if [ ! -z "$local_conan_server" ]; then conan remote add --insert 0 ess-dmsc-local "$local_conan_server"; fi \
     && mkdir kafka_to_nexus \
@@ -20,12 +25,14 @@ RUN if [ ! -z "$local_conan_server" ]; then conan remote add --insert 0 ess-dmsc
     && conan install "boost_build/1.69.0@bincrafters/stable" --build \
     && conan install --build=outdated ../kafka_to_nexus_src/conan/conanfile.txt
 
-COPY ./cmake ../kafka_to_nexus_src/cmake
-COPY ./src ../kafka_to_nexus_src/src
-COPY ./CMakeLists.txt ../kafka_to_nexus_src/CMakeLists.txt
+RUN if [ ! -z "$local_conan_server" && ! -z "$upload_conan_packages" ]; then conan upload '*' --all -c --remote ess-dmsc-local; fi
+
+COPY ./cmake kafka_to_nexus_src/cmake
+COPY ./src kafka_to_nexus_src/src
+COPY ./CMakeLists.txt kafka_to_nexus_src/CMakeLists.txt
 
 RUN cd kafka_to_nexus \
-    && cmake -GNinja -DCONAN="MANUAL" --target="kafka-to-nexus" -DCMAKE_BUILD_TYPE=Release -DUSE_GRAYLOG_LOGGER=True -DRUN_DOXYGEN=False -DBUILD_TESTS=False ../kafka_to_nexus_src \
+    && cmake -GNinja -DCONAN="MANUAL" -DCMAKE_BUILD_TYPE=Release -DUSE_GRAYLOG_LOGGER=True -DRUN_DOXYGEN=False -DBUILD_TESTS=False ../kafka_to_nexus_src \
     && ninja kafka-to-nexus \
     && mkdir /output-files \
     && conan remove "*" -s -f \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,17 +7,17 @@ ARG local_conan_server
 USER root
 WORKDIR /home/root
 
-COPY ./conan kafka_to_nexus_src/conan
+COPY ./conan/conanfile.txt kafka_to_nexus_src/conan/conanfile.txt
+COPY ./docker_launch.sh ../../docker_launch.sh
 
-# Dirty hack to override flatbuffers/1.11.0 with 1.10 as a bug means 1.11 doesn't build on alpine
+# "sed" command isa hack to override flatbuffers/1.11.0 with 1.10 as a bug means 1.11 doesn't build on alpine
 # Fixed at HEAD, so can be removed when flatbuffers 1.12 is released
-RUN sed -i '10iflatbuffers/1.10.0@google/stable' kafka_to_nexus_src/conan/conanfile.txt
-
 # Install kafkacat to use in detecting when Kafka broker is ready
-RUN apk add --no-cache kafkacat
-
 # Explicit build of boost_build required because otherwise we get a version of b2 built against glibc (alpine instead has musl)
-RUN if [ ! -z "$local_conan_server" ]; then conan remote add --insert 0 ess-dmsc-local "$local_conan_server"; fi \
+RUN sed -i '10iflatbuffers/1.10.0@google/stable' kafka_to_nexus_src/conan/conanfile.txt \
+    && apk del graphviz doxygen valgrind vim flex-dev \
+    && apk add --no-cache kafkacat \
+    && if [ ! -z "$local_conan_server" ]; then conan remote add --insert 0 ess-dmsc-local "$local_conan_server"; fi \
     && mkdir kafka_to_nexus \
     && cd kafka_to_nexus \
     && conan install "boost_build/1.69.0@bincrafters/stable" --build \
@@ -35,5 +35,4 @@ RUN cd kafka_to_nexus \
     && rm -rf ../../kafka_to_nexus_src/* \
     && rm -rf /tmp/* /var/tmp/* /kafka_to_nexus/src /root/.conan/
 
-COPY ./docker_launch.sh ../../docker_launch.sh
 CMD ["/docker_launch.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,10 @@ WORKDIR /home/root
 COPY ./conan kafka_to_nexus_src/conan
 
 # Dirty hack to override flatbuffers/1.11.0 with 1.10 as a bug means 1.11 doesn't build on alpine
-# Fixed at HEAD, so can be removed when we have 1.12
+# Fixed at HEAD, so can be removed when flatbuffers 1.12 is released
 RUN sed -i '10iflatbuffers/1.10.0@google/stable' kafka_to_nexus_src/conan/conanfile.txt
 
-# Install packages - We don't want to purge kafkacat and tzdata after building
-# explicit build of boost_build required because otherwise we get a version of b2 built against glibc (alpine instead has musl)
+# Explicit build of boost_build required because otherwise we get a version of b2 built against glibc (alpine instead has musl)
 RUN if [ ! -z "$local_conan_server" ]; then conan remote add --insert 0 ess-dmsc-local "$local_conan_server"; fi \
     && mkdir kafka_to_nexus \
     && cd kafka_to_nexus \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ FROM screamingudder/alpine-build-node:2.0.0
 ARG http_proxy
 ARG https_proxy
 ARG local_conan_server
-# Set to "yes" to upload conan packages to local_conan_server
-ARG upload_conan_packages
 
 USER root
 WORKDIR /home/root
@@ -24,8 +22,6 @@ RUN if [ ! -z "$local_conan_server" ]; then conan remote add --insert 0 ess-dmsc
     && cd kafka_to_nexus \
     && conan install "boost_build/1.69.0@bincrafters/stable" --build \
     && conan install --build=outdated ../kafka_to_nexus_src/conan/conanfile.txt
-
-RUN if [ ! -z "$local_conan_server" && ! -z "$upload_conan_packages" ]; then conan upload '*' --all -c --remote ess-dmsc-local; fi
 
 COPY ./cmake kafka_to_nexus_src/cmake
 COPY ./src kafka_to_nexus_src/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM screamingudder/alpine-build-node:1.8.2
+FROM screamingudder/alpine-build-node:2.0.0
 
 ARG http_proxy
 ARG https_proxy
@@ -12,8 +12,6 @@ COPY ./conan kafka_to_nexus_src/conan
 # Dirty hack to override flatbuffers/1.11.0 with 1.10 as a bug means 1.11 doesn't build on alpine
 # Fixed at HEAD, so can be removed when we have 1.12
 RUN sed -i '10iflatbuffers/1.10.0@google/stable' kafka_to_nexus_src/conan/conanfile.txt
-
-RUN apk add --no-cache ninja binutils-gold
 
 # Install packages - We don't want to purge kafkacat and tzdata after building
 # explicit build of boost_build required because otherwise we get a version of b2 built against glibc (alpine instead has musl)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -155,6 +155,19 @@ builders = pipeline_builder.createBuilders { container ->
       container.copyFrom('build', '.')
       junit "build/${test_output}"
 
+      step([
+          $class: 'CoberturaPublisher',
+          autoUpdateHealth: true,
+          autoUpdateStability: true,
+          coberturaReportFile: 'build/coverage.xml',
+          failUnhealthy: false,
+          failUnstable: false,
+          maxNumberOfBuilds: 0,
+          onlyStable: false,
+          sourceEncoding: 'ASCII',
+          zoomCoverageChart: true
+      ])
+
       withCredentials([
         string(
           credentialsId: 'kafka-to-nexus-codecov-token',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,7 +143,7 @@ builders = pipeline_builder.createBuilders { container ->
 
   pipeline_builder.stage("${container.key}: Test") {
     // env.CHANGE_ID is set for pull request builds.
-    if (container.key == test_and_coverage_os && !env.CHANGE_ID) {
+    if (container.key == test_and_coverage_os) {
       def test_output = "TestResults.xml"
       container.sh """
         cd build

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,7 +136,7 @@ builders = pipeline_builder.createBuilders { container ->
     container.sh """
     cd build
     . ./activate_run.sh
-    make -j4 all
+    ninja all
     """
   }  // stage
 
@@ -351,7 +351,7 @@ def get_macos_pipeline() {
           }
 
           try {
-            sh "make -j4 all UnitTests"
+            sh "ninja all UnitTests"
             sh ". ./activate_run.sh && ./bin/UnitTests"
           } catch (e) {
             failure_function(e, 'MacOSX / build+test failed')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -165,8 +165,7 @@ builders = pipeline_builder.createBuilders { container ->
           cd ${pipeline_builder.project}
           export WORKSPACE='.'
           export JENKINS_URL=${JENKINS_URL}
-          python3 -m pip install --user codecov
-          python3 -m codecov -t ${TOKEN} --commit ${scm_vars.GIT_COMMIT} -f ../build/coverage.xml
+          /home/jenkins/.local/bin/codecov -t ${TOKEN} --commit ${scm_vars.GIT_COMMIT} -f ../build/coverage.xml
         """
       }  // withCredentials
     } else if (container.key != release_os && container.key != no_graylog) {
@@ -209,7 +208,6 @@ builders = pipeline_builder.createBuilders { container ->
       try {
         // Do black format of python scripts
         container.sh """
-          python3 -m pip install --user black
           /home/jenkins/.local/bin/black --version
           cd ${project}
           /home/jenkins/.local/bin/black system-tests

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,16 +7,14 @@ project = "kafka-to-nexus"
 
 // 'no_graylog' builds code with plain spdlog conan package instead of ess-dmsc spdlog-graylog.
 // It fails to build in case graylog functionality was used without prior checking if graylog was available.
-clangformat_os = "debian10"
-test_and_coverage_os = "centos7"
+clangformat_os = "ubuntu1804"
+test_and_coverage_os = "ubuntu1804"
 release_os = "centos7-release"
 no_graylog = "centos7-no_graylog"
 
 container_build_nodes = [
-  'centos7': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8'),
   'centos7-release': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8'),
   'centos7-no_graylog': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8'),
-  'debian10': ContainerBuildNode.getDefaultContainerBuildNode('debian10'),
   'ubuntu1804': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu1804-gcc8'),
   'alpine': ContainerBuildNode.getDefaultContainerBuildNode('alpine') // gcc 9.2
 ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,6 +57,16 @@ builders = pipeline_builder.createBuilders { container ->
   }  // stage
 
   pipeline_builder.stage("${container.key}: Dependencies") {
+    if (container.key == "alpine") {
+      // Dirty hack to override flatbuffers/1.11.0 with 1.10 as a bug means 1.11 doesn't build on alpine
+      // Fixed at HEAD, so can be removed when flatbuffers 1.12 is released
+      // Explicit build of boost_build required because otherwise we get a version of b2 built against glibc (alpine instead has musl)
+      container.sh """
+        sed -i '10iflatbuffers/1.10.0@google/stable' ${pipeline_builder.project}/conan/conanfile.txt
+        conan install "boost_build/1.69.0@bincrafters/stable" --build
+      """
+    }
+
     def conan_remote = "ess-dmsc-local"
     if (container.key == no_graylog) {
       container.sh """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -179,7 +179,7 @@ builders = pipeline_builder.createBuilders { container ->
         def comment_text = "**Code Coverage**\n                                           Lines    Exec  Cover\n${coverage_summary}\n*For more detail see Cobertura report in Jenkins interface)*"
 
         withCredentials([string(credentialsId: 'cow-bot-token', variable: 'GITHUB_TOKEN')]) {
-          sh "curl -s -H \"Authorization: token ${GITHUB_TOKEN}\" -X POST -d '{\"body\": \"${comment_text}\"}' \"https://api.github.com/repos/${repository_name}/issues/${ghprbPullId}/comments\""
+          sh "curl -s -H \"Authorization: token ${GITHUB_TOKEN}\" -X POST -d '{\"body\": \"${comment_text}\"}' \"https://api.github.com/repos/${repository_name}/issues/${env.CHANGE_ID}/comments\""
         }
       }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,7 +106,7 @@ builders = pipeline_builder.createBuilders { container ->
       container.sh """
         cd build
         . ./activate_run.sh
-        cmake ${coverage_on} ${doxygen_on} ../${pipeline_builder.project}
+        cmake ${coverage_on} ${doxygen_on} -GNinja ../${pipeline_builder.project}
       """
     } else {
       def graylog_cmake_option
@@ -120,6 +120,7 @@ builders = pipeline_builder.createBuilders { container ->
         cd build
         . ./activate_run.sh
         cmake \
+          -GNinja \
           -DCMAKE_BUILD_TYPE=Release \
           -DCONAN=MANUAL \
           -DCMAKE_SKIP_RPATH=FALSE \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -150,8 +150,6 @@ builders = pipeline_builder.createBuilders { container ->
         . ./activate_run.sh
         ./bin/UnitTests -- --gtest_output=xml:${test_output}
         ninja coverage
-        lcov --directory . --capture --output-file coverage.info
-        lcov --remove coverage.info '*_generated.h' '*/src/date/*' '*/.conan/data/*' '*/usr/*' --output-file coverage.info
       """
 
       container.copyFrom('build', '.')
@@ -167,8 +165,8 @@ builders = pipeline_builder.createBuilders { container ->
           cd ${pipeline_builder.project}
           export WORKSPACE='.'
           export JENKINS_URL=${JENKINS_URL}
-          python3.6 -m pip install --user codecov
-          python3.6 -m codecov -t ${TOKEN} --commit ${scm_vars.GIT_COMMIT} -f ../build/coverage.info
+          python3 -m pip install --user codecov
+          python3 -m codecov -t ${TOKEN} --commit ${scm_vars.GIT_COMMIT} -f ../build/coverage.xml
         """
       }  // withCredentials
     } else if (container.key != release_os && container.key != no_graylog) {
@@ -211,7 +209,7 @@ builders = pipeline_builder.createBuilders { container ->
       try {
         // Do black format of python scripts
         container.sh """
-          python3.6 -m pip install --user black
+          python3 -m pip install --user black
           /home/jenkins/.local/bin/black --version
           cd ${project}
           /home/jenkins/.local/bin/black system-tests

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,7 +175,7 @@ builders = pipeline_builder.createBuilders { container ->
         ).trim()
 
         def repository_url = scm.userRemoteConfigs[0].url
-        def repository_name = repository_url.replace("git@github.com:","").replace(".git","")
+        def repository_name = repository_url.replace("git@github.com:","").replace(".git","").replace("https://github.com/","")
         def comment_text = "**Code Coverage**\n                                           Lines    Exec  Cover\n${coverage_summary}\n*For more detail see Cobertura report in Jenkins interface)*"
 
         withCredentials([string(credentialsId: 'cow-bot-token', variable: 'GITHUB_TOKEN')]) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -169,18 +169,10 @@ builders = pipeline_builder.createBuilders { container ->
       ])
 
       if (env.CHANGE_ID) {
-        post {
-          success {
-            script {
-              if (env.CHANGE_ID) {
-                publishCoverageGithub(filepath:'build/coverage.xml',
-                                      coverageXmlType: 'cobertura',
-                                      comparisonOption: [ value: 'optionFixedCoverage', fixedCoverage: '0.65' ],
-                                      coverageRateType: 'Line')
-              }
-            }
-          }
-        }
+        publishCoverageGithub(filepath:'build/coverage.xml',
+                              coverageXmlType: 'cobertura',
+                              comparisonOption: [ value: 'optionFixedCoverage', fixedCoverage: '0.65' ],
+                              coverageRateType: 'Line')
       }
 
     } else if (container.key != release_os && container.key != no_graylog) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,8 @@ container_build_nodes = [
   'centos7-release': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8'),
   'centos7-no_graylog': ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8'),
   'debian10': ContainerBuildNode.getDefaultContainerBuildNode('debian10'),
-  'ubuntu1804': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu1804-gcc8')
+  'ubuntu1804': ContainerBuildNode.getDefaultContainerBuildNode('ubuntu1804-gcc8'),
+  'alpine': ContainerBuildNode.getDefaultContainerBuildNode('alpine') // gcc 9.2
 ]
 
 // Define number of old builds to keep. These numbers are somewhat arbitrary,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,14 +91,14 @@ builders = pipeline_builder.createBuilders { container ->
     if (container.key != release_os && container.key != no_graylog) {
       def coverage_on
       if (container.key == test_and_coverage_os) {
-        coverage_on = '-DCOV=1'
+        coverage_on = '-DCOV=ON'
       } else {
         coverage_on = ''
       }
 
       def doxygen_on
       if (container.key == clangformat_os) {
-        doxygen_on = '-DRUN_DOXYGEN=TRUE'
+        doxygen_on = '-DRUN_DOXYGEN=ON'
       } else {
         doxygen_on = ''
       }
@@ -149,7 +149,7 @@ builders = pipeline_builder.createBuilders { container ->
         cd build
         . ./activate_run.sh
         ./bin/UnitTests -- --gtest_output=xml:${test_output}
-        make coverage
+        ninja coverage
         lcov --directory . --capture --output-file coverage.info
         lcov --remove coverage.info '*_generated.h' '*/src/date/*' '*/.conan/data/*' '*/usr/*' --output-file coverage.info
       """
@@ -261,7 +261,7 @@ builders = pipeline_builder.createBuilders { container ->
         container.sh """
           cd build
           pwd
-          make docs 2> ${test_output}
+          ninja docs 2> ${test_output}
         """
         container.copyFrom("build/${test_output}", '.')
         archiveArtifacts "${test_output}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -171,7 +171,7 @@ builders = pipeline_builder.createBuilders { container ->
       if (env.CHANGE_ID) {
         publishCoverageGithub(filepath:'build/coverage.xml',
                               coverageXmlType: 'cobertura',
-                              comparisonOption: [ value: 'optionFixedCoverage', fixedCoverage: '0.65' ],
+                              comparisonOption: [ value: 'optionFixedCoverage', fixedCoverage: '0.70' ],
                               coverageRateType: 'Line')
       }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,11 +168,16 @@ builders = pipeline_builder.createBuilders { container ->
           zoomCoverageChart: true
       ])
 
-      post {
-        success {
-          script {
-            if (env.CHANGE_ID) {
-              publishCoverageGithub(filepath:'build/coverage.xml', coverageXmlType: 'cobertura', comparisonOption: [ value: 'optionFixedCoverage', fixedCoverage: '0.65' ], coverageRateType: 'Line')
+      if (env.CHANGE_ID) {
+        post {
+          success {
+            script {
+              if (env.CHANGE_ID) {
+                publishCoverageGithub(filepath:'build/coverage.xml',
+                                      coverageXmlType: 'cobertura',
+                                      comparisonOption: [ value: 'optionFixedCoverage', fixedCoverage: '0.65' ],
+                                      coverageRateType: 'Line')
+              }
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -169,8 +169,10 @@ builders = pipeline_builder.createBuilders { container ->
       ])
 
       if (env.CHANGE_ID) {
-        sh "sed -n -e '/^TOTAL/p' build/coverage.txt > build/coverage_summary.txt"
-        String coverage_summary = new File('build/coverage_summary.txt').text
+        coverage_summary = sh (
+            script: "sed -n -e '/^TOTAL/p' build/coverage.txt",
+            returnStdout: true
+        ).trim()
 
         def repository_url = scm.userRemoteConfigs[0].url
         def repository_name = repository_url.replace("git@github.com:","").replace(".git","")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -176,7 +176,7 @@ builders = pipeline_builder.createBuilders { container ->
 
         def repository_url = scm.userRemoteConfigs[0].url
         def repository_name = repository_url.replace("git@github.com:","").replace(".git","").replace("https://github.com/","")
-        def comment_text = "**Code Coverage**\n                                           Lines    Exec  Cover\n${coverage_summary}\n*For more detail see Cobertura report in Jenkins interface)*"
+        def comment_text = "**Code Coverage**\\n*(Lines    Exec  Cover)*\\n${coverage_summary}\\n*For more detail see Cobertura report in Jenkins interface*"
 
         withCredentials([string(credentialsId: 'cow-bot-token', variable: 'GITHUB_TOKEN')]) {
           sh "curl -s -H \"Authorization: token ${GITHUB_TOKEN}\" -X POST -d '{\"body\": \"${comment_text}\"}' \"https://api.github.com/repos/${repository_name}/issues/${env.CHANGE_ID}/comments\""

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -351,7 +351,7 @@ def get_macos_pipeline() {
           }
 
           try {
-            sh "ninja all UnitTests"
+            sh "make -j4 all UnitTests"
             sh ". ./activate_run.sh && ./bin/UnitTests"
           } catch (e) {
             failure_function(e, 'MacOSX / build+test failed')

--- a/README.md
+++ b/README.md
@@ -97,8 +97,9 @@ make
 ```
 
 There are additional CMake flags for adjusting the build:
-* `-DRUN_DOXYGEN=TRUE` if Doxygen documentation is required. Also, requires `make docs` to be run afterwards
-* `-DBUILD_TESTS=FALSE` to skip building the unit tests
+* `-DRUN_DOXYGEN=ON` if Doxygen documentation is required. Also, requires `make docs` to be run afterwards
+* `-DBUILD_TESTS=OFF` to skip building the unit tests
+* `-DHTML_COVERAGE_REPORT=ON` to generate an html unit test coverage report, output to `<BUILD_DIR>/coverage/index.html`
 
 ### Running the unit tests
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://jenkins.esss.dk/dm/job/ess-dmsc/job/kafka-to-nexus/job/master/badge/icon)](https://jenkins.esss.dk/dm/job/ess-dmsc/job/kafka-to-nexus/job/master/)
-[![codecov](https://codecov.io/gh/ess-dmsc/kafka-to-nexus/branch/master/graph/badge.svg)](https://codecov.io/gh/ess-dmsc/kafka-to-nexus)
 [![DOI](https://zenodo.org/badge/81435658.svg)](https://zenodo.org/badge/latestdoi/81435658)
 
 

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -1,4 +1,4 @@
-# Copyright (c) 2012 - 2015, Lars Bilke
+# Copyright (c) 2012 - 2017, Lars Bilke
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -26,7 +26,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-#
+# CHANGES:
 #
 # 2012-01-31, Lars Bilke
 # - Enable Code Coverage
@@ -35,129 +35,401 @@
 # - Added support for Clang.
 # - Some additional usage instructions.
 #
+# 2016-02-03, Lars Bilke
+# - Refactored functions to use named parameters
+#
+# 2017-06-02, Lars Bilke
+# - Merged with modified version from github.com/ufz/ogs
+#
+# 2019-05-06, Anatolii Kurotych
+# - Remove unnecessary --coverage flag
+#
+# 2019-12-13, FeRD (Frank Dana)
+# - Deprecate COVERAGE_LCOVR_EXCLUDES and COVERAGE_GCOVR_EXCLUDES lists in favor
+#   of tool-agnostic COVERAGE_EXCLUDES variable, or EXCLUDE setup arguments.
+# - CMake 3.4+: All excludes can be specified relative to BASE_DIRECTORY
+# - All setup functions: accept BASE_DIRECTORY, EXCLUDE list
+# - Set lcov basedir with -b argument
+# - Add automatic --demangle-cpp in lcovr, if 'c++filt' is available (can be
+#   overridden with NO_DEMANGLE option in setup_target_for_coverage_lcovr().)
+# - Delete output dir, .info file on 'make clean'
+# - Remove Python detection, since version mismatches will break gcovr
+# - Minor cleanup (lowercase function names, update examples...)
+#
+# 2019-12-19, FeRD (Frank Dana)
+# - Rename Lcov outputs, make filtered file canonical, fix cleanup for targets
+#
+# 2020-01-19, Bob Apthorpe
+# - Added gfortran support
+#
+# 2020-02-17, FeRD (Frank Dana)
+# - Make all add_custom_target()s VERBATIM to auto-escape wildcard characters
+#   in EXCLUDEs, and remove manual escaping from gcovr targets
+#
 # USAGE:
-
-# 0. (Mac only) If you use Xcode 5.1 make sure to patch geninfo as described here:
-#      http://stackoverflow.com/a/22404544/80480
 #
 # 1. Copy this file into your cmake modules path.
 #
 # 2. Add the following line to your CMakeLists.txt:
-#      INCLUDE(CodeCoverage)
+#      include(CodeCoverage)
 #
-# 3. Set compiler flags to turn off optimization and enable coverage:
-#    SET(CMAKE_CXX_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
-#	 SET(CMAKE_C_FLAGS "-g -O0 -fprofile-arcs -ftest-coverage")
+# 3. Append necessary compiler flags:
+#      append_coverage_compiler_flags()
 #
-# 3. Use the function SETUP_TARGET_FOR_COVERAGE to create a custom make target
-#    which runs your test executable and produces a lcov code coverage report:
+# 3.a (OPTIONAL) Set appropriate optimization flags, e.g. -O0, -O1 or -Og
+#
+# 4. If you need to exclude additional directories from the report, specify them
+#    using full paths in the COVERAGE_EXCLUDES variable before calling
+#    setup_target_for_coverage_*().
 #    Example:
-#	 SETUP_TARGET_FOR_COVERAGE(
-#				my_coverage_target  # Name for custom target.
-#				test_driver         # Name of the test driver executable that runs the tests.
-#									# NOTE! This should always have a ZERO as exit code
-#									# otherwise the coverage generation will not complete.
-#				coverage            # Name of output directory.
-#				)
+#      set(COVERAGE_EXCLUDES
+#          '${PROJECT_SOURCE_DIR}/src/dir1/*'
+#          '/path/to/my/src/dir2/*')
+#    Or, use the EXCLUDE argument to setup_target_for_coverage_*().
+#    Example:
+#      setup_target_for_coverage_lcov(
+#          NAME coverage
+#          EXECUTABLE testrunner
+#          EXCLUDE "${PROJECT_SOURCE_DIR}/src/dir1/*" "/path/to/my/src/dir2/*")
 #
-# 4. Build a Debug build:
-#	 cmake -DCMAKE_BUILD_TYPE=Debug ..
-#	 make
-#	 make my_coverage_target
+# 4.a NOTE: With CMake 3.4+, COVERAGE_EXCLUDES or EXCLUDE can also be set
+#     relative to the BASE_DIRECTORY (default: PROJECT_SOURCE_DIR)
+#     Example:
+#       set(COVERAGE_EXCLUDES "dir1/*")
+#       setup_target_for_coverage_gcovr_html(
+#           NAME coverage
+#           EXECUTABLE testrunner
+#           BASE_DIRECTORY "${PROJECT_SOURCE_DIR}/src"
+#           EXCLUDE "dir2/*")
 #
+# 5. Use the functions described below to create a custom make target which
+#    runs your test executable and produces a code coverage report.
 #
+# 6. Build a Debug build:
+#      cmake -DCMAKE_BUILD_TYPE=Debug ..
+#      make
+#      make my_coverage_target
+#
+
+include(CMakeParseArguments)
 
 # Check prereqs
-FIND_PROGRAM( GCOV_PATH gcov )
-FIND_PROGRAM( LCOV_PATH lcov )
-FIND_PROGRAM( GENHTML_PATH genhtml )
-FIND_PROGRAM( GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/tests)
+find_program( GCOV_PATH gcov )
+find_program( LCOV_PATH  NAMES lcov lcov.bat lcov.exe lcov.perl)
+find_program( GENHTML_PATH NAMES genhtml genhtml.perl genhtml.bat )
+find_program( GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/scripts/test)
+find_program( CPPFILT_PATH NAMES c++filt )
 
-IF(NOT GCOV_PATH)
-    MESSAGE(FATAL_ERROR "gcov not found! Aborting...")
-ENDIF() # NOT GCOV_PATH
+if(NOT GCOV_PATH)
+    message(FATAL_ERROR "gcov not found! Aborting...")
+endif() # NOT GCOV_PATH
 
-IF("${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?[Cc]lang")
-    IF("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 3)
-        MESSAGE(FATAL_ERROR "Clang version must be 3.0.0 or greater! Aborting...")
-    ENDIF()
-ELSEIF(NOT CMAKE_COMPILER_IS_GNUCXX)
-    MESSAGE(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
-ENDIF() # CHECK VALID COMPILER
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?[Cc]lang")
+    if("${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS 3)
+        message(FATAL_ERROR "Clang version must be 3.0.0 or greater! Aborting...")
+    endif()
+elseif(NOT CMAKE_COMPILER_IS_GNUCXX)
+    if("${CMAKE_Fortran_COMPILER_ID}" MATCHES "[Ff]lang")
+        # Do nothing; exit conditional without error if true
+    elseif("${CMAKE_Fortran_COMPILER_ID}" MATCHES "GNU")
+        # Do nothing; exit conditional without error if true
+    else()
+        message(FATAL_ERROR "Compiler is not GNU gcc! Aborting...")
+    endif()
+endif()
 
-SET(CMAKE_CXX_FLAGS_COVERAGE
-        "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
+set(COVERAGE_COMPILER_FLAGS "-g -fprofile-arcs -ftest-coverage"
+        CACHE INTERNAL "")
+
+set(CMAKE_Fortran_FLAGS_COVERAGE
+        ${COVERAGE_COMPILER_FLAGS}
+        CACHE STRING "Flags used by the Fortran compiler during coverage builds."
+        FORCE )
+set(CMAKE_CXX_FLAGS_COVERAGE
+        ${COVERAGE_COMPILER_FLAGS}
         CACHE STRING "Flags used by the C++ compiler during coverage builds."
         FORCE )
-SET(CMAKE_C_FLAGS_COVERAGE
-        "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
+set(CMAKE_C_FLAGS_COVERAGE
+        ${COVERAGE_COMPILER_FLAGS}
         CACHE STRING "Flags used by the C compiler during coverage builds."
         FORCE )
-SET(CMAKE_EXE_LINKER_FLAGS_COVERAGE
+set(CMAKE_EXE_LINKER_FLAGS_COVERAGE
         ""
         CACHE STRING "Flags used for linking binaries during coverage builds."
         FORCE )
-SET(CMAKE_SHARED_LINKER_FLAGS_COVERAGE
+set(CMAKE_SHARED_LINKER_FLAGS_COVERAGE
         ""
         CACHE STRING "Flags used by the shared libraries linker during coverage builds."
         FORCE )
-MARK_AS_ADVANCED(
+mark_as_advanced(
+        CMAKE_Fortran_FLAGS_COVERAGE
         CMAKE_CXX_FLAGS_COVERAGE
         CMAKE_C_FLAGS_COVERAGE
         CMAKE_EXE_LINKER_FLAGS_COVERAGE
         CMAKE_SHARED_LINKER_FLAGS_COVERAGE )
 
-IF ( NOT (CMAKE_BUILD_TYPE STREQUAL "Debug" OR CMAKE_BUILD_TYPE STREQUAL "Coverage"))
-    MESSAGE( WARNING "Code coverage results with an optimized (non-Debug) build may be misleading" )
-ENDIF() # NOT CMAKE_BUILD_TYPE STREQUAL "Debug"
+if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")
+    message(WARNING "Code coverage results with an optimised (non-Debug) build may be misleading")
+endif() # NOT CMAKE_BUILD_TYPE STREQUAL "Debug"
 
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+    link_libraries(gcov)
+endif()
 
-# Param _targetname     The name of new the custom make target
-# Param _testrunner     The name of the target which runs the tests.
-#						MUST return ZERO always, even on errors.
-#						If not, no coverage report will be created!
-# Param _outputname     lcov output is generated as _outputname.info
-#                       HTML report is generated in _outputname/index.html
-# Optional fourth parameter is passed as arguments to _testrunner
-#   Pass them in list form, e.g.: "-j;2" for -j 2
-FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
+# Defines a target for running and collection code coverage information
+# Builds dependencies, runs the given executable and outputs reports.
+# NOTE! The executable should always have a ZERO as exit code otherwise
+# the coverage generation will not complete.
+#
+# setup_target_for_coverage_lcov(
+#     NAME testrunner_coverage                    # New target name
+#     EXECUTABLE testrunner -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
+#     DEPENDENCIES testrunner                     # Dependencies to build first
+#     BASE_DIRECTORY "../"                        # Base directory for report
+#                                                 #  (defaults to PROJECT_SOURCE_DIR)
+#     EXCLUDE "src/dir1/*" "src/dir2/*"           # Patterns to exclude (can be relative
+#                                                 #  to BASE_DIRECTORY, with CMake 3.4+)
+#     NO_DEMANGLE                                 # Don't demangle C++ symbols
+#                                                 #  even if c++filt is found
+# )
+function(setup_target_for_coverage_lcov)
 
-    IF(NOT LCOV_PATH)
-        MESSAGE(FATAL_ERROR "lcov not found! Aborting...")
-    ENDIF() # NOT LCOV_PATH
+    set(options NO_DEMANGLE)
+    set(oneValueArgs BASE_DIRECTORY NAME)
+    set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES LCOV_ARGS GENHTML_ARGS)
+    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    IF(NOT GENHTML_PATH)
-        MESSAGE(FATAL_ERROR "genhtml not found! Aborting...")
-    ENDIF() # NOT GENHTML_PATH
+    if(NOT LCOV_PATH)
+        message(FATAL_ERROR "lcov not found! Aborting...")
+    endif() # NOT LCOV_PATH
 
-    SET(coverage_info "${CMAKE_BINARY_DIR}/${_outputname}.info")
-    SET(coverage_cleaned "${coverage_info}.cleaned")
+    if(NOT GENHTML_PATH)
+        message(FATAL_ERROR "genhtml not found! Aborting...")
+    endif() # NOT GENHTML_PATH
 
-    SEPARATE_ARGUMENTS(test_command UNIX_COMMAND "${_testrunner}")
+    # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
+    if(${Coverage_BASE_DIRECTORY})
+        get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
+    else()
+        set(BASEDIR ${PROJECT_SOURCE_DIR})
+    endif()
+
+    # Collect excludes (CMake 3.4+: Also compute absolute paths)
+    set(LCOV_EXCLUDES "")
+    foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_LCOV_EXCLUDES})
+        if(CMAKE_VERSION VERSION_GREATER 3.4)
+            get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
+        endif()
+        list(APPEND LCOV_EXCLUDES "${EXCLUDE}")
+    endforeach()
+    list(REMOVE_DUPLICATES LCOV_EXCLUDES)
+
+    # Conditional arguments
+    if(CPPFILT_PATH AND NOT ${Coverage_NO_DEMANGLE})
+        set(GENHTML_EXTRA_ARGS "--demangle-cpp")
+    endif()
 
     # Setup target
-    ADD_CUSTOM_TARGET(${_targetname}
+    add_custom_target(${Coverage_NAME}
 
             # Cleanup lcov
-            ${LCOV_PATH} --directory . --zerocounters
+            COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -directory . -b ${BASEDIR} --zerocounters
+            # Create baseline to make sure untouched files show up in the report
+            COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -c -i -d . -b ${BASEDIR} -o ${Coverage_NAME}.base
 
             # Run tests
-            COMMAND ${test_command} ${ARGV3}
+            COMMAND ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
 
             # Capturing lcov counters and generating report
-            COMMAND ${LCOV_PATH} --directory . --capture --output-file ${coverage_info}
-            COMMAND ${LCOV_PATH} --remove ${coverage_info} 'tests/*' ${ARGN} '/usr/*' --output-file ${coverage_cleaned}
-            COMMAND ${GENHTML_PATH} -o ${_outputname} ${coverage_cleaned}
-            COMMAND ${CMAKE_COMMAND} -E remove ${coverage_info} ${coverage_cleaned}
+            COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --directory . -b ${BASEDIR} --capture --output-file ${Coverage_NAME}.capture
+            # add baseline counters
+            COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.capture --output-file ${Coverage_NAME}.total
+            # filter collected data to final coverage report
+            COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --remove ${Coverage_NAME}.total ${LCOV_EXCLUDES} --output-file ${Coverage_NAME}.info
 
-            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+            # Generate HTML output
+            COMMAND ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS} -o ${Coverage_NAME} ${Coverage_NAME}.info
+
+            # Set output files as GENERATED (will be removed on 'make clean')
+            BYPRODUCTS
+            ${Coverage_NAME}.base
+            ${Coverage_NAME}.capture
+            ${Coverage_NAME}.total
+            ${Coverage_NAME}.info
+            ${Coverage_NAME}  # report directory
+
+            WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+            DEPENDS ${Coverage_DEPENDENCIES}
+            VERBATIM # Protect arguments to commands
             COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
             )
 
-    # Show info where to find the report
-    ADD_CUSTOM_COMMAND(TARGET ${_targetname} POST_BUILD
+    # Show where to find the lcov info report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
             COMMAND ;
-            COMMENT "Open ./${_outputname}/index.html in your browser to view the coverage report."
+            COMMENT "Lcov code coverage info report saved in ${Coverage_NAME}.info."
             )
 
-ENDFUNCTION() # SETUP_TARGET_FOR_COVERAGE
+    # Show info where to find the report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+            COMMAND ;
+            COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
+            )
+
+endfunction() # setup_target_for_coverage_lcov
+
+# Defines a target for running and collection code coverage information
+# Builds dependencies, runs the given executable and outputs reports.
+# NOTE! The executable should always have a ZERO as exit code otherwise
+# the coverage generation will not complete.
+#
+# setup_target_for_coverage_gcovr_xml(
+#     NAME ctest_coverage                    # New target name
+#     EXECUTABLE ctest -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
+#     DEPENDENCIES executable_target         # Dependencies to build first
+#     BASE_DIRECTORY "../"                   # Base directory for report
+#                                            #  (defaults to PROJECT_SOURCE_DIR)
+#     EXCLUDE "src/dir1/*" "src/dir2/*"      # Patterns to exclude (can be relative
+#                                            #  to BASE_DIRECTORY, with CMake 3.4+)
+# )
+function(setup_target_for_coverage_gcovr_xml)
+
+    set(options NONE)
+    set(oneValueArgs BASE_DIRECTORY NAME)
+    set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
+    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(NOT GCOVR_PATH)
+        message(FATAL_ERROR "gcovr not found! Aborting...")
+    endif() # NOT GCOVR_PATH
+
+    # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
+    if(${Coverage_BASE_DIRECTORY})
+        get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
+    else()
+        set(BASEDIR ${PROJECT_SOURCE_DIR})
+    endif()
+
+    # Collect excludes (CMake 3.4+: Also compute absolute paths)
+    set(GCOVR_EXCLUDES "")
+    foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_GCOVR_EXCLUDES})
+        if(CMAKE_VERSION VERSION_GREATER 3.4)
+            get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
+        endif()
+        list(APPEND GCOVR_EXCLUDES "${EXCLUDE}")
+    endforeach()
+    list(REMOVE_DUPLICATES GCOVR_EXCLUDES)
+
+    # Combine excludes to several -e arguments
+    set(GCOVR_EXCLUDE_ARGS "")
+    foreach(EXCLUDE ${GCOVR_EXCLUDES})
+        list(APPEND GCOVR_EXCLUDE_ARGS "-e")
+        list(APPEND GCOVR_EXCLUDE_ARGS "${EXCLUDE}")
+    endforeach()
+
+    add_custom_target(${Coverage_NAME}
+            # Run tests
+            ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
+
+            # Running gcovr
+            COMMAND ${GCOVR_PATH} --xml
+            -r ${BASEDIR} ${GCOVR_EXCLUDE_ARGS}
+            --object-directory=${PROJECT_BINARY_DIR}
+            -o ${Coverage_NAME}.xml
+            BYPRODUCTS ${Coverage_NAME}.xml
+            WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+            DEPENDS ${Coverage_DEPENDENCIES}
+            VERBATIM # Protect arguments to commands
+            COMMENT "Running gcovr to produce Cobertura code coverage report."
+            )
+
+    # Show info where to find the report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+            COMMAND ;
+            COMMENT "Cobertura code coverage report saved in ${Coverage_NAME}.xml."
+            )
+endfunction() # setup_target_for_coverage_gcovr_xml
+
+# Defines a target for running and collection code coverage information
+# Builds dependencies, runs the given executable and outputs reports.
+# NOTE! The executable should always have a ZERO as exit code otherwise
+# the coverage generation will not complete.
+#
+# setup_target_for_coverage_gcovr_html(
+#     NAME ctest_coverage                    # New target name
+#     EXECUTABLE ctest -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
+#     DEPENDENCIES executable_target         # Dependencies to build first
+#     BASE_DIRECTORY "../"                   # Base directory for report
+#                                            #  (defaults to PROJECT_SOURCE_DIR)
+#     EXCLUDE "src/dir1/*" "src/dir2/*"      # Patterns to exclude (can be relative
+#                                            #  to BASE_DIRECTORY, with CMake 3.4+)
+# )
+function(setup_target_for_coverage_gcovr_html)
+
+    set(options NONE)
+    set(oneValueArgs BASE_DIRECTORY NAME)
+    set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES)
+    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(NOT GCOVR_PATH)
+        message(FATAL_ERROR "gcovr not found! Aborting...")
+    endif() # NOT GCOVR_PATH
+
+    # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
+    if(${Coverage_BASE_DIRECTORY})
+        get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
+    else()
+        set(BASEDIR ${PROJECT_SOURCE_DIR})
+    endif()
+
+    # Collect excludes (CMake 3.4+: Also compute absolute paths)
+    set(GCOVR_EXCLUDES "")
+    foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_GCOVR_EXCLUDES})
+        if(CMAKE_VERSION VERSION_GREATER 3.4)
+            get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
+        endif()
+        list(APPEND GCOVR_EXCLUDES "${EXCLUDE}")
+    endforeach()
+    list(REMOVE_DUPLICATES GCOVR_EXCLUDES)
+
+    # Combine excludes to several -e arguments
+    set(GCOVR_EXCLUDE_ARGS "")
+    foreach(EXCLUDE ${GCOVR_EXCLUDES})
+        list(APPEND GCOVR_EXCLUDE_ARGS "-e")
+        list(APPEND GCOVR_EXCLUDE_ARGS "${EXCLUDE}")
+    endforeach()
+
+    add_custom_target(${Coverage_NAME}
+            # Run tests
+            ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
+
+            # Create folder
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${PROJECT_BINARY_DIR}/${Coverage_NAME}
+
+            # Running gcovr
+            COMMAND ${GCOVR_PATH} --html --html-details
+            -r ${BASEDIR} ${GCOVR_EXCLUDE_ARGS}
+            --object-directory=${PROJECT_BINARY_DIR}
+            -o ${Coverage_NAME}/index.html
+
+            BYPRODUCTS ${PROJECT_BINARY_DIR}/${Coverage_NAME}  # report directory
+            WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
+            DEPENDS ${Coverage_DEPENDENCIES}
+            VERBATIM # Protect arguments to commands
+            COMMENT "Running gcovr to produce HTML code coverage report."
+            )
+
+    # Show info where to find the report
+    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
+            COMMAND ;
+            COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
+            )
+
+endfunction() # setup_target_for_coverage_gcovr_html
+
+function(append_coverage_compiler_flags)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${COVERAGE_COMPILER_FLAGS}" PARENT_SCOPE)
+    message(STATUS "Appending code coverage compiler flags: ${COVERAGE_COMPILER_FLAGS}")
+endfunction() # append_coverage_compiler_flags

--- a/cmake/CodeCoverage.cmake
+++ b/cmake/CodeCoverage.cmake
@@ -181,108 +181,6 @@ endif()
 # NOTE! The executable should always have a ZERO as exit code otherwise
 # the coverage generation will not complete.
 #
-# setup_target_for_coverage_lcov(
-#     NAME testrunner_coverage                    # New target name
-#     EXECUTABLE testrunner -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
-#     DEPENDENCIES testrunner                     # Dependencies to build first
-#     BASE_DIRECTORY "../"                        # Base directory for report
-#                                                 #  (defaults to PROJECT_SOURCE_DIR)
-#     EXCLUDE "src/dir1/*" "src/dir2/*"           # Patterns to exclude (can be relative
-#                                                 #  to BASE_DIRECTORY, with CMake 3.4+)
-#     NO_DEMANGLE                                 # Don't demangle C++ symbols
-#                                                 #  even if c++filt is found
-# )
-function(setup_target_for_coverage_lcov)
-
-    set(options NO_DEMANGLE)
-    set(oneValueArgs BASE_DIRECTORY NAME)
-    set(multiValueArgs EXCLUDE EXECUTABLE EXECUTABLE_ARGS DEPENDENCIES LCOV_ARGS GENHTML_ARGS)
-    cmake_parse_arguments(Coverage "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
-
-    if(NOT LCOV_PATH)
-        message(FATAL_ERROR "lcov not found! Aborting...")
-    endif() # NOT LCOV_PATH
-
-    if(NOT GENHTML_PATH)
-        message(FATAL_ERROR "genhtml not found! Aborting...")
-    endif() # NOT GENHTML_PATH
-
-    # Set base directory (as absolute path), or default to PROJECT_SOURCE_DIR
-    if(${Coverage_BASE_DIRECTORY})
-        get_filename_component(BASEDIR ${Coverage_BASE_DIRECTORY} ABSOLUTE)
-    else()
-        set(BASEDIR ${PROJECT_SOURCE_DIR})
-    endif()
-
-    # Collect excludes (CMake 3.4+: Also compute absolute paths)
-    set(LCOV_EXCLUDES "")
-    foreach(EXCLUDE ${Coverage_EXCLUDE} ${COVERAGE_EXCLUDES} ${COVERAGE_LCOV_EXCLUDES})
-        if(CMAKE_VERSION VERSION_GREATER 3.4)
-            get_filename_component(EXCLUDE ${EXCLUDE} ABSOLUTE BASE_DIR ${BASEDIR})
-        endif()
-        list(APPEND LCOV_EXCLUDES "${EXCLUDE}")
-    endforeach()
-    list(REMOVE_DUPLICATES LCOV_EXCLUDES)
-
-    # Conditional arguments
-    if(CPPFILT_PATH AND NOT ${Coverage_NO_DEMANGLE})
-        set(GENHTML_EXTRA_ARGS "--demangle-cpp")
-    endif()
-
-    # Setup target
-    add_custom_target(${Coverage_NAME}
-
-            # Cleanup lcov
-            COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -directory . -b ${BASEDIR} --zerocounters
-            # Create baseline to make sure untouched files show up in the report
-            COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -c -i -d . -b ${BASEDIR} -o ${Coverage_NAME}.base
-
-            # Run tests
-            COMMAND ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
-
-            # Capturing lcov counters and generating report
-            COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --directory . -b ${BASEDIR} --capture --output-file ${Coverage_NAME}.capture
-            # add baseline counters
-            COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -a ${Coverage_NAME}.base -a ${Coverage_NAME}.capture --output-file ${Coverage_NAME}.total
-            # filter collected data to final coverage report
-            COMMAND ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --remove ${Coverage_NAME}.total ${LCOV_EXCLUDES} --output-file ${Coverage_NAME}.info
-
-            # Generate HTML output
-            COMMAND ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS} -o ${Coverage_NAME} ${Coverage_NAME}.info
-
-            # Set output files as GENERATED (will be removed on 'make clean')
-            BYPRODUCTS
-            ${Coverage_NAME}.base
-            ${Coverage_NAME}.capture
-            ${Coverage_NAME}.total
-            ${Coverage_NAME}.info
-            ${Coverage_NAME}  # report directory
-
-            WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
-            DEPENDS ${Coverage_DEPENDENCIES}
-            VERBATIM # Protect arguments to commands
-            COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
-            )
-
-    # Show where to find the lcov info report
-    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
-            COMMAND ;
-            COMMENT "Lcov code coverage info report saved in ${Coverage_NAME}.info."
-            )
-
-    # Show info where to find the report
-    add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
-            COMMAND ;
-            COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
-            )
-
-endfunction() # setup_target_for_coverage_lcov
-
-# Defines a target for running and collection code coverage information
-# Builds dependencies, runs the given executable and outputs reports.
-# NOTE! The executable should always have a ZERO as exit code otherwise
-# the coverage generation will not complete.
-#
 # setup_target_for_coverage_gcovr_xml(
 #     NAME ctest_coverage                    # New target name
 #     EXECUTABLE ctest -j ${PROCESSOR_COUNT} # Executable in PROJECT_BINARY_DIR
@@ -335,8 +233,12 @@ function(setup_target_for_coverage_gcovr_xml)
             COMMAND ${GCOVR_PATH} --xml
             -r ${BASEDIR} ${GCOVR_EXCLUDE_ARGS}
             --object-directory=${PROJECT_BINARY_DIR}
-            -o ${Coverage_NAME}.xml
-            BYPRODUCTS ${Coverage_NAME}.xml
+            -o ${Coverage_NAME}.xml &&
+            ${GCOVR_PATH}
+            -r ${BASEDIR} ${GCOVR_EXCLUDE_ARGS}
+            --object-directory=${PROJECT_BINARY_DIR}
+            > ${Coverage_NAME}.txt
+            BYPRODUCTS ${Coverage_NAME}.xml ${Coverage_NAME}.txt
             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
             DEPENDS ${Coverage_DEPENDENCIES}
             VERBATIM # Protect arguments to commands

--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -1,11 +1,11 @@
 [requires]
-gtest/1.8.1@bincrafters/stable
+gtest/1.10.0
 fmt/6.1.2
-h5cpp/0.3.1@ess-dmsc/stable
+h5cpp/2cfb0ad@ess-dmsc/stable
 librdkafka/1.2.0@ess-dmsc/stable
 jsonformoderncpp/3.6.1@vthiery/stable
 streaming-data-types/65e23a1@ess-dmsc/stable
-CLI11/1.8.0@cliutils/stable
+CLI11/1.9.0@cliutils/stable
 trompeloeil/v36@rollbear/stable
 spdlog-graylog/1.5.0-dm1@ess-dmsc/stable
 date/4b46deb@ess-dmsc/stable

--- a/conan/conanfile_no_graylog.txt
+++ b/conan/conanfile_no_graylog.txt
@@ -1,11 +1,11 @@
 [requires]
-gtest/1.8.1@bincrafters/stable
+gtest/1.10.0
 fmt/6.0.0@bincrafters/stable
-h5cpp/0.3.1@ess-dmsc/stable
+h5cpp/2cfb0ad@ess-dmsc/stable
 librdkafka/1.2.0@ess-dmsc/stable
 jsonformoderncpp/3.6.1@vthiery/stable
 streaming-data-types/65e23a1@ess-dmsc/stable
-CLI11/1.8.0@cliutils/stable
+CLI11/1.9.0@cliutils/stable
 trompeloeil/v36@rollbear/stable
 spdlog/1.4.2@bincrafters/stable
 date/4b46deb@ess-dmsc/stable

--- a/docker_launch.sh
+++ b/docker_launch.sh
@@ -17,7 +17,7 @@ then
    echo "Kafka broker not accessible at file writer launch"
    exit 1
 fi
-export LD_LIBRARY_PATH=/kafka_to_nexus/lib/
+export LD_LIBRARY_PATH=/home/root/kafka_to_nexus/lib/
 
 COMMAND_URI="${COMMAND_URI:=//localhost:9092/TEST_writerCommand}"
 STATUS_URI="${STATUS_URI:=//localhost:9092/TEST_writerStatus}"
@@ -26,7 +26,7 @@ HDF_OUTPUT_PREFIX="${HDF_OUTPUT_PREFIX:=/output-files/}"
 
 if [ -z "$CONFIG_FILE" ]
 then
-    COMMAND=/kafka_to_nexus/bin/kafka-to-nexus\ --command-uri\ "${COMMAND_URI}"\ \
+    COMMAND=/home/root/kafka_to_nexus/bin/kafka-to-nexus\ --command-uri\ "${COMMAND_URI}"\ \
       --status-uri\ "${STATUS_URI}"\ \
       --graylog-logger-address\ "${GRAYLOG_ADDRESS}"\ \
       --hdf-output-prefix\ "${HDF_OUTPUT_PREFIX}"\ \
@@ -36,7 +36,7 @@ then
     $COMMAND
 
 else
-    COMMAND=/kafka_to_nexus/bin/kafka-to-nexus\ --config-file\ "${CONFIG_FILE}"
+    COMMAND=/home/root/kafka_to_nexus/bin/kafka-to-nexus\ --config-file\ "${CONFIG_FILE}"
 
     echo $COMMAND
     $COMMAND

--- a/src/FileWriterTask.cpp
+++ b/src/FileWriterTask.cpp
@@ -9,7 +9,6 @@
 
 #include "FileWriterTask.h"
 #include "DemuxTopic.h"
-#include "EventLogger.h"
 #include "HDFFile.h"
 #include "KafkaW/ProducerTopic.h"
 #include "Source.h"

--- a/src/KafkaW/BrokerSettings.h
+++ b/src/KafkaW/BrokerSettings.h
@@ -22,7 +22,6 @@ struct BrokerSettings {
   int PollTimeoutMS = 100;
   int MetadataTimeoutMS = 2000;
   int OffsetsForTimesTimeoutMS = 2000;
-  int ConsumerCloseTimeoutMS = 5000;
   std::map<std::string, std::string> KafkaConfiguration = {
       {"metadata.request.timeout.ms", "2000"}, // 2 Secs
       {"socket.timeout.ms", "2000"},

--- a/src/MainOpt.cpp
+++ b/src/MainOpt.cpp
@@ -8,10 +8,7 @@
 // Screaming Udder!                              https://esss.se
 
 #include "MainOpt.h"
-#include "URI.h"
 #include "helper.h"
-#include "json.h"
-#include <iostream>
 
 using uri::URI;
 

--- a/src/Source.cpp
+++ b/src/Source.cpp
@@ -8,6 +8,7 @@
 // Screaming Udder!                              https://esss.se
 
 #include "Source.h"
+#include "ProcessMessageResult.h"
 
 namespace FileWriter {
 

--- a/src/Source.h
+++ b/src/Source.h
@@ -9,14 +9,14 @@
 
 #pragma once
 
-#include "FlatbufferReader.h"
 #include "HDFFile.h"
-#include "ProcessMessageResult.h"
 #include "WriterModuleBase.h"
 #include "logger.h"
 #include <string>
 
 namespace FileWriter {
+
+enum class ProcessMessageResult;
 
 /// \brief Represents a sourcename on a topic.
 ///

--- a/src/States.h
+++ b/src/States.h
@@ -9,9 +9,7 @@
 
 #pragma once
 
-#include <memory>
 #include <mpark/variant.hpp>
-#include <string>
 
 struct MainOpt;
 

--- a/src/Streamer.h
+++ b/src/Streamer.h
@@ -13,15 +13,13 @@
 
 #pragma once
 
-#include "EventLogger.h"
+#include "FlatbufferMessage.h"
 #include "KafkaW/Consumer.h"
 #include "StreamStatus.h"
 #include "StreamerOptions.h"
 #include "logger.h"
 #include <chrono>
 #include <future>
-#include <memory>
-#include <utility>
 
 namespace FileWriter {
 class DemuxTopic;

--- a/src/WriterModuleBase.h
+++ b/src/WriterModuleBase.h
@@ -10,10 +10,7 @@
 #pragma once
 
 #include "FlatbufferMessage.h"
-#include <fmt/format.h>
-#include <functional>
 #include <h5cpp/hdf5.hpp>
-#include <map>
 #include <memory>
 #include <string>
 

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -14,7 +14,6 @@
 #include <string>
 #ifdef HAVE_GRAYLOG_LOGGER
 #include <graylog_logger/GraylogInterface.hpp>
-#include <graylog_logger/Log.hpp>
 #include <spdlog/sinks/graylog_sink.h>
 #endif
 

--- a/src/tests/DemuxerTests.cpp
+++ b/src/tests/DemuxerTests.cpp
@@ -7,6 +7,7 @@
 //
 // Screaming Udder!                              https://esss.se
 
+#include "FlatbufferReader.h"
 #include "helpers/StubWriterModule.h"
 #include <DemuxTopic.h>
 #include <gtest/gtest.h>

--- a/src/tests/StreamerTestMocks.h
+++ b/src/tests/StreamerTestMocks.h
@@ -2,6 +2,7 @@
 
 #include <trompeloeil.hpp>
 
+#include "FlatbufferReader.h"
 #include "Streamer.h"
 
 namespace FileWriter {

--- a/src/tests/StreamerTests.cpp
+++ b/src/tests/StreamerTests.cpp
@@ -8,6 +8,7 @@
 // Screaming Udder!                              https://esss.se
 
 #include <chrono>
+#include <f142_logdata_generated.h>
 #include <flatbuffers/flatbuffers.h>
 #include <gtest/gtest.h>
 #include <trompeloeil.hpp>
@@ -18,7 +19,6 @@
 #include "Streamer.h"
 #include "StreamerTestMocks.h"
 #include "helpers/SetExtractorModule.h"
-#include <f142_logdata_generated.h>
 
 namespace FileWriter {
 

--- a/src/tests/writer_module/WriterRegistrationTests.cpp
+++ b/src/tests/writer_module/WriterRegistrationTests.cpp
@@ -10,7 +10,6 @@
 #include "../json.h"
 #include "WriterRegistrar.h"
 #include "helpers/StubWriterModule.h"
-#include <WriterModuleBase.h>
 #include <gtest/gtest.h>
 
 using namespace FileWriter;

--- a/src/tests/writer_module/ns10_WriterTests.cpp
+++ b/src/tests/writer_module/ns10_WriterTests.cpp
@@ -8,7 +8,6 @@
 // Screaming Udder!                              https://esss.se
 
 #include <flatbuffers/flatbuffers.h>
-#include <fstream>
 #include <gtest/gtest.h>
 #include <memory>
 

--- a/system-tests/README.md
+++ b/system-tests/README.md
@@ -16,6 +16,8 @@ Requires Python 3.6+.
 
 * Stop and remove any containers that may interfere with the system tests, e.g IOC or Kafka containers and containers from previous runs. To stop and remove all containers use `docker stop $(docker ps -a -q) && docker rm $(docker ps -a -q)`
 
+* If you have a local conan server then set environment variable `local_conan_server=<ADDRESS OF SERVER>`, if there are binaries for conan packages on the server this makes a huge difference in time taken to build the file writer docker image.
+
 * Run `python -m pytest -s .` from the `system-tests/` directory
 
 * Optionally use `--local-build <PATH_TO_BUILD_DIR>` to run against a local build of the file writer rather than rebuilding in a docker container. Note that the build directory is the one containing the `bin` directory.

--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -134,6 +134,8 @@ def build_filewriter_image(request):
             build_args["https_proxy"] = os.environ["https_proxy"]
         if "local_conan_server" in os.environ:
             build_args["local_conan_server"] = os.environ["local_conan_server"]
+        if "upload_conan_packages" in os.environ:
+            build_args["upload_conan_packages"] = os.environ["upload_conan_packages"]
         image, logs = client.images.build(
             path="../", tag="kafka-to-nexus:latest", rm=False, buildargs=build_args
         )

--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -134,8 +134,6 @@ def build_filewriter_image(request):
             build_args["https_proxy"] = os.environ["https_proxy"]
         if "local_conan_server" in os.environ:
             build_args["local_conan_server"] = os.environ["local_conan_server"]
-        if "upload_conan_packages" in os.environ:
-            build_args["upload_conan_packages"] = os.environ["upload_conan_packages"]
         image, logs = client.images.build(
             path="../", tag="kafka-to-nexus:latest", rm=False, buildargs=build_args
         )

--- a/system-tests/test_filewriter_static_data.py
+++ b/system-tests/test_filewriter_static_data.py
@@ -23,11 +23,11 @@ def test_static_data_reaches_file(docker_compose):
     filepath = "output-files/output_file_static.nxs"
     with OpenNexusFileWhenAvailable(filepath) as file:
         assert not file.swmr_mode
-        assert file["entry/start_time"].value == "2016-04-12T02:58:52"
-        assert file["entry/end_time"].value == "2016-04-12T03:29:11"
-        assert file["entry/duration"].value == 1817.0
+        assert file["entry/start_time"][()] == "2016-04-12T02:58:52"
+        assert file["entry/end_time"][()] == "2016-04-12T03:29:11"
+        assert file["entry/duration"][()] == 1817.0
         assert file["entry/features"][0] == 10138143369737381149
-        assert file["entry/user_1/affiliation"].value == "ISIS, STFC"
+        assert file["entry/user_1/affiliation"][()] == "ISIS, STFC"
         assert np.allclose(
             file["entry/instrument/monitor1/transformations/location"].attrs["vector"],
             np.array([0.0, 0.0, -1.0]),


### PR DESCRIPTION
Base the docker image on Alpine 11, which has gcc 9.2.
Makes the image smaller and faster to build for system tests.

Also adds an alpine pipeline build, which will ensure we have package binaries on the conan server for the system test image to use. Having a gcc 9.2 build already should also mean those of us who run Ubuntu can switch to Ubuntu 20.04 LTS as soon as it is released in April.

Removed CentOS-debug and Debian10 builds.