### PR TITLE
Make kafka config flag consistent with kafkacat

### DIFF
--- a/src/CLIOptions.cpp
+++ b/src/CLIOptions.cpp
@@ -207,7 +207,7 @@ void setCLIOptions(CLI::App &App, MainOpt &MainOptions) {
       "abandoning stream.",
       true);
   addKafkaOption(
-      App, "-S,--kafka-config",
+      App, "-X,--kafka-config",
       MainOptions.StreamerConfiguration.BrokerSettings.KafkaConfiguration,
       "LibRDKafka options");
   App.add_option("--use-hdf-swmr", MainOptions.UseHdfSwmr,


### PR DESCRIPTION
I suggest we change the flag for the Kafka config option from `-S` to `-X` to match kafkacat and kafkacow.