### PR TITLE
ECDC-2618 Updating error messages in FileWriterTask class

### DIFF
--- a/src/FileWriterTask.cpp
+++ b/src/FileWriterTask.cpp
@@ -35,7 +35,7 @@ std::vector<Source> &FileWriterTask::sources() { return SourceToModuleMap; }
 
 void FileWriterTask::setFilename(std::string const &Prefix,
                                  std::string const &Name) {
-  FilePath = Prefix;
+  FileDirectory = Prefix;
   if (Prefix.empty()) {
     Filename = Name;
   } else {
@@ -56,8 +56,8 @@ void FileWriterTask::InitialiseHdf(std::string const &NexusStructure,
                               "A file with that filename already exists in that directory. Delete the existing file or provide another filename.");
     std::throw_with_nested(std::runtime_error(ErrorString));
   }
-  else if(not FilePath.empty() and not std::filesystem::exists(FilePath)){
-    ErrorString = fmt::format("Failed to initialize HDF file \"{}\". Error was: The directory \"{}\" does not exist.", Filename, FilePath);
+  else if(not FileDirectory.empty() and not std::filesystem::exists(FileDirectory)){
+    ErrorString = fmt::format("Failed to initialize HDF file \"{}\". Error was: The directory \"{}\" does not exist.", Filename, FileDirectory);
     std::throw_with_nested(std::runtime_error(ErrorString));
   }
 

--- a/src/FileWriterTask.cpp
+++ b/src/FileWriterTask.cpp
@@ -35,6 +35,7 @@ std::vector<Source> &FileWriterTask::sources() { return SourceToModuleMap; }
 
 void FileWriterTask::setFilename(std::string const &Prefix,
                                  std::string const &Name) {
+  FilePath = Prefix;
   if (Prefix.empty()) {
     Filename = Name;
   } else {
@@ -49,13 +50,23 @@ void FileWriterTask::addSource(Source &&Source) {
 void FileWriterTask::InitialiseHdf(std::string const &NexusStructure,
                                    std::vector<StreamHDFInfo> &HdfInfo) {
   auto NexusStructureJson = hdf_parse(NexusStructure, Logger);
+  std::string ErrorString;
+  if (std::filesystem::exists(Filename)){
+    ErrorString = fmt::format("Failed to initialize HDF file \"{}\". Error was: \"{}\"", Filename,
+                              "A file with that filename already exists in that directory. Delete the existing file or provide another filename.");
+    std::throw_with_nested(std::runtime_error(ErrorString));
+  }
+  else if(not FilePath.empty() and not std::filesystem::exists(FilePath)){
+    ErrorString = fmt::format("Failed to initialize HDF file \"{}\". Error was: The directory \"{}\" does not exist.", Filename, FilePath);
+    std::throw_with_nested(std::runtime_error(ErrorString));
+  }
 
   try {
     Logger->info("Creating HDF file {}", Filename);
     File = std::make_unique<HDFFile>(Filename, NexusStructureJson, HdfInfo);
   } catch (std::exception const &E) {
-    std::string ErrorString = fmt::format("Failed to initialize HDF file \"{}\". Error was: {}", Filename,
-                                          E.what());
+    ErrorString = fmt::format("Failed to initialize HDF file \"{}\". Error was: {}", Filename,
+                              E.what());
     LOG_ERROR(ErrorString);
     std::throw_with_nested(std::runtime_error(ErrorString));
   }

--- a/src/FileWriterTask.h
+++ b/src/FileWriterTask.h
@@ -86,7 +86,7 @@ public:
   void flushDataToFile();
 
 private:
-  std::string FilePath;
+  std::string FileDirectory;
   std::string Filename;
   std::vector<Source> SourceToModuleMap;
   std::string JobId;

--- a/src/FileWriterTask.h
+++ b/src/FileWriterTask.h
@@ -86,6 +86,7 @@ public:
   void flushDataToFile();
 
 private:
+  std::string FilePath;
   std::string Filename;
   std::vector<Source> SourceToModuleMap;
   std::string JobId;


### PR DESCRIPTION
### Issue

ECDC-2618

### Description of work

Minor updates to handling of error messages in FileWriterTask for the two cases:

1. Nexus file already exists.
2. Directory provided in .ini file does not exist.

