### PR TITLE
Update dependencies, including librdkafka

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -8,7 +8,7 @@ to ignore repeated updates from the Forwarder, which are sent to ensure there is
 from shortly before the start of each file being written. ([#551](https://github.com/ess-dmsc/kafka-to-nexus/pull/551))
 - The application is no longer (completely) blocking when doing initial set-up kafka meta data calls. ([#554](https://github.com/ess-dmsc/kafka-to-nexus/pull/554))
 - Fixed bug which caused f142 messages with value of zero to be written as a different value. ([#556](https://github.com/ess-dmsc/kafka-to-nexus/pull/556))
-- Updated conan package dependencies:
+ Updated conan package dependencies ([#557](https://github.com/ess-dmsc/kafka-to-nexus/pull/557)):
   - librdkafka
   -  streaming-data-types
   -  CLI11

--- a/changes.md
+++ b/changes.md
@@ -7,3 +7,8 @@ This feature is turned on for all writer modules except event messages (`ev42`).
 to ignore repeated updates from the Forwarder, which are sent to ensure there is an update available on Kafka
 from shortly before the start of each file being written.
 - The application is no longer (completely) blocking when doing initial set-up kafka meta data calls.
+- Updated dependencies:
+  - librdkafka
+  -  streaming-data-types
+  -  CLI11
+  -  trompeloeil

--- a/changes.md
+++ b/changes.md
@@ -8,8 +8,8 @@ to ignore repeated updates from the Forwarder, which are sent to ensure there is
 from shortly before the start of each file being written. ([#551](https://github.com/ess-dmsc/kafka-to-nexus/pull/551))
 - The application is no longer (completely) blocking when doing initial set-up kafka meta data calls. ([#554](https://github.com/ess-dmsc/kafka-to-nexus/pull/554))
 - Fixed bug which caused f142 messages with value of zero to be written as a different value. ([#556](https://github.com/ess-dmsc/kafka-to-nexus/pull/556))
- Updated conan package dependencies ([#557](https://github.com/ess-dmsc/kafka-to-nexus/pull/557)):
+- Updated conan package dependencies ([#557](https://github.com/ess-dmsc/kafka-to-nexus/pull/557)):
   - librdkafka
-  -  streaming-data-types
-  -  CLI11
-  -  trompeloeil
+  - streaming-data-types
+  - CLI11
+  - trompeloeil

--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -2,11 +2,11 @@
 gtest/1.10.0
 fmt/6.1.2
 h5cpp/2cfb0ad@ess-dmsc/stable
-librdkafka/1.2.0@ess-dmsc/stable
+librdkafka/1.5.0@ess-dmsc/stable
 jsonformoderncpp/3.7.3@vthiery/stable
-streaming-data-types/96fd730@ess-dmsc/stable
-CLI11/1.9.0@cliutils/stable
-trompeloeil/v36@rollbear/stable
+streaming-data-types/3966e53@ess-dmsc/stable
+CLI11/1.9.1@cliutils/stable
+trompeloeil/v38@rollbear/stable
 spdlog-graylog/1.5.0-dm1@ess-dmsc/stable
 date/4b46deb@ess-dmsc/stable
 asio/1.13.0

--- a/conan/conanfile_no_graylog.txt
+++ b/conan/conanfile_no_graylog.txt
@@ -2,11 +2,11 @@
 gtest/1.10.0
 fmt/6.0.0
 h5cpp/2cfb0ad@ess-dmsc/stable
-librdkafka/1.2.0@ess-dmsc/stable
+librdkafka/1.5.0@ess-dmsc/stable
 jsonformoderncpp/3.7.3@vthiery/stable
-streaming-data-types/96fd730@ess-dmsc/stable
-CLI11/1.9.0@cliutils/stable
-trompeloeil/v36@rollbear/stable
+streaming-data-types/3966e53@ess-dmsc/stable
+CLI11/1.9.1@cliutils/stable
+trompeloeil/v38@rollbear/stable
 spdlog/1.4.2
 date/4b46deb@ess-dmsc/stable
 asio/1.13.0

--- a/src/tests/helpers/MockMessage.h
+++ b/src/tests/helpers/MockMessage.h
@@ -28,6 +28,7 @@ public:
   MAKE_CONST_MOCK0(msg_opaque, void *());
   MAKE_CONST_MOCK0(latency, int64_t());
   MAKE_CONST_MOCK0(status, RdKafka::Message::Status());
+  MAKE_CONST_MOCK0(broker_id, int32_t());
   MAKE_MOCK0(headers, RdKafka::Headers *());
   MAKE_MOCK1(headers, RdKafka::Headers *(RdKafka::ErrorCode *));
   MAKE_MOCK0(c_ptr, rd_kafka_message_s *());

--- a/src/tests/helpers/RdKafkaMocks.h
+++ b/src/tests/helpers/RdKafkaMocks.h
@@ -136,7 +136,7 @@ public:
   MAKE_MOCK1(subscription, RdKafka::ErrorCode(std::vector<std::string> &),
              override);
   MAKE_MOCK1(controllerid, int32_t(int), override);
-  MAKE_MOCK1(fatal_error, RdKafka::ErrorCode(std::string &), override);
+  MAKE_CONST_MOCK1(fatal_error, RdKafka::ErrorCode(std::string &), override);
   MAKE_MOCK5(oauthbearer_set_token,
              RdKafka::ErrorCode(const std::string &, int64_t,
                                 const std::string &,
@@ -144,6 +144,7 @@ public:
              override);
   MAKE_MOCK1(oauthbearer_set_token_failure,
              RdKafka::ErrorCode(const std::string &), override);
+  MAKE_MOCK0(groupMetadata, RdKafka::ConsumerGroupMetadata *(), override);
 
 private:
   int metadataCallCounter = 0;
@@ -210,7 +211,7 @@ public:
              override);
   MAKE_MOCK1(flush, RdKafka::ErrorCode(int), override);
   MAKE_MOCK1(controllerid, int32_t(int), override);
-  MAKE_MOCK1(fatal_error, RdKafka::ErrorCode(std::string &), override);
+  MAKE_CONST_MOCK1(fatal_error, RdKafka::ErrorCode(std::string &), override);
   MAKE_MOCK5(oauthbearer_set_token,
              RdKafka::ErrorCode(const std::string &, int64_t,
                                 const std::string &,
@@ -224,13 +225,11 @@ public:
                                  RdKafka::Headers *, void *),
               override);
   MAKE_MOCK1(purge, RdKafka::ErrorCode(int), override);
-#if RD_KAFKA_VERSION >= 0x010400ff
   IMPLEMENT_MOCK1(init_transactions);
   IMPLEMENT_MOCK0(begin_transaction);
   IMPLEMENT_MOCK3(send_offsets_to_transaction);
   IMPLEMENT_MOCK1(commit_transaction);
   IMPLEMENT_MOCK1(abort_transaction);
-#endif
 };
 
 class MockConf : public RdKafka::Conf {


### PR DESCRIPTION
Updates
- librdkafka
- streaming-data-types
- CLI11
- trompeloeil

Most notably librdkafka from version 1.2.0 to 1.5.0.