### PR TITLE
Revert dependency injection of executor

### DIFF
--- a/src/Kafka/Consumer.cpp
+++ b/src/Kafka/Consumer.cpp
@@ -9,7 +9,6 @@
 
 #include "Consumer.h"
 #include "MetadataException.h"
-#include "Msg.h"
 #include <algorithm>
 #include <atomic>
 #include <chrono>

--- a/src/Kafka/Consumer.h
+++ b/src/Kafka/Consumer.h
@@ -12,6 +12,7 @@
 #include "BrokerSettings.h"
 #include "ConsumerRebalanceCb.h"
 #include "KafkaEventCb.h"
+#include "Msg.h"
 #include "PollStatus.h"
 #include <chrono>
 #include <librdkafka/rdkafkacpp.h>
@@ -144,5 +145,59 @@ private:
   getOffsets(std::vector<RdKafka::TopicPartition *> const &TopicPartitions);
   static void deletePartitions(
       std::vector<RdKafka::TopicPartition *> const &TopicPartitions);
+};
+
+class StubConsumer : public ConsumerInterface {
+public:
+  ~StubConsumer() override = default;
+
+  void addTopic(std::string const &Topic) override { UNUSED_ARG(Topic); };
+
+  void addTopicAtTimestamp(std::string const &Topic,
+                           std::chrono::milliseconds StartTime) override {
+    UNUSED_ARG(Topic);
+    UNUSED_ARG(StartTime);
+  };
+
+  std::pair<PollStatus, FileWriter::Msg> poll() override {
+    return {PollStatus::TimedOut, FileWriter::Msg()};
+  };
+  bool topicPresent(const std::string &Topic) override {
+    UNUSED_ARG(Topic);
+    return true;
+  };
+
+  std::vector<int32_t>
+  queryTopicPartitions(const std::string &TopicName) override {
+    UNUSED_ARG(TopicName);
+    return {};
+  };
+
+  std::vector<int64_t>
+  offsetsForTimesAllPartitions(std::string const &Topic,
+                               std::chrono::milliseconds Time) override {
+    UNUSED_ARG(Topic);
+    UNUSED_ARG(Time);
+    return {};
+  };
+
+  void addPartitionAtOffset(std::string const &Topic, int PartitionId,
+                            int64_t Offset) override {
+    UNUSED_ARG(Topic);
+    UNUSED_ARG(PartitionId);
+    UNUSED_ARG(Offset);
+  };
+
+  int64_t getHighWatermarkOffset(std::string const &Topic,
+                                 int32_t Partition) override {
+    UNUSED_ARG(Topic);
+    UNUSED_ARG(Partition);
+    return 0;
+  };
+
+  std::vector<int64_t> getCurrentOffsets(std::string const &Topic) override {
+    UNUSED_ARG(Topic);
+    return {};
+  };
 };
 } // namespace Kafka

--- a/src/Kafka/ConsumerFactory.cpp
+++ b/src/Kafka/ConsumerFactory.cpp
@@ -46,4 +46,15 @@ std::unique_ptr<Consumer> createConsumer(const BrokerSettings &Settings,
 std::unique_ptr<Consumer> createConsumer(BrokerSettings const &Settings) {
   return createConsumer(Settings, Settings.Address);
 }
+
+std::unique_ptr<ConsumerInterface>
+ConsumerFactory::createConsumer(const BrokerSettings &Settings) {
+  return Kafka::createConsumer(Settings);
+}
+
+std::unique_ptr<ConsumerInterface>
+ConsumerFactory::createConsumer(const BrokerSettings &Settings,
+                                const std::string &Broker) {
+  return Kafka::createConsumer(Settings, Broker);
+}
 } // namespace Kafka

--- a/src/Kafka/ConsumerFactory.cpp
+++ b/src/Kafka/ConsumerFactory.cpp
@@ -51,10 +51,4 @@ std::unique_ptr<ConsumerInterface>
 ConsumerFactory::createConsumer(const BrokerSettings &Settings) {
   return Kafka::createConsumer(Settings);
 }
-
-std::unique_ptr<ConsumerInterface>
-ConsumerFactory::createConsumer(const BrokerSettings &Settings,
-                                const std::string &Broker) {
-  return Kafka::createConsumer(Settings, Broker);
-}
 } // namespace Kafka

