### PR TITLE
Pinning ubuntu version tag in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:bionic-20200112
 
 ARG http_proxy
 ARG https_proxy


### PR DESCRIPTION
### Issue

*Specify the associated JIRA ticket, e.g. DM-1234.*

### Description of work

The system tests docker builds are failing, so we are going to try and pin an older version of ubuntu rather than using the latest `ubuntu:18.04` image from docker hub to see if that fixes it. 

### Nominate for Group Code Review

- [ ] Nominate for code review 

