### PR TITLE
C++17 and no boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1.0)
 project("kafka-to-nexus")
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 set(SRC_CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 list(APPEND CMAKE_MODULE_PATH ${SRC_CMAKE_MODULE_PATH})

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ The following minimum software is required to get started:
 - Conan
 - CMake >= 3.1.0
 - Git
-- A C++14 compatible compiler (preferably GCC or Clang)
+- A C++17 compatible compiler (preferably GCC or Clang).
+GCC >=8 and AppleClang >=10 are good enough; complete C++17 support is not required.
 - Doxygen (only required if you would like to generate the documentation)
 
 Conan will install all the other required packages.

--- a/changes.md
+++ b/changes.md
@@ -15,4 +15,4 @@ from shortly before the start of each file being written. ([#551](https://github
   - trompeloeil
 - Codebase now requires C++17 to make use of `std::optional`, `std::variant` and `std::filesystem`. `filesystem` is 
 used from the `std::experimental` namespace when necessary to support gcc 8 and AppleClang 10. Compile times reduced by
-approx 5%, for details of tset see PR ([#558](https://github.com/ess-dmsc/kafka-to-nexus/pull/558)).
+approx 5%, for details of test see PR ([#558](https://github.com/ess-dmsc/kafka-to-nexus/pull/558)).

--- a/changes.md
+++ b/changes.md
@@ -13,3 +13,6 @@ from shortly before the start of each file being written. ([#551](https://github
   - streaming-data-types
   - CLI11
   - trompeloeil
+- Codebase now requires C++17 to make use of `std::optional`, `std::variant` and `std::filesystem`. `filesystem` is 
+used from the `std::experimental` namespace when necessary to support gcc 8 and AppleClang 10. Compile times reduced by
+approx 5%, for details of tset see PR ([#558](https://github.com/ess-dmsc/kafka-to-nexus/pull/558)).

--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -1,7 +1,7 @@
 [requires]
 gtest/1.10.0
 fmt/6.1.2
-h5cpp/2cfb0ad@ess-dmsc/stable
+h5cpp/897cec0@ess-dmsc/testing
 librdkafka/1.5.0@ess-dmsc/stable
 jsonformoderncpp/3.7.3@vthiery/stable
 streaming-data-types/3966e53@ess-dmsc/stable
@@ -26,7 +26,8 @@ flatbuffers:shared=True
 gtest:shared=False
 hdf5:shared=True
 librdkafka:shared=True
-date:disable_string_view=True
+date:disable_string_view=False
+h5cpp:with_boost=False
 
 [imports]
 ., *.dylib* -> ./lib @ keep_path=False

--- a/conan/conanfile.txt
+++ b/conan/conanfile.txt
@@ -1,7 +1,7 @@
 [requires]
 gtest/1.10.0
 fmt/6.1.2
-h5cpp/897cec0@ess-dmsc/testing
+h5cpp/dc5aeda@ess-dmsc/stable
 librdkafka/1.5.0@ess-dmsc/stable
 jsonformoderncpp/3.7.3@vthiery/stable
 streaming-data-types/3966e53@ess-dmsc/stable
@@ -10,10 +10,8 @@ trompeloeil/v38@rollbear/stable
 spdlog-graylog/1.5.0-dm1@ess-dmsc/stable
 date/4b46deb@ess-dmsc/stable
 asio/1.13.0
-optional-lite/3.2.0
 readerwriterqueue/07e22ec@ess-dmsc/stable
 concurrentqueue/8f7e861@ess-dmsc/stable
-variant/1.3.0@bincrafters/stable
 
 [generators]
 cmake

--- a/conan/conanfile_no_graylog.txt
+++ b/conan/conanfile_no_graylog.txt
@@ -1,7 +1,7 @@
 [requires]
 gtest/1.10.0
 fmt/6.0.0
-h5cpp/897cec0@ess-dmsc/testing
+h5cpp/dc5aeda@ess-dmsc/stable
 librdkafka/1.5.0@ess-dmsc/stable
 jsonformoderncpp/3.7.3@vthiery/stable
 streaming-data-types/3966e53@ess-dmsc/stable
@@ -10,10 +10,8 @@ trompeloeil/v38@rollbear/stable
 spdlog/1.4.2
 date/4b46deb@ess-dmsc/stable
 asio/1.13.0
-optional-lite/3.2.0
 readerwriterqueue/07e22ec@ess-dmsc/stable
 concurrentqueue/8f7e861@ess-dmsc/stable
-variant/1.3.0@bincrafters/stable
 
 [generators]
 cmake

--- a/conan/conanfile_no_graylog.txt
+++ b/conan/conanfile_no_graylog.txt
@@ -1,7 +1,7 @@
 [requires]
 gtest/1.10.0
 fmt/6.0.0
-h5cpp/2cfb0ad@ess-dmsc/stable
+h5cpp/897cec0@ess-dmsc/testing
 librdkafka/1.5.0@ess-dmsc/stable
 jsonformoderncpp/3.7.3@vthiery/stable
 streaming-data-types/3966e53@ess-dmsc/stable
@@ -26,7 +26,8 @@ flatbuffers:shared=True
 gtest:shared=True
 hdf5:shared=True
 librdkafka:shared=True
-date:disable_string_view=True
+date:disable_string_view=False
+h5cpp:with_boost=False
 
 [imports]
 ., *.dylib* -> ./lib @ keep_path=False

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -124,6 +124,7 @@ set(kafka_to_nexus_INC
         Master.h
         Msg.h
         FlatbufferMessage.h
+        Filesystem.h
         Source.h
         StreamerOptions.h
         StreamController.h
@@ -183,6 +184,10 @@ add_executable(kafka-to-nexus ${sources})
 target_compile_definitions(kafka-to-nexus PRIVATE ${compile_defs_common})
 target_include_directories(kafka-to-nexus PRIVATE ${path_include_common} ${VERSION_INCLUDE_DIR})
 target_link_libraries(kafka-to-nexus ${libraries_common})
+
+# Link stdc++fs or c++experimental to get std::experimental::filesystem when necessary
+target_link_libraries(kafka-to-nexus $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>)
+target_link_libraries(kafka-to-nexus $<$<AND:$<CXX_COMPILER_ID:AppleClang>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,11.0>>:c++fs>)
 
 option(BUILD_TESTS "Build unit tests" ON)
 if (BUILD_TESTS)

--- a/src/Filesystem.h
+++ b/src/Filesystem.h
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BSD-2-Clause
+//
+// This code has been produced by the European Spallation Source
+// and its partner institutes under the BSD 2 Clause License.
+//
+// See LICENSE.md at the top level for license information.
+//
+// Screaming Udder!                              https://esss.se
+
+#pragma once
+
+// Check for feature test macro for <filesystem>
+#if defined(__cpp_lib_filesystem)
+#define INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 0
+
+// Check for feature test macro for <experimental/filesystem>
+#elif defined(__cpp_lib_experimental_filesystem)
+#define INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 1
+
+// Can't check if headers exist so assume experimental to be safe
+#elif !defined(__has_include)
+#define INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 1
+
+// Check if the header "<filesystem>" exists
+#elif __has_include(<filesystem>)
+
+// If we're compiling on Visual Studio and are not compiling with C++17, we need
+// to use experimental
+#ifdef _MSC_VER
+
+// Check and include header that defines "_HAS_CXX17"
+#if __has_include(<yvals_core.h>)
+#include <yvals_core.h>
+
+// Check for enabled C++17 support
+#if defined(_HAS_CXX17) && _HAS_CXX17
+// We're using C++17, so let's use the normal version
+#define INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 0
+#endif
+#endif
+
+// If the marco isn't defined yet, that means any of the other VS specific
+// checks failed, so we need to use experimental
+#ifndef INCLUDE_STD_FILESYSTEM_EXPERIMENTAL
+#define INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 1
+#endif
+
+// Not on Visual Studio. Let's use the normal version
+#else // #ifdef _MSC_VER
+#define INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 0
+#endif
+
+// Check if the header "<filesystem>" exists
+#elif __has_include(<experimental/filesystem>)
+#define INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 1
+
+// Fail if neither header is available with a nice error message
+#else
+#error Could not find system header "<filesystem>" or "<experimental/filesystem>"
+#endif
+
+// We priously determined that we need the exprimental version
+#if INCLUDE_STD_FILESYSTEM_EXPERIMENTAL
+// Include it
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+
+// We have a decent compiler and can use the normal version
+#else
+// Include it
+#include <filesystem>
+namespace fs = std::filesystem;
+#endif

--- a/src/Filesystem.h
+++ b/src/Filesystem.h
@@ -51,6 +51,7 @@
 #endif
 
 // Check if the header "<filesystem>" exists
+// cppcheck-suppress preprocessorErrorDirective
 #elif __has_include(<experimental/filesystem>)
 #define INCLUDE_STD_FILESYSTEM_EXPERIMENTAL 1
 

--- a/src/HDFFile.cpp
+++ b/src/HDFFile.cpp
@@ -13,13 +13,14 @@
 #include <date/date.h>
 #include <date/tz.h>
 #include <flatbuffers/flatbuffers.h>
+#include <stack>
+#include <fstream>
 
 namespace FileWriter {
 
 using nlohmann::json;
 using std::string;
 using std::vector;
-using json_out_of_range = nlohmann::detail::out_of_range;
 
 /// As a safeguard, limit the maximum dimensions of multi dimensional arrays
 /// that we are willing to write
@@ -879,7 +880,7 @@ void HDFFile::init(std::string const &Filename,
   } catch (std::exception const &E) {
     Logger->error(
         "ERROR could not create the HDF  path={}  file={}  trace:\n{}",
-        boost::filesystem::current_path().string(), Filename,
+        std::filesystem::current_path().string(), Filename,
         hdf5::error::print_nested(E));
     std::throw_with_nested(std::runtime_error("HDFFile failed to open!"));
   }
@@ -959,7 +960,7 @@ void HDFFile::close() {
                   H5File.id().file_name().string(), Trace);
     std::throw_with_nested(std::runtime_error(fmt::format(
         "HDFFile failed to close.  Current Path: {}  Filename: {}  Trace:\n{}",
-        boost::filesystem::current_path().string(),
+        std::filesystem::current_path().string(),
         H5File.id().file_name().string(), Trace)));
   }
 }
@@ -980,10 +981,10 @@ void HDFFile::reopen(std::string const &Filename) {
     auto Trace = hdf5::error::print_nested(E);
     Logger->error(
         "ERROR could not reopen HDF file  path={}  file={}  trace:\n{}",
-        boost::filesystem::current_path().string(), Filename, Trace);
+        std::filesystem::current_path().string(), Filename, Trace);
     std::throw_with_nested(std::runtime_error(fmt::format(
         "HDFFile failed to reopen.  Current Path: {}  Filename: {}  Trace:\n{}",
-        boost::filesystem::current_path().string(), Filename, Trace)));
+        std::filesystem::current_path().string(), Filename, Trace)));
   }
 }
 

--- a/src/HDFFile.cpp
+++ b/src/HDFFile.cpp
@@ -8,13 +8,14 @@
 // Screaming Udder!                              https://esss.se
 
 #include "HDFFile.h"
+#include "Filesystem.h"
 #include "Version.h"
 #include "json.h"
 #include <date/date.h>
 #include <date/tz.h>
 #include <flatbuffers/flatbuffers.h>
-#include <stack>
 #include <fstream>
+#include <stack>
 
 namespace FileWriter {
 
@@ -880,8 +881,7 @@ void HDFFile::init(std::string const &Filename,
   } catch (std::exception const &E) {
     Logger->error(
         "ERROR could not create the HDF  path={}  file={}  trace:\n{}",
-        std::filesystem::current_path().string(), Filename,
-        hdf5::error::print_nested(E));
+        fs::current_path().string(), Filename, hdf5::error::print_nested(E));
     std::throw_with_nested(std::runtime_error("HDFFile failed to open!"));
   }
   this->NexusStructure = NexusStructure;
@@ -960,8 +960,7 @@ void HDFFile::close() {
                   H5File.id().file_name().string(), Trace);
     std::throw_with_nested(std::runtime_error(fmt::format(
         "HDFFile failed to close.  Current Path: {}  Filename: {}  Trace:\n{}",
-        std::filesystem::current_path().string(),
-        H5File.id().file_name().string(), Trace)));
+        fs::current_path().string(), H5File.id().file_name().string(), Trace)));
   }
 }
 
@@ -981,10 +980,10 @@ void HDFFile::reopen(std::string const &Filename) {
     auto Trace = hdf5::error::print_nested(E);
     Logger->error(
         "ERROR could not reopen HDF file  path={}  file={}  trace:\n{}",
-        std::filesystem::current_path().string(), Filename, Trace);
+        fs::current_path().string(), Filename, Trace);
     std::throw_with_nested(std::runtime_error(fmt::format(
         "HDFFile failed to reopen.  Current Path: {}  Filename: {}  Trace:\n{}",
-        std::filesystem::current_path().string(), Filename, Trace)));
+        fs::current_path().string(), Filename, Trace)));
   }
 }
 

