### PR TITLE
Remove unused and misleading setting

### DIFF
--- a/src/Kafka/BrokerSettings.h
+++ b/src/Kafka/BrokerSettings.h
@@ -33,7 +33,6 @@ struct BrokerSettings {
       30s}; // If there is an error with the Kafka broker when consuming data
             // (for writing files), wait this long before stopping
   std::map<std::string, std::string> KafkaConfiguration = {
-      {"metadata.request.timeout.ms", "2000"}, // 2 Secs
       {"socket.timeout.ms", "2000"},
       {"message.max.bytes", "24000000"},
       {"fetch.message.max.bytes", "24000000"},


### PR DESCRIPTION
`metadata.request.timeout.ms` is not actually used, so it was misleading that it is explicitly set, especially to very low value.
Metadata timeouts are specified in the metadata query function call.