### PR TITLE
Add example of multidim dataset in json to docs

### DIFF
--- a/documentation/commands.md
+++ b/documentation/commands.md
@@ -109,17 +109,23 @@ In the following example a dataset is defined:
         "type": "dataset",
         "dataset": {
           "size": [
-            5
+            2,
+            3
           ],
           "type": "int64"
         },
         "values": [
-          0,
-          1,
-          3,
-          2,
-          2
-        ],
+          [
+            0,
+            1,
+            3
+          ],
+          [
+            2,
+            2,
+            1
+          ]
+        ]
         "attributes": {
           "NX_class": "NXlog"
         }


### PR DESCRIPTION
Noticed there was no example of a multidimensional dataset in the documentation when I was checking NC output.