--- a/src/Kafka/ConsumerFactory.h
+++ b/src/Kafka/ConsumerFactory.h
@@ -16,4 +16,40 @@ namespace Kafka {
 std::unique_ptr<Consumer> createConsumer(const BrokerSettings &Settings,
                                          const std::string &Broker);
 std::unique_ptr<Consumer> createConsumer(BrokerSettings const &Settings);
+
+class ConsumerFactoryInterface {
+public:
+  virtual std::unique_ptr<ConsumerInterface>
+  createConsumer(const BrokerSettings &Settings, const std::string &Broker) = 0;
+  virtual std::unique_ptr<ConsumerInterface>
+  createConsumer(BrokerSettings const &Settings) = 0;
+  virtual ~ConsumerFactoryInterface() = default;
+};
+
+class ConsumerFactory : public ConsumerFactoryInterface {
+public:
+  std::unique_ptr<ConsumerInterface>
+  createConsumer(const BrokerSettings &Settings,
+                 const std::string &Broker) override;
+  std::unique_ptr<ConsumerInterface>
+  createConsumer(BrokerSettings const &Settings) override;
+  ~ConsumerFactory() override = default;
+};
+
+class StubConsumerFactory : public ConsumerFactoryInterface {
+public:
+  std::unique_ptr<ConsumerInterface>
+  createConsumer(const BrokerSettings &Settings,
+                 const std::string &Broker) override {
+    UNUSED_ARG(Settings);
+    UNUSED_ARG(Broker);
+    return std::unique_ptr<ConsumerInterface>(new StubConsumer());
+  };
+  std::unique_ptr<ConsumerInterface>
+  createConsumer(BrokerSettings const &Settings) override {
+    UNUSED_ARG(Settings);
+    return std::unique_ptr<ConsumerInterface>(new StubConsumer());
+  };
+  ~StubConsumerFactory() override = default;
+};
 } // namespace Kafka

--- a/src/Kafka/ConsumerFactory.h
+++ b/src/Kafka/ConsumerFactory.h
@@ -20,8 +20,6 @@ std::unique_ptr<Consumer> createConsumer(BrokerSettings const &Settings);
 class ConsumerFactoryInterface {
 public:
   virtual std::unique_ptr<ConsumerInterface>
-  createConsumer(const BrokerSettings &Settings, const std::string &Broker) = 0;
-  virtual std::unique_ptr<ConsumerInterface>
   createConsumer(BrokerSettings const &Settings) = 0;
   virtual ~ConsumerFactoryInterface() = default;
 };
