### PR TITLE
Ns10 bug

### DIFF
--- a/src/schemas/ns10/NicosCacheWriter.cpp
+++ b/src/schemas/ns10/NicosCacheWriter.cpp
@@ -70,11 +70,11 @@ CacheWriter::init_hdf(hdf5::node::Group &HDFGroup,
         DefaultChunkSize);          // NOLINT(bugprone-unused-raii)
     auto AttributesJson = nlohmann::json::parse(HDFAttributes);
     FileWriter::writeAttributes(HDFGroup, &AttributesJson, Logger);
-    if(HDFGroup.attributes.exists("NX_class")){
-       Logger->info("NX_class already specified!");
+    if (HDFGroup.attributes.exists("NX_class")) {
+      Logger->info("NX_class already specified!");
     } else {
       auto ClassAttribute =
-        CurrentGroup.attributes.create<std::string>("NX_class");
+          CurrentGroup.attributes.create<std::string>("NX_class");
       ClassAttribute.write("NXlog");
     }
   } catch (std::exception &E) {

--- a/src/schemas/ns10/NicosCacheWriter.cpp
+++ b/src/schemas/ns10/NicosCacheWriter.cpp
@@ -68,11 +68,15 @@ CacheWriter::init_hdf(hdf5::node::Group &HDFGroup,
         CurrentGroup,               // NOLINT(bugprone-unused-raii)
         NeXusDataset::Mode::Create, // NOLINT(bugprone-unused-raii)
         DefaultChunkSize);          // NOLINT(bugprone-unused-raii)
-    auto ClassAttribute =
-        CurrentGroup.attributes.create<std::string>("NX_class");
-    ClassAttribute.write("NXlog");
     auto AttributesJson = nlohmann::json::parse(HDFAttributes);
     FileWriter::writeAttributes(HDFGroup, &AttributesJson, Logger);
+    if(HDFGroup.attributes.exists("NX_class")){
+       Logger->info("NX_class already specified!");
+    } else {
+      auto ClassAttribute =
+        CurrentGroup.attributes.create<std::string>("NX_class");
+      ClassAttribute.write("NXlog");
+    }
   } catch (std::exception &E) {
     Logger->error("Unable to initialise areaDetector data tree in "
                   "HDF file with error message: \"{}\"",


### PR DESCRIPTION
### Issue

**DM-1905**

### Description of work

When implementing a NICOS CacheStream I hit a problem that the NicoscachReader.cpp refused to write data. The issue is that it got a NX_class attribute from the NICOS passed json but still tried to set NX_class itself. This made him baulk at a duplicate attribute and refuse to write because it thought the structure is wrong. 

I modified src/schemas/ns10/NicosCacheWriter.cpp around line 70 to check for NX_class after writing the attributes from the json and add a NX_class attribute only when it is not present. This mirrors the logic in f142_rw.cpp. 

### Nominate for Group Code Review

- [ x] Nominate for code review 

