### PR TITLE
Fix crash when service id is missing from run start or stop message

### DIFF
--- a/src/CommandListener.cpp
+++ b/src/CommandListener.cpp
@@ -26,7 +26,9 @@ void CommandListener::start() {
   BrokerSettings.Address = config.CommandBrokerURI.HostPort;
   consumer = KafkaW::createConsumer(BrokerSettings, BrokerSettings.Address);
   if (consumer->topicPresent(config.CommandBrokerURI.Topic))
-    consumer->addTopic(config.CommandBrokerURI.Topic);
+    // consumer->addTopic(config.CommandBrokerURI.Topic);
+    consumer->addTopicAtTimestamp(config.CommandBrokerURI.Topic,
+                                  std::chrono::milliseconds{1582759520275});
   else {
     Logger->error(
         "Topic {} not in broker. Could not start listener for topic {}.",

--- a/src/CommandListener.cpp
+++ b/src/CommandListener.cpp
@@ -26,9 +26,7 @@ void CommandListener::start() {
   BrokerSettings.Address = config.CommandBrokerURI.HostPort;
   consumer = KafkaW::createConsumer(BrokerSettings, BrokerSettings.Address);
   if (consumer->topicPresent(config.CommandBrokerURI.Topic))
-    // consumer->addTopic(config.CommandBrokerURI.Topic);
-    consumer->addTopicAtTimestamp(config.CommandBrokerURI.Topic,
-                                  std::chrono::milliseconds{1582759520275});
+    consumer->addTopic(config.CommandBrokerURI.Topic);
   else {
     Logger->error(
         "Topic {} not in broker. Could not start listener for topic {}.",

--- a/src/CommandParser.cpp
+++ b/src/CommandParser.cpp
@@ -20,26 +20,30 @@
 namespace {
 void checkRequiredFieldsArePresent(const RunStart *RunStartData) {
   std::stringstream Errors;
-  if (RunStartData->job_id()->size() == 0) {
+  if (RunStartData->job_id() == nullptr ||
+      RunStartData->job_id()->size() == 0) {
     Errors << "Job ID missing, this field is required\n";
   }
 
-  if (RunStartData->nexus_structure()->size() == 0) {
+  if (RunStartData->nexus_structure() == nullptr ||
+      RunStartData->nexus_structure()->size() == 0) {
     Errors << "NeXus Structure missing, this field is "
               "required\n";
   }
 
-  if (RunStartData->filename()->size() == 0) {
+  if (RunStartData->filename() == nullptr ||
+      RunStartData->filename()->size() == 0) {
     Errors << "Filename missing, this field is required\n";
   }
 
-  if (RunStartData->broker()->size() == 0) {
+  if (RunStartData->broker() == nullptr ||
+      RunStartData->broker()->size() == 0) {
     Errors << "Broker missing, this field is required\n";
   } else {
     try {
       uri::URI(RunStartData->broker()->str());
     } catch (const std::runtime_error &URIError) {
-      Errors << "Broker missing, this field is required\n";
+      Errors << "Unable to parse broker address\n";
     }
   }
 
@@ -71,7 +75,9 @@ extractStartInformation(Msg const &CommandMessage,
   Result.StopTime = std::chrono::milliseconds{RunStartData->stop_time()};
   Result.NexusStructure = RunStartData->nexus_structure()->str();
   Result.JobID = RunStartData->job_id()->str();
-  Result.ServiceID = RunStartData->service_id()->str();
+  if (RunStartData->service_id() != nullptr) {
+    Result.ServiceID = RunStartData->service_id()->str();
+  }
   Result.BrokerInfo = uri::URI(RunStartData->broker()->str());
   Result.Filename = RunStartData->filename()->str();
 
@@ -90,7 +96,9 @@ StopCommandInfo extractStopInformation(Msg const &CommandMessage) {
 
   Result.JobID = RunStopData->job_id()->str();
   Result.StopTime = std::chrono::milliseconds{RunStopData->stop_time()};
-  Result.ServiceID = RunStopData->service_id()->str();
+  if (RunStopData->service_id() != nullptr) {
+    Result.ServiceID = RunStopData->service_id()->str();
+  }
 
   return Result;
 }

--- a/src/tests/helpers/RunStartStopHelpers.cpp
+++ b/src/tests/helpers/RunStartStopHelpers.cpp
@@ -1,13 +1,14 @@
 #include "Msg.h"
 
 #include <6s4t_run_stop_generated.h>
+#include <nonstd/optional.hpp>
 #include <pl72_run_start_generated.h>
 
 namespace RunStartStopHelpers {
 FileWriter::Msg buildRunStartMessage(
     std::string const &InstrumentName, std::string const &RunName,
     std::string const &NexusStructure, std::string const &JobID,
-    std::string const &ServiceID, std::string const &Broker,
+    nonstd::optional<std::string> const &ServiceID, std::string const &Broker,
     std::string const &Filename, uint64_t StartTime, uint64_t StopTime) {
   flatbuffers::FlatBufferBuilder Builder;
 
@@ -15,32 +16,53 @@ FileWriter::Msg buildRunStartMessage(
   const auto RunIDOffset = Builder.CreateString(RunName);
   const auto NexusStructureOffset = Builder.CreateString(NexusStructure);
   const auto JobIDOffset = Builder.CreateString(JobID);
-  const auto ServiceIDOffset = Builder.CreateString(ServiceID);
+  flatbuffers::Offset<flatbuffers::String> ServiceIDOffset;
+  if (ServiceID) {
+    ServiceIDOffset = Builder.CreateString(*ServiceID);
+  }
   const auto BrokerOffset = Builder.CreateString(Broker);
   const auto FilenameOffset = Builder.CreateString(Filename);
 
-  auto messageRunStart =
-      CreateRunStart(Builder, StartTime, StopTime, RunIDOffset,
-                     InstrumentNameOffset, NexusStructureOffset, JobIDOffset,
-                     BrokerOffset, ServiceIDOffset, FilenameOffset);
+  RunStartBuilder StartBuilder{Builder};
+  StartBuilder.add_start_time(StartTime);
+  StartBuilder.add_stop_time(StopTime);
+  StartBuilder.add_run_name(RunIDOffset);
+  StartBuilder.add_instrument_name(InstrumentNameOffset);
+  StartBuilder.add_nexus_structure(NexusStructureOffset);
+  StartBuilder.add_job_id(JobIDOffset);
+  StartBuilder.add_broker(BrokerOffset);
+  if (ServiceID) {
+    StartBuilder.add_service_id(ServiceIDOffset);
+  }
+  StartBuilder.add_filename(FilenameOffset);
+  auto messageRunStart = StartBuilder.Finish();
 
   FinishRunStartBuffer(Builder, messageRunStart);
   auto MessageBuffer = Builder.Release();
   return {MessageBuffer.data(), MessageBuffer.size()};
 }
 
-FileWriter::Msg buildRunStopMessage(uint64_t StopTime,
-                                    std::string const &RunName,
-                                    std::string const &JobID,
-                                    std::string const &ServiceID) {
+FileWriter::Msg
+buildRunStopMessage(uint64_t StopTime, std::string const &RunName,
+                    std::string const &JobID,
+                    nonstd::optional<std::string> const &ServiceID) {
   flatbuffers::FlatBufferBuilder Builder;
 
   const auto RunIDOffset = Builder.CreateString(RunName);
   const auto JobIDOffset = Builder.CreateString(JobID);
-  const auto ServiceIDOffset = Builder.CreateString(ServiceID);
+  flatbuffers::Offset<flatbuffers::String> ServiceIDOffset;
+  if (ServiceID) {
+    ServiceIDOffset = Builder.CreateString(*ServiceID);
+  }
 
-  auto messageRunStop = CreateRunStop(Builder, StopTime, RunIDOffset,
-                                      JobIDOffset, ServiceIDOffset);
+  RunStopBuilder StopBuilder{Builder};
+  StopBuilder.add_stop_time(StopTime);
+  StopBuilder.add_run_name(RunIDOffset);
+  StopBuilder.add_job_id(JobIDOffset);
+  if (ServiceID) {
+    StopBuilder.add_service_id(ServiceIDOffset);
+  }
+  auto messageRunStop = StopBuilder.Finish();
 
   FinishRunStopBuffer(Builder, messageRunStop);
   auto MessageBuffer = Builder.Release();

--- a/src/tests/helpers/RunStartStopHelpers.h
+++ b/src/tests/helpers/RunStartStopHelpers.h
@@ -17,11 +17,11 @@ namespace RunStartStopHelpers {
 FileWriter::Msg buildRunStartMessage(
     std::string const &InstrumentName, std::string const &RunName,
     std::string const &NexusStructure, std::string const &JobID,
-    std::string const &ServiceID, std::string const &Broker,
+    nonstd::optional<std::string> const &ServiceID, std::string const &Broker,
     std::string const &Filename, uint64_t StartTime, uint64_t StopTime);
 
-FileWriter::Msg buildRunStopMessage(uint64_t StopTime,
-                                    std::string const &RunName,
-                                    std::string const &JobID,
-                                    std::string const &ServiceID);
+FileWriter::Msg
+buildRunStopMessage(uint64_t StopTime, std::string const &RunName,
+                    std::string const &JobID,
+                    nonstd::optional<std::string> const &ServiceID);
 } // namespace RunStartStopHelpers


### PR DESCRIPTION
### Issue
DM-1859

### Description of work

Fix is to check for `nullptr` before accessing service id field of flatbuffer.
Covered by new unit tests for start and stop message parsing.

### Nominate for Group Code Review

- [ ] Nominate for code review 

