### PR TITLE
Fix bug in Consumer::addPartitionAtOffset

### DIFF
--- a/src/Kafka/Consumer.cpp
+++ b/src/Kafka/Consumer.cpp
@@ -111,11 +111,19 @@ void Consumer::addPartitionAtOffset(std::string const &Topic, int PartitionId,
   Logger->info("Consumer::addPartitionAtOffset()  topic: {},  partitionId: {}, "
                "offset: {}",
                Topic, PartitionId, Offset);
-  auto TopicPartition = std::unique_ptr<RdKafka::TopicPartition>(
+  std::vector<RdKafka::TopicPartition *> Assignments;
+  auto ErrorCode = KafkaConsumer->assignment(Assignments);
+  if (ErrorCode != RdKafka::ERR_NO_ERROR) {
+    Logger->error("Could not assign to {}. Could not get current assignments.",
+                  Topic);
+    throw std::runtime_error(
+        fmt::format("Could not assign topic-partition of topic {}. Could not "
+                    "get current assignments. RdKafka error: \"{}\"",
+                    Topic, err2str(ErrorCode)));
+  }
+  Assignments.emplace_back(
       RdKafka::TopicPartition::create(Topic, PartitionId, Offset));
-  auto ReturnCode = KafkaConsumer->assign({
-      TopicPartition.get(),
-  });
+  auto ReturnCode = KafkaConsumer->assign(Assignments);
   if (ReturnCode != RdKafka::ERR_NO_ERROR) {
     Logger->error("Could not assign to {}", Topic);
     throw std::runtime_error(fmt::format(


### PR DESCRIPTION
### Description of work

* The `assign` call *replaces* topic-partitions instead of adding new ones. Thus when previously calling `addPartitionAtOffset`, you removed previous assignments. This PR fixes that.