@@ -29,22 +27,12 @@ public:
 class ConsumerFactory : public ConsumerFactoryInterface {
 public:
   std::unique_ptr<ConsumerInterface>
-  createConsumer(const BrokerSettings &Settings,
-                 const std::string &Broker) override;
-  std::unique_ptr<ConsumerInterface>
   createConsumer(BrokerSettings const &Settings) override;
   ~ConsumerFactory() override = default;
 };
 
 class StubConsumerFactory : public ConsumerFactoryInterface {
 public:
-  std::unique_ptr<ConsumerInterface>
-  createConsumer(const BrokerSettings &Settings,
-                 const std::string &Broker) override {
-    UNUSED_ARG(Settings);
-    UNUSED_ARG(Broker);
-    return std::unique_ptr<ConsumerInterface>(new StubConsumer());
-  };
   std::unique_ptr<ConsumerInterface>
   createConsumer(BrokerSettings const &Settings) override {
     UNUSED_ARG(Settings);

--- a/src/Stream/Topic.cpp
+++ b/src/Stream/Topic.cpp
@@ -15,6 +15,20 @@
 
 namespace Stream {
 
+Topic::Topic(Kafka::BrokerSettings const &Settings, std::string const &Topic,
+             SrcToDst Map, MessageWriter *Writer,
+             Metrics::Registrar &RegisterMetric, time_point StartTime,
+             duration StartTimeLeeway, time_point StopTime,
+             duration StopTimeLeeway,
+             std::unique_ptr<Kafka::ConsumerFactoryInterface> CreateConsumers)
+    : KafkaSettings(Settings), TopicName(Topic), DataMap(std::move(Map)),
+      WriterPtr(Writer), StartConsumeTime(StartTime),
+      StartLeeway(StartTimeLeeway), StopConsumeTime(StopTime),
+      StopLeeway(StopTimeLeeway),
+      CurrentMetadataTimeOut(Settings.MinMetadataTimeout),
+      Registrar(RegisterMetric.getNewRegistrar(Topic)),
+      ConsumerCreator(std::move(CreateConsumers)) {}
+
 void Topic::start() {
   Executor.sendWork([=]() { initMetadataCalls(KafkaSettings, TopicName); });
 }

--- a/src/Stream/Topic.cpp
+++ b/src/Stream/Topic.cpp
@@ -20,7 +20,7 @@ Topic::Topic(Kafka::BrokerSettings const &Settings, std::string const &Topic,
              Metrics::Registrar &RegisterMetric, time_point StartTime,
              duration StartTimeLeeway, time_point StopTime,
              duration StopTimeLeeway,
-             std::unique_ptr<Kafka::ConsumerFactoryInterface> CreateConsumers)
+             std::unique_ptr<Kafka::ConsumerFactoryInterface> CreateConsumers = std::make_unique<Kafka::ConsumerFactory>())
     : KafkaSettings(Settings), TopicName(Topic), DataMap(std::move(Map)),
       WriterPtr(Writer), StartConsumeTime(StartTime),
       StartLeeway(StartTimeLeeway), StopConsumeTime(StopTime),

--- a/src/Stream/Topic.cpp
+++ b/src/Stream/Topic.cpp
@@ -20,7 +20,8 @@ Topic::Topic(Kafka::BrokerSettings const &Settings, std::string const &Topic,
              Metrics::Registrar &RegisterMetric, time_point StartTime,
              duration StartTimeLeeway, time_point StopTime,
              duration StopTimeLeeway,
-             std::unique_ptr<Kafka::ConsumerFactoryInterface> CreateConsumers = std::make_unique<Kafka::ConsumerFactory>())
+             std::unique_ptr<Kafka::ConsumerFactoryInterface> CreateConsumers =
+                 std::make_unique<Kafka::ConsumerFactory>())
     : KafkaSettings(Settings), TopicName(Topic), DataMap(std::move(Map)),
       WriterPtr(Writer), StartConsumeTime(StartTime),
       StartLeeway(StartTimeLeeway), StopConsumeTime(StopTime),

--- a/src/Stream/Topic.cpp
+++ b/src/Stream/Topic.cpp
@@ -15,24 +15,12 @@
 
 namespace Stream {
 
-Topic::Topic(Kafka::BrokerSettings const &Settings, std::string const &Topic,
-             SrcToDst Map, MessageWriter *Writer,
-             Metrics::Registrar &RegisterMetric, time_point StartTime,
-             duration StartTimeLeeway, time_point StopTime,
-             duration StopTimeLeeway)
-    : KafkaSettings(Settings), TopicName(Topic), DataMap(std::move(Map)),
-      WriterPtr(Writer), StartConsumeTime(StartTime),
-      StartLeeway(StartTimeLeeway), StopConsumeTime(StopTime),
-      StopLeeway(StopTimeLeeway),
-      CurrentMetadataTimeOut(Settings.MinMetadataTimeout),
-      Registrar(RegisterMetric.getNewRegistrar(Topic)) {}
-
 void Topic::start() {
   Executor.sendWork([=]() { initMetadataCalls(KafkaSettings, TopicName); });
 }
 
-void Topic::initMetadataCalls(Kafka::BrokerSettings Settings,
-                              std::string Topic) {
+void Topic::initMetadataCalls(Kafka::BrokerSettings const &Settings,
+                              std::string const &Topic) {
   Executor.sendWork([=]() {
     CurrentMetadataTimeOut = Settings.MinMetadataTimeout;
     getPartitionsForTopic(Settings, Topic);
@@ -45,8 +33,8 @@ void Topic::setStopTime(std::chrono::system_clock::time_point StopTime) {
   }
 }
 
-void Topic::getPartitionsForTopic(Kafka::BrokerSettings Settings,
-                                  std::string Topic) {
+void Topic::getPartitionsForTopic(Kafka::BrokerSettings const &Settings,
+                                  std::string const &Topic) {
   try {
     auto FoundPartitions = getPartitionsForTopicInternal(
         Settings.Address, Topic, Settings.MinMetadataTimeout);
@@ -73,21 +61,22 @@ void Topic::getPartitionsForTopic(Kafka::BrokerSettings Settings,
 }
 
 std::vector<std::pair<int, int64_t>>
-Topic::getOffsetForTimeInternal(std::string Broker, std::string Topic,
-                                std::vector<int> Partitions, time_point Time,
-                                duration TimeOut) const {
+Topic::getOffsetForTimeInternal(std::string const &Broker,
+                                std::string const &Topic,
+                                std::vector<int> const &Partitions,
+                                time_point Time, duration TimeOut) const {
   return Kafka::getOffsetForTime(Broker, Topic, Partitions, Time, TimeOut);
 }
 
-std::vector<int> Topic::getPartitionsForTopicInternal(std::string Broker,
-                                                      std::string Topic,
+std::vector<int> Topic::getPartitionsForTopicInternal(std::string const &Broker,
+                                                      std::string const &Topic,
                                                       duration TimeOut) const {
   return Kafka::getPartitionsForTopic(Broker, Topic, TimeOut);
 }
 
-void Topic::getOffsetsForPartitions(Kafka::BrokerSettings Settings,
-                                    std::string Topic,
-                                    std::vector<int> Partitions) {
+void Topic::getOffsetsForPartitions(Kafka::BrokerSettings const &Settings,
+                                    std::string const &Topic,
+                                    std::vector<int> const &Partitions) {
   try {
     auto PartitionOffsetList = getOffsetForTimeInternal(
         Settings.Address, Topic, Partitions, StartConsumeTime - StartLeeway,
@@ -115,12 +104,12 @@ void Topic::getOffsetsForPartitions(Kafka::BrokerSettings Settings,
 }
 
 void Topic::createStreams(
-    Kafka::BrokerSettings Settings, std::string Topic,
-    std::vector<std::pair<int, int64_t>> PartitionOffsets) {
+    Kafka::BrokerSettings const &Settings, std::string const &Topic,
+    std::vector<std::pair<int, int64_t>> const &PartitionOffsets) {
   for (const auto &CParOffset : PartitionOffsets) {
     auto CRegistrar = Registrar.getNewRegistrar(
         "partition_" + std::to_string(CParOffset.first));
-    auto Consumer = Kafka::createConsumer(Settings);
+    auto Consumer = ConsumerCreator->createConsumer(Settings);
     Consumer->addPartitionAtOffset(Topic, CParOffset.first, CParOffset.second);
     auto TempPartition = std::make_unique<Partition>(
         std::move(Consumer), CParOffset.first, Topic, DataMap, WriterPtr,

--- a/src/Stream/Topic.h
+++ b/src/Stream/Topic.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "Kafka/BrokerSettings.h"
+#include "Kafka/ConsumerFactory.h"
 #include "Metrics/Registrar.h"
 #include "Partition.h"
 #include "Stream/MessageWriter.h"
@@ -25,7 +26,15 @@ public:
   Topic(Kafka::BrokerSettings const &Settings, std::string const &Topic,
         SrcToDst Map, MessageWriter *Writer, Metrics::Registrar &RegisterMetric,
         time_point StartTime, duration StartTimeLeeway, time_point StopTime,
-        duration StopTimeLeeway);
+        duration StopTimeLeeway,
+        std::unique_ptr<Kafka::ConsumerFactoryInterface> CreateConsumers)
+      : KafkaSettings(Settings), TopicName(Topic), DataMap(std::move(Map)),
+        WriterPtr(Writer), StartConsumeTime(StartTime),
+        StartLeeway(StartTimeLeeway), StopConsumeTime(StopTime),
+        StopLeeway(StopTimeLeeway),
+        CurrentMetadataTimeOut(Settings.MinMetadataTimeout),
+        Registrar(RegisterMetric.getNewRegistrar(Topic)),
+        ConsumerCreator(std::move(CreateConsumers)) {}
 
   /// \brief Must be called after the constructor.
   /// \note This function exist in order to make unit testing possible.
@@ -48,30 +57,32 @@ protected:
   Metrics::Registrar Registrar;
 
   // This intermediate function is required for unit testing.
-  virtual void initMetadataCalls(Kafka::BrokerSettings Settings,
-                                 std::string Topic);
+  virtual void initMetadataCalls(Kafka::BrokerSettings const &Settings,
+                                 std::string const &Topic);
 
-  virtual void getPartitionsForTopic(Kafka::BrokerSettings Settings,
-                                     std::string Topic);
+  virtual void getPartitionsForTopic(Kafka::BrokerSettings const &Settings,
+                                     std::string const &Topic);
 
-  virtual void getOffsetsForPartitions(Kafka::BrokerSettings Settings,
-                                       std::string Topic,
-                                       std::vector<int> Partitions);
+  virtual void getOffsetsForPartitions(Kafka::BrokerSettings const &Settings,
+                                       std::string const &Topic,
+                                       std::vector<int> const &Partitions);
 
   virtual void
-  createStreams(Kafka::BrokerSettings Settings, std::string Topic,
-                std::vector<std::pair<int, int64_t>> PartitionOffsets);
+  createStreams(Kafka::BrokerSettings const &Settings, std::string const &Topic,
+                std::vector<std::pair<int, int64_t>> const &PartitionOffsets);
 
   virtual std::vector<std::pair<int, int64_t>>
-  getOffsetForTimeInternal(std::string Broker, std::string Topic,
-                           std::vector<int> Partitions, time_point Time,
+  getOffsetForTimeInternal(std::string const &Broker, std::string const &Topic,
+                           std::vector<int> const &Partitions, time_point Time,
                            duration TimeOut) const;
 
   virtual std::vector<int>
-  getPartitionsForTopicInternal(std::string Broker, std::string Topic,
+  getPartitionsForTopicInternal(std::string const &Broker,
+                                std::string const &Topic,
                                 duration TimeOut) const;
 
   std::vector<std::unique_ptr<Partition>> ConsumerThreads;
+  std::unique_ptr<Kafka::ConsumerFactoryInterface> ConsumerCreator;
   ThreadedExecutor Executor; // Must be last
 };
 } // namespace Stream

--- a/src/Stream/Topic.h
+++ b/src/Stream/Topic.h
@@ -27,14 +27,7 @@ public:
         SrcToDst Map, MessageWriter *Writer, Metrics::Registrar &RegisterMetric,
         time_point StartTime, duration StartTimeLeeway, time_point StopTime,
         duration StopTimeLeeway,
-        std::unique_ptr<Kafka::ConsumerFactoryInterface> CreateConsumers)
-      : KafkaSettings(Settings), TopicName(Topic), DataMap(std::move(Map)),
-        WriterPtr(Writer), StartConsumeTime(StartTime),
-        StartLeeway(StartTimeLeeway), StopConsumeTime(StopTime),
-        StopLeeway(StopTimeLeeway),
-        CurrentMetadataTimeOut(Settings.MinMetadataTimeout),
-        Registrar(RegisterMetric.getNewRegistrar(Topic)),
-        ConsumerCreator(std::move(CreateConsumers)) {}
+        std::unique_ptr<Kafka::ConsumerFactoryInterface> CreateConsumers);
 
   /// \brief Must be called after the constructor.
   /// \note This function exist in order to make unit testing possible.

--- a/src/ThreadedExecutor.h
+++ b/src/ThreadedExecutor.h
@@ -17,13 +17,6 @@
 
 using JobType = std::function<void()>;
 
-class IExecutor {
-public:
-  virtual ~IExecutor() = default;
-  virtual void sendWork(JobType Task) = 0;
-  virtual void sendLowPriorityWork(JobType Task) = 0;
-};
-
 /// \brief Class for executing jobs in a separate "worker thread".
 ///
 /// This implementation uses two work/task queues: high priority and low
@@ -33,7 +26,7 @@ public:
 /// \note The execution order of jobs in a queue can not be guaranteed. In
 /// fact, it is likely that all the tasks produced by one thread will be
 /// completed before the tasks produced by another thread.
-class ThreadedExecutor : public IExecutor {
+class ThreadedExecutor {
 private:
 public:
   /// \brief Constructor of ThreadedExecutor.
@@ -51,19 +44,21 @@ public:
     } else {
       sendWork([=]() { RunThread = false; });
     }
-    WorkerThread.join();
+    if (WorkerThread.joinable()) {
+      WorkerThread.join();
+    }
   }
   /// \brief Put tasks in the high priority queue.
   ///
   /// \param Task The std::function that will be executed when processing the
   /// task.
-  void sendWork(JobType Task) override { TaskQueue.enqueue(std::move(Task)); }
+  void sendWork(JobType Task) { TaskQueue.enqueue(std::move(Task)); }
 
   /// \brief Put tasks in the low priority queue.
   ///
   /// \param Task The std::function that will be executed when processing the
   /// task.
-  void sendLowPriorityWork(JobType Task) override {
+  void sendLowPriorityWork(JobType Task) {
     LowPriorityTaskQueue.enqueue(std::move(Task));
   }
 

--- a/src/tests/Stream/PartitionTests.cpp
+++ b/src/tests/Stream/PartitionTests.cpp
@@ -82,8 +82,6 @@ void waitUntilDoneProcessing(PartitionStandIn *UnderTest) {
   Future.wait();
 }
 
-// Tests disabled due to being sensitive to thread scheduling
-
 class PartitionTest : public ::testing::Test {
 public:
   auto createTestedInstance(Stream::time_point StopTime =

--- a/src/tests/Stream/PartitionTests.cpp
+++ b/src/tests/Stream/PartitionTests.cpp
@@ -53,8 +53,8 @@ public:
                    Stream::time_point Stop, Stream::duration StopLeeway,
                    Stream::duration KafkaErrorTimeout)
       : Stream::Partition(std::move(Consumer), Partition, std::move(TopicName),
-                          Map, Writer, std::move(RegisterMetric), Start, Stop, StopLeeway,
-                          KafkaErrorTimeout) {}
+                          Map, Writer, std::move(RegisterMetric), Start, Stop,
+                          StopLeeway, KafkaErrorTimeout) {}
   void addPollTask() override {
     // Do nothing as don't want to automatically poll again
   }

--- a/src/tests/Stream/PartitionTests.cpp
+++ b/src/tests/Stream/PartitionTests.cpp
@@ -17,11 +17,6 @@
 using std::chrono_literals::operator""s;
 using trompeloeil::_;
 
-class ImmediateExecutor : public IExecutor {
-  void sendWork(JobType Task) override { Task(); }
-  void sendLowPriorityWork(JobType Task) override { Task(); }
-};
-
 class SourceFilterStandInAlt : public Stream::SourceFilter {
 public:
   SourceFilterStandInAlt()
@@ -58,7 +53,7 @@ public:
                    Stream::time_point Stop, Stream::duration StopLeeway,
                    Stream::duration KafkaErrorTimeout)
       : Stream::Partition(std::move(Consumer), Partition, std::move(TopicName),
-                          Map, Writer, RegisterMetric, Start, Stop, StopLeeway,
+                          Map, Writer, std::move(RegisterMetric), Start, Stop, StopLeeway,
                           KafkaErrorTimeout) {}
   void addPollTask() override {
     // Do nothing as don't want to automatically poll again
@@ -77,9 +72,19 @@ public:
   using Partition::StopTimeLeeway;
 };
 
+void waitUntilDoneProcessing(PartitionStandIn *UnderTest) {
+  // Queue a job in the executor and block until it is complete
+  // so that we know previously queued job that is part of test should
+  // now have been executed
+  std::promise<bool> Promise;
+  auto Future = Promise.get_future();
+  UnderTest->Executor.sendWork([&Promise]() { Promise.set_value(true); });
+  Future.wait();
+}
+
 // Tests disabled due to being sensitive to thread scheduling
 
-class DISABLED_PartitionTest : public ::testing::Test {
+class PartitionTest : public ::testing::Test {
 public:
   auto createTestedInstance(Stream::time_point StopTime =
                                 std::chrono::system_clock::time_point::max()) {
@@ -108,7 +113,7 @@ public:
   std::array<char, 9> SomeData{'z', 'z', 'z', 'z', 'z', 'z', 'z', 'z', 'z'};
 };
 
-TEST_F(DISABLED_PartitionTest, OnConstructionValuesAreAsExpected) {
+TEST_F(PartitionTest, OnConstructionValuesAreAsExpected) {
   auto StopTime = Start + 20s;
   auto UnderTest = createTestedInstance(StopTime);
   EXPECT_EQ(UnderTest->getPartitionID(), UsedPartitionId);
@@ -117,13 +122,13 @@ TEST_F(DISABLED_PartitionTest, OnConstructionValuesAreAsExpected) {
   EXPECT_EQ(UnderTest->StopTime, StopTime);
 }
 
-TEST_F(DISABLED_PartitionTest, IfStopTimeTooCloseToMaxThenItIsBackedOff) {
+TEST_F(PartitionTest, IfStopTimeTooCloseToMaxThenItIsBackedOff) {
   auto StopTime = std::chrono::system_clock::time_point::max() - StopLeeway / 2;
   auto UnderTest = createTestedInstance(StopTime);
   EXPECT_EQ(UnderTest->StopTime, StopTime - StopLeeway);
 }
 
-TEST_F(DISABLED_PartitionTest, EmptyMessageIsIgnored) {
+TEST_F(PartitionTest, EmptyMessageIsIgnored) {
   auto UnderTest = createTestedInstance();
   Kafka::MockConsumer::PollReturnType PollReturn;
   PollReturn.first = Kafka::PollStatus::Empty;
@@ -132,7 +137,7 @@ TEST_F(DISABLED_PartitionTest, EmptyMessageIsIgnored) {
   EXPECT_EQ(int(UnderTest->MessagesReceived), 0);
 }
 
-TEST_F(DISABLED_PartitionTest, ActualMessageIsCounted) {
+TEST_F(PartitionTest, ActualMessageIsCounted) {
   Kafka::MockConsumer::PollReturnType PollReturn;
   PollReturn.first = Kafka::PollStatus::Message;
   auto UnderTest = createTestedInstance();
@@ -141,7 +146,7 @@ TEST_F(DISABLED_PartitionTest, ActualMessageIsCounted) {
   EXPECT_EQ(int(UnderTest->MessagesReceived), 1);
 }
 
-TEST_F(DISABLED_PartitionTest, TimeoutMessageIsCountedButThenIgnored) {
+TEST_F(PartitionTest, TimeoutMessageIsCountedButThenIgnored) {
   Kafka::MockConsumer::PollReturnType PollReturn;
   PollReturn.first = Kafka::PollStatus::TimedOut;
   auto UnderTest = createTestedInstance();
@@ -151,7 +156,7 @@ TEST_F(DISABLED_PartitionTest, TimeoutMessageIsCountedButThenIgnored) {
   EXPECT_EQ(int(UnderTest->KafkaTimeouts), 1);
 }
 
-TEST_F(DISABLED_PartitionTest, ErrorMessageIsCountedButThenIgnored) {
+TEST_F(PartitionTest, ErrorMessageIsCountedButThenIgnored) {
   Kafka::MockConsumer::PollReturnType PollReturn;
   PollReturn.first = Kafka::PollStatus::Error;
   auto UnderTest = createTestedInstance();
@@ -161,7 +166,7 @@ TEST_F(DISABLED_PartitionTest, ErrorMessageIsCountedButThenIgnored) {
   EXPECT_EQ(int(UnderTest->KafkaErrors), 1);
 }
 
-TEST_F(DISABLED_PartitionTest, EndOfPartitionMessageIsIgnored) {
+TEST_F(PartitionTest, EndOfPartitionMessageIsIgnored) {
   Kafka::MockConsumer::PollReturnType PollReturn;
   PollReturn.first = Kafka::PollStatus::EndOfPartition;
   auto UnderTest = createTestedInstance();
@@ -170,7 +175,7 @@ TEST_F(DISABLED_PartitionTest, EndOfPartitionMessageIsIgnored) {
   EXPECT_EQ(int(UnderTest->MessagesReceived), 0);
 }
 
-TEST_F(DISABLED_PartitionTest, WithNoFiltersPartitionIsFinishedOnMessage) {
+TEST_F(PartitionTest, WithNoFiltersPartitionIsFinishedOnMessage) {
   Kafka::MockConsumer::PollReturnType PollReturn;
   PollReturn.first = Kafka::PollStatus::Message;
   auto UnderTest = createTestedInstance();
@@ -180,7 +185,7 @@ TEST_F(DISABLED_PartitionTest, WithNoFiltersPartitionIsFinishedOnMessage) {
   EXPECT_TRUE(UnderTest->hasFinished());
 }
 
-TEST_F(DISABLED_PartitionTest, MessageWithInvalidFlatBufferIsNotProcessed) {
+TEST_F(PartitionTest, MessageWithInvalidFlatBufferIsNotProcessed) {
   FileWriter::MessageMetaData MetaData{
       std::chrono::duration_cast<std::chrono::milliseconds>(
           (Start + 10s).time_since_epoch()),
@@ -195,7 +200,7 @@ TEST_F(DISABLED_PartitionTest, MessageWithInvalidFlatBufferIsNotProcessed) {
   EXPECT_EQ(int(UnderTest->FlatbufferErrors), 1);
 }
 
-TEST_F(DISABLED_PartitionTest, MessageWithinStopLeewayDoesNotTriggerFinished) {
+TEST_F(PartitionTest, MessageWithinStopLeewayDoesNotTriggerFinished) {
   Stop = Start + 20s;
   FileWriter::MessageMetaData MetaData{
       std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -210,7 +215,7 @@ TEST_F(DISABLED_PartitionTest, MessageWithinStopLeewayDoesNotTriggerFinished) {
   EXPECT_FALSE(UnderTest->hasFinished());
 }
 
-TEST_F(DISABLED_PartitionTest, MessageAfterStopLeewayTriggersFinished) {
+TEST_F(PartitionTest, MessageAfterStopLeewayTriggersFinished) {
   Stop = Start + 20s;
   FileWriter::MessageMetaData MetaData{
       std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -225,7 +230,7 @@ TEST_F(DISABLED_PartitionTest, MessageAfterStopLeewayTriggersFinished) {
   EXPECT_TRUE(UnderTest->hasFinished());
 }
 
-TEST_F(DISABLED_PartitionTest, FiltersAreInitialisedWithOriginalStoptime) {
+TEST_F(PartitionTest, FiltersAreInitialisedWithOriginalStoptime) {
   auto StopTime = Start + 100s;
   auto UnderTest = createTestedInstance(StopTime);
 
@@ -234,17 +239,18 @@ TEST_F(DISABLED_PartitionTest, FiltersAreInitialisedWithOriginalStoptime) {
   }
 }
 
-TEST_F(DISABLED_PartitionTest, SetStopTimePropagatesToFilters) {
+TEST_F(PartitionTest, SetStopTimePropagatesToFilters) {
   auto NewStopTime = Start + 12445s;
   auto UnderTest = createTestedInstance();
   UnderTest->setStopTime(NewStopTime);
 
+  waitUntilDoneProcessing(UnderTest.get());
   for (auto &CFilter : UnderTest->MsgFilters) {
     EXPECT_EQ(CFilter.second->getStopTime(), NewStopTime);
   }
 }
 
-TEST_F(DISABLED_PartitionTest, IfSourceHashUnknownThenNotProcessed) {
+TEST_F(PartitionTest, IfSourceHashUnknownThenNotProcessed) {
   auto UnderTest = createTestedInstance();
   auto TestFilter = std::make_unique<SourceFilterStandInAlt>();
   UnderTest->MsgFilters.clear();
@@ -256,7 +262,7 @@ TEST_F(DISABLED_PartitionTest, IfSourceHashUnknownThenNotProcessed) {
   EXPECT_EQ(int(UnderTest->MessagesProcessed), 0);
 }
 
-TEST_F(DISABLED_PartitionTest, IfSourceHashIsKnownThenItIsProcessed) {
+TEST_F(PartitionTest, IfSourceHashIsKnownThenItIsProcessed) {
   auto UnderTest = createTestedInstance();
   auto TestFilter = std::make_unique<SourceFilterStandInAlt>();
   auto TestFilterPtr = TestFilter.get();
@@ -269,7 +275,7 @@ TEST_F(DISABLED_PartitionTest, IfSourceHashIsKnownThenItIsProcessed) {
   EXPECT_EQ(int(UnderTest->MessagesProcessed), 1);
 }
 
-TEST_F(DISABLED_PartitionTest, FilterNotRemovedIfNotDone) {
+TEST_F(PartitionTest, FilterNotRemovedIfNotDone) {
   auto UnderTest = createTestedInstance();
   auto TestFilter = std::make_unique<SourceFilterStandInAlt>();
   auto TestFilterPtr = TestFilter.get();
@@ -283,7 +289,7 @@ TEST_F(DISABLED_PartitionTest, FilterNotRemovedIfNotDone) {
   EXPECT_EQ(UnderTest->MsgFilters.size(), OldSize);
 }
 
-TEST_F(DISABLED_PartitionTest, FilterIsRemovedWhenDone) {
+TEST_F(PartitionTest, FilterIsRemovedWhenDone) {
   auto UnderTest = createTestedInstance();
   auto TestFilter = std::make_unique<SourceFilterStandInAlt>();
   auto TestFilterPtr = TestFilter.get();

--- a/src/tests/Stream/TopicTests.cpp
+++ b/src/tests/Stream/TopicTests.cpp
@@ -75,6 +75,17 @@ public:
   }
 };
 
+void waitUntilDoneProcessing(TopicStandIn *UnderTest) {
+  // Queue a job in the executor and block until it is complete
+  // so that we know previously queued job that is part of test should
+  // now have been executed
+  std::promise<bool> Promise;
+  auto Future = Promise.get_future();
+  UnderTest->Executor.sendLowPriorityWork(
+      [&Promise]() { Promise.set_value(true); });
+  Future.wait();
+}
+
 class TopicTest : public ::testing::Test {
 public:
   auto createTestedInstance() {
@@ -98,12 +109,7 @@ TEST_F(TopicTest, StartMetaDataCall) {
   REQUIRE_CALL(*UnderTest, getPartitionsForTopic(_, UsedTopicName)).TIMES(1);
   UnderTest->initMetadataCallsBase(KafkaSettings, UsedTopicName);
 
-  // Wait until we are done processing "getPartitionsForTopic
-  std::promise<bool> Promise;
-  auto Future = Promise.get_future();
-  UnderTest->Executor.sendLowPriorityWork(
-      [&Promise]() { Promise.set_value(true); });
-  Future.wait();
+  waitUntilDoneProcessing(UnderTest.get());
 }
 
 TEST_F(TopicTest, GetPartitionsForTopicException) {
@@ -115,12 +121,7 @@ TEST_F(TopicTest, GetPartitionsForTopicException) {
       .THROW(MetadataException("Test"));
   UnderTest->getPartitionsForTopicBase(KafkaSettings, UsedTopicName);
 
-  // Wait until we are done processing "getPartitionsForTopic
-  std::promise<bool> Promise;
-  auto Future = Promise.get_future();
-  UnderTest->Executor.sendLowPriorityWork(
-      [&Promise]() { Promise.set_value(true); });
-  Future.wait();
+  waitUntilDoneProcessing(UnderTest.get());
 }
 
 TEST_F(TopicTest, GetPartitionsForTopicNoException) {
@@ -135,12 +136,7 @@ TEST_F(TopicTest, GetPartitionsForTopicNoException) {
       .TIMES(1);
   UnderTest->getPartitionsForTopicBase(KafkaSettings, UsedTopicName);
 
-  // Wait until we are done processing "getPartitionsForTopic
-  std::promise<bool> Promise;
-  auto Future = Promise.get_future();
-  UnderTest->Executor.sendLowPriorityWork(
-      [&Promise]() { Promise.set_value(true); });
-  Future.wait();
+  waitUntilDoneProcessing(UnderTest.get());
 }
 
 TEST_F(TopicTest, GetOffsetsForPartitionsException) {
@@ -156,12 +152,7 @@ TEST_F(TopicTest, GetOffsetsForPartitionsException) {
   UnderTest->getOffsetsForPartitionsBase(KafkaSettings, UsedTopicName,
                                          Partitions);
 
-  // Wait until we are done processing "getOffsetsForPartitions
-  std::promise<bool> Promise;
-  auto Future = Promise.get_future();
-  UnderTest->Executor.sendLowPriorityWork(
-      [&Promise]() { Promise.set_value(true); });
-  Future.wait();
+  waitUntilDoneProcessing(UnderTest.get());
 }
 
 TEST_F(TopicTest, GetOffsetsForPartitionsNoException) {
@@ -178,12 +169,7 @@ TEST_F(TopicTest, GetOffsetsForPartitionsNoException) {
   UnderTest->getOffsetsForPartitionsBase(KafkaSettings, UsedTopicName,
                                          Partitions);
 
-  // Wait until we are done processing "getOffsetsForPartitions
-  std::promise<bool> Promise;
-  auto Future = Promise.get_future();
-  UnderTest->Executor.sendLowPriorityWork(
-      [&Promise]() { Promise.set_value(true); });
-  Future.wait();
+  waitUntilDoneProcessing(UnderTest.get());
 }
 
 TEST_F(TopicTest, CreateStreams) {

--- a/system-tests/requirements.txt
+++ b/system-tests/requirements.txt
@@ -5,4 +5,4 @@ docker>=3.4.1
 h5py>=2.8.0
 flatbuffers>=1.11
 black==19.3b0
-https://github.com/ess-dmsc/python-streaming-data-types/releases/download/0.3.0/streaming_data_types-0.3.0-py3-none-any.whl
+ess-streaming-data-types


### PR DESCRIPTION
- Reverts `PartitionTests` changes that were made to enable dependency injection of Executor since this turns out to be unviable.

- Use a factory to create consumers so we avoid making real consumers in `TopicTests`. Since poll is not re-called in the tests we were guaranteed to have to wait for the consumer destruction timeout of 5 seconds, which on my machine is the same as the run time for all other unit tests put together.

- Added `const &` for many method parameters in `Topic`.

- Minor refactoring in `TopicTests` to aid understanding of what is being tested and why.