--- a/src/HDFFile.h
+++ b/src/HDFFile.h
@@ -13,10 +13,10 @@
 #include "logger.h"
 #include <H5Ipublic.h>
 #include <chrono>
+#include <deque>
 #include <h5cpp/hdf5.hpp>
 #include <string>
 #include <vector>
-#include <deque>
 
 namespace FileWriter {
 

--- a/src/HDFFile.h
+++ b/src/HDFFile.h
@@ -16,6 +16,7 @@
 #include <h5cpp/hdf5.hpp>
 #include <string>
 #include <vector>
+#include <deque>
 
 namespace FileWriter {
 

--- a/src/Master.cpp
+++ b/src/Master.cpp
@@ -16,6 +16,7 @@
 #include "logger.h"
 #include <chrono>
 #include <functional>
+#include <variant>
 
 namespace FileWriter {
 
@@ -25,7 +26,7 @@ FileWriterState getNextState(Msg const &Command,
   try {
     if (CommandParser::isStopCommand(Command) ||
         CommandParser::isStartCommand(Command)) {
-      if (mpark::get_if<States::Writing>(&CurrentState)) {
+      if (std::get_if<States::Writing>(&CurrentState)) {
         if (CommandParser::isStopCommand(Command)) {
           auto StopInfo = CommandParser::extractStopInformation(Command);
           if (StopInfo.StopTime.count() == 0) {
@@ -111,9 +112,9 @@ bool Master::hasWritingStopped() {
 }
 
 void Master::moveToNewState(FileWriterState const &NewState) {
-  if (auto StartReq = mpark::get_if<States::StartRequested>(&NewState)) {
+  if (auto StartReq = std::get_if<States::StartRequested>(&NewState)) {
     startWriting(StartReq->StartInfo);
-  } else if (auto StopReq = mpark::get_if<States::StopRequested>(&NewState)) {
+  } else if (auto StopReq = std::get_if<States::StopRequested>(&NewState)) {
     requestStopWriting(StopReq->StopInfo);
   }
 }
@@ -133,7 +134,7 @@ void Master::run() {
 }
 
 bool Master::isWriting() const {
-  return mpark::get_if<States::Idle>(&CurrentState) == nullptr;
+  return std::get_if<States::Idle>(&CurrentState) == nullptr;
 }
 
 void Master::setToIdle() {

--- a/src/Master.h
+++ b/src/Master.h
@@ -17,7 +17,6 @@
 #include "States.h"
 #include <atomic>
 #include <memory>
-#include <mpark/variant.hpp>
 #include <string>
 #include <vector>
 

--- a/src/States.h
+++ b/src/States.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <mpark/variant.hpp>
+#include <variant>
 
 struct MainOpt;
 
@@ -29,7 +29,7 @@ struct StopRequested {
 };
 } // namespace States
 
-using FileWriterState = mpark::variant<States::Idle, States::StartRequested,
-                                       States::Writing, States::StopRequested>;
+using FileWriterState = std::variant<States::Idle, States::StartRequested,
+                                     States::Writing, States::StopRequested>;
 
 } // namespace FileWriter

--- a/src/WriterModule/f142/f142_Writer.cpp
+++ b/src/WriterModule/f142/f142_Writer.cpp
@@ -50,7 +50,7 @@ void makeIt(hdf5::node::Group const &Parent, hdf5::Dimensions const &Shape,
 void initValueDataset(hdf5::node::Group &Parent, Type ElementType,
                       hdf5::Dimensions const &Shape,
                       hdf5::Dimensions const &ChunkSize,
-                      nonstd::optional<std::string> const &ValueUnits) {
+                      std::optional<std::string> const &ValueUnits) {
   using OpenFuncType = std::function<void()>;
   std::map<Type, OpenFuncType> CreateValuesMap{
       {Type::int8, [&]() { makeIt<std::int8_t>(Parent, Shape, ChunkSize); }},

--- a/src/WriterModule/f142/f142_Writer.h
+++ b/src/WriterModule/f142/f142_Writer.h
@@ -17,7 +17,7 @@
 #include <chrono>
 #include <memory>
 #include <nlohmann/json.hpp>
-#include <nonstd/optional.hpp>
+#include <optional>
 #include <vector>
 
 namespace WriterModule {
@@ -83,7 +83,7 @@ protected:
   uint64_t ValueIndexInterval = std::numeric_limits<uint64_t>::max();
   size_t ArraySize{1};
   size_t ChunkSize{64 * 1024};
-  nonstd::optional<std::string> ValueUnits;
+  std::optional<std::string> ValueUnits;
 };
 
 } // namespace f142

--- a/src/json.h
+++ b/src/json.h
@@ -10,14 +10,14 @@
 #pragma once
 
 #include <nlohmann/json.hpp>
-#include <nonstd/optional.hpp>
+#include <optional>
 #include <string>
 
 template <typename T>
-nonstd::optional<T> find(std::string Key, nlohmann::json const &Json) {
+std::optional<T> find(std::string Key, nlohmann::json const &Json) {
   auto It = Json.find(Key);
   if (It != Json.end()) {
-    return nonstd::optional<T>(It.value().get<T>());
+    return std::optional<T>(It.value().get<T>());
   }
-  return nonstd::nullopt;
+  return std::nullopt;
 }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -73,6 +73,10 @@ target_link_libraries(UnitTests
         ${CONAN_LIBS_GTEST}
         )
 
+# Link stdc++fs or c++experimental to get std::experimental::filesystem when necessary
+target_link_libraries(UnitTests $<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:stdc++fs>)
+target_link_libraries(UnitTests $<$<AND:$<CXX_COMPILER_ID:AppleClang>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,11.0>>:c++fs>)
+
 target_compile_definitions(UnitTests PRIVATE TEST_DATA_PATH="${TEST_DATA_PATH}")
 
 enable_testing()

--- a/src/tests/CommandParserTests.cpp
+++ b/src/tests/CommandParserTests.cpp
@@ -10,7 +10,7 @@
 #include <6s4t_run_stop_generated.h>
 #include <chrono>
 #include <gtest/gtest.h>
-#include <nonstd/optional.hpp>
+#include <optional>
 #include <pl72_run_start_generated.h>
 
 #include "CommandParser.h"
@@ -23,7 +23,7 @@ std::string const InstrumentNameInput = "TEST";
 std::string const RunNameInput = "42";
 std::string const NexusStructureInput = "{}";
 std::string const JobIDInput = "qw3rty";
-nonstd::optional<std::string> const ServiceIDInput = "filewriter1";
+std::optional<std::string> const ServiceIDInput = "filewriter1";
 std::string const BrokerInput = "somehost:1234";
 std::string const FilenameInput = "a-dummy-name-01.h5";
 uint64_t const StartTimeInput = 123456789000;
@@ -151,7 +151,7 @@ TEST(CommandParserStartTests, IfNoStartTimeThenUsesSuppliedCurrentTime) {
 }
 
 TEST(CommandParserStartTests, IfBlankServiceIdThenIsBlank) {
-  nonstd::optional<std::string> const EmptyServiceID = "";
+  std::optional<std::string> const EmptyServiceID = "";
   auto MessageBuffer = buildRunStartMessage(
       InstrumentNameInput, RunNameInput, NexusStructureInput, JobIDInput,
       EmptyServiceID, BrokerInput, FilenameInput, StartTimeInput,
@@ -164,7 +164,7 @@ TEST(CommandParserStartTests, IfBlankServiceIdThenIsBlank) {
 }
 
 TEST(CommandParserStartTests, IfMissingServiceIdThenIsBlank) {
-  nonstd::optional<std::string> const NoServiceID = nonstd::nullopt;
+  std::optional<std::string> const NoServiceID = std::nullopt;
   auto MessageBuffer = buildRunStartMessage(
       InstrumentNameInput, RunNameInput, NexusStructureInput, JobIDInput,
       NoServiceID, BrokerInput, FilenameInput, StartTimeInput, StopTimeInput);
@@ -205,7 +205,7 @@ TEST(CommandParserHappyStopTests, IfStopTimePresentThenExtractedCorrectly) {
 }
 
 TEST(CommandParserStopTests, IfNoServiceIdThenIsBlank) {
-  nonstd::optional<std::string> const EmptyServiceID = "";
+  std::optional<std::string> const EmptyServiceID = "";
   auto MessageBuffer = buildRunStopMessage(StopTimeInput, RunNameInput,
                                            JobIDInput, EmptyServiceID);
 
@@ -216,7 +216,7 @@ TEST(CommandParserStopTests, IfNoServiceIdThenIsBlank) {
 }
 
 TEST(CommandParserStopTests, IfMissingServiceIdThenIsBlank) {
-  nonstd::optional<std::string> const NoServiceID = nonstd::nullopt;
+  std::optional<std::string> const NoServiceID = std::nullopt;
   auto MessageBuffer =
       buildRunStopMessage(StopTimeInput, RunNameInput, JobIDInput, NoServiceID);
 

--- a/src/tests/MasterTests.cpp
+++ b/src/tests/MasterTests.cpp
@@ -36,7 +36,7 @@ TEST(GetNewStateTests, IfIdleThenOnStartCommandStartIsRequested) {
   auto const NewState =
       getNextState(StartCommand, std::chrono::milliseconds{0}, CurrentState);
 
-  ASSERT_TRUE(mpark::get_if<States::StartRequested>(&NewState));
+  ASSERT_TRUE(std::get_if<States::StartRequested>(&NewState));
 }
 
 TEST(GetNewStateTests, IfWritingThenOnStartCommandNoStateChange) {
@@ -44,7 +44,7 @@ TEST(GetNewStateTests, IfWritingThenOnStartCommandNoStateChange) {
   auto const NewState =
       getNextState(StartCommand, std::chrono::milliseconds{0}, CurrentState);
 
-  ASSERT_TRUE(mpark::get_if<States::Writing>(&NewState));
+  ASSERT_TRUE(std::get_if<States::Writing>(&NewState));
 }
 
 TEST(GetNewStateTests, IfWritingThenOnStopCommandStopIsRequested) {
@@ -52,7 +52,7 @@ TEST(GetNewStateTests, IfWritingThenOnStopCommandStopIsRequested) {
   auto const NewState =
       getNextState(StopCommand, std::chrono::milliseconds{0}, CurrentState);
 
-  ASSERT_TRUE(mpark::get_if<States::StopRequested>(&NewState));
+  ASSERT_TRUE(std::get_if<States::StopRequested>(&NewState));
 }
 
 TEST(GetNewStateTests, IfIdleThenOnStopCommandNoStateChange) {
@@ -60,7 +60,7 @@ TEST(GetNewStateTests, IfIdleThenOnStopCommandNoStateChange) {
   auto const NewState =
       getNextState(StopCommand, std::chrono::milliseconds{0}, CurrentState);
 
-  ASSERT_TRUE(mpark::get_if<States::Idle>(&NewState));
+  ASSERT_TRUE(std::get_if<States::Idle>(&NewState));
 }
 
 class FakeJobCreator : public IJobCreator {

--- a/src/tests/WriterModule/f142_WriterTests.cpp
+++ b/src/tests/WriterModule/f142_WriterTests.cpp
@@ -251,7 +251,7 @@ struct AlarmInfo {
 template <class ValFuncType>
 std::pair<std::unique_ptr<uint8_t[]>, size_t> generateFlatbufferMessageBase(
     ValFuncType ValueFunc, Value ValueTypeId, std::uint64_t Timestamp,
-    nonstd::optional<AlarmInfo> EpicsAlarmChange = nonstd::nullopt) {
+    std::optional<AlarmInfo> EpicsAlarmChange = std::nullopt) {
   auto Builder = flatbuffers::FlatBufferBuilder();
   auto SourceNameOffset = Builder.CreateString("SomeSourceName");
   auto ValueOffset = ValueFunc(Builder);
@@ -276,7 +276,7 @@ std::pair<std::unique_ptr<uint8_t[]>, size_t> generateFlatbufferMessageBase(
 
 std::pair<std::unique_ptr<uint8_t[]>, size_t> generateFlatbufferMessage(
     double Value, std::uint64_t Timestamp,
-    nonstd::optional<AlarmInfo> EpicsAlarmChange = nonstd::nullopt) {
+    std::optional<AlarmInfo> EpicsAlarmChange = std::nullopt) {
   auto ValueFunc = [Value](auto &Builder) {
     DoubleBuilder ValueBuilder(Builder);
     ValueBuilder.add_value(Value);
@@ -421,7 +421,7 @@ TEST_F(f142WriteData, WhenMessageContainsAlarmStatusOfNoChangeItIsNotWritten) {
   uint64_t Timestamp{11};
   auto FlatbufferData = generateFlatbufferMessage(
       3.14, Timestamp,
-      nonstd::optional<AlarmInfo>(
+      std::optional<AlarmInfo>(
           {AlarmStatus::NO_CHANGE, AlarmSeverity::NO_CHANGE}));
   TestWriter.write(FileWriter::FlatbufferMessage(FlatbufferData.first.get(),
                                                  FlatbufferData.second));
@@ -460,7 +460,7 @@ TEST_P(f142WriteAlarms, WhenMessageContainsAnAlarmChangeItIsWritten) {
   AlarmWritingTestInfo TestAlarm = GetParam();
   auto FlatbufferData = generateFlatbufferMessage(
       3.14, TestAlarm.Timestamp,
-      nonstd::optional<AlarmInfo>({TestAlarm.Status, TestAlarm.Severity}));
+      std::optional<AlarmInfo>({TestAlarm.Status, TestAlarm.Severity}));
   TestWriter.write(FileWriter::FlatbufferMessage(FlatbufferData.first.get(),
                                                  FlatbufferData.second));
 

--- a/src/tests/helpers/RunStartStopHelpers.cpp
+++ b/src/tests/helpers/RunStartStopHelpers.cpp
@@ -2,14 +2,14 @@
 #include "Msg.h"
 
 #include <6s4t_run_stop_generated.h>
-#include <nonstd/optional.hpp>
+#include <optional>
 #include <pl72_run_start_generated.h>
 
 namespace RunStartStopHelpers {
 FileWriter::Msg buildRunStartMessage(
     std::string const &InstrumentName, std::string const &RunName,
     std::string const &NexusStructure, std::string const &JobID,
-    nonstd::optional<std::string> const &ServiceID, std::string const &Broker,
+    std::optional<std::string> const &ServiceID, std::string const &Broker,
     std::string const &Filename, uint64_t StartTime, uint64_t StopTime) {
   flatbuffers::FlatBufferBuilder Builder;
 
@@ -46,7 +46,7 @@ FileWriter::Msg buildRunStartMessage(
 FileWriter::Msg
 buildRunStopMessage(uint64_t StopTime, std::string const &RunName,
                     std::string const &JobID,
-                    nonstd::optional<std::string> const &ServiceID) {
+                    std::optional<std::string> const &ServiceID) {
   flatbuffers::FlatBufferBuilder Builder;
 
   const auto RunIDOffset = Builder.CreateString(RunName);

--- a/src/tests/helpers/RunStartStopHelpers.h
+++ b/src/tests/helpers/RunStartStopHelpers.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-#include <nonstd/optional.hpp>
+#include <optional>
 
 namespace FileWriter {
 struct Msg;
@@ -19,11 +19,11 @@ namespace RunStartStopHelpers {
 FileWriter::Msg buildRunStartMessage(
     std::string const &InstrumentName, std::string const &RunName,
     std::string const &NexusStructure, std::string const &JobID,
-    nonstd::optional<std::string> const &ServiceID, std::string const &Broker,
+    std::optional<std::string> const &ServiceID, std::string const &Broker,
     std::string const &Filename, uint64_t StartTime, uint64_t StopTime);
 
 FileWriter::Msg
 buildRunStopMessage(uint64_t StopTime, std::string const &RunName,
                     std::string const &JobID,
-                    nonstd::optional<std::string> const &ServiceID);
+                    std::optional<std::string> const &ServiceID);
 } // namespace RunStartStopHelpers


### PR DESCRIPTION
### Issue
DM-1842

~Please merge conan recipe update first: https://github.com/ess-dmsc/conan-h5cpp~ done

### Description of work

Use boostless build of h5cpp and update to C++17.
Replace non-std implementations of `variant` and `optional` with std implementation.

Out of curiosity I tested build time with boost and boostless builds of h5cpp.
Total clean build time of filewriter and unit tests:
| Build Threads  | With boost | Without Boost |
| ------------- | ------------- | ------------- |
| 16  | 1m16s  | 1m12s |
| 2  | 5m20s |  5m6s |

This is a consistent ~5% decrease, our Jenkins builds will also save some time in not having to download the boost module packages from the conan server.

### Nominate for Group Code Review

- [ ] Nominate for code review 

### Reminder

*Changes should be documented in `changes.md`*
