### PR TITLE
ECDC-2611: File writer system tests to use confluent_kafka

### DIFF
--- a/system-tests/helpers/kafkahelpers.py
+++ b/system-tests/helpers/kafkahelpers.py
@@ -1,21 +1,27 @@
-from kafka import KafkaConsumer, KafkaProducer
-from typing import Optional
 import uuid
-from streaming_data_types.logdata_f142 import serialise_f142
-from streaming_data_types.epics_connection_info_ep00 import serialise_ep00
 from datetime import datetime
+from typing import Optional
+
+from confluent_kafka import Consumer, Producer
+
+from streaming_data_types.epics_connection_info_ep00 import serialise_ep00
+from streaming_data_types.logdata_f142 import serialise_f142
 
 
-def create_producer() -> KafkaProducer:
-    return KafkaProducer(bootstrap_servers="localhost:9093")
+def create_producer() -> Producer:
+    conf = {
+        "bootstrap.servers": "localhost:9093",
+    }
+    return Producer(conf)
 
 
 def create_consumer():
-    return KafkaConsumer(
-        bootstrap_servers="localhost:9093",
-        group_id=uuid.uuid4(),
-        auto_offset_reset="latest",
-    )
+    conf = {
+        "bootstrap.servers": "localhost:9093",
+        "group_id":uuid.uuid4(),
+        "auto.offset.reset":"latest",
+    }
+    return Consumer(conf)
 
 
 def datetime_to_ms(time: datetime) -> int:
@@ -27,7 +33,7 @@ def datetime_to_ns(time: datetime):
 
 
 def publish_f142_message(
-    producer: KafkaProducer,
+    producer: Producer,
     topic: str,
     timestamp: datetime,
     source_name: Optional[str] = None,
@@ -54,8 +60,8 @@ def publish_f142_message(
         alarm_status,
         alarm_severity,
     )
-    producer.send(
-        topic=topic, value=f142_message, timestamp_ms=datetime_to_ms(timestamp)
+    producer.produce(
+        topic=topic, value=f142_message, timestamp=datetime_to_ms(timestamp)
     )
     producer.flush()
 
@@ -66,7 +72,7 @@ def publish_ep00_message(
     if source_name is None:
         source_name = "SIMPLE:DOUBLE"
     ep00_message = serialise_ep00(datetime_to_ns(timestamp), status, source_name)
-    producer.send(
-        topic=topic, value=ep00_message, timestamp_ms=datetime_to_ms(timestamp)
+    producer.produce(
+        topic=topic, value=ep00_message, timestamp=datetime_to_ms(timestamp)
     )
     producer.flush()

--- a/system-tests/helpers/kafkahelpers.py
+++ b/system-tests/helpers/kafkahelpers.py
@@ -15,7 +15,7 @@ def create_producer() -> Producer:
     return Producer(conf)
 
 
-def create_consumer():
+def create_consumer() -> Consumer:
     conf = {
         "bootstrap.servers": "localhost:9093",
         "group_id":uuid.uuid4(),

--- a/system-tests/requirements.txt
+++ b/system-tests/requirements.txt
@@ -1,5 +1,5 @@
 pytest>=4.3.0
-kafka-python >= 2.0.2
+confluent_kafka >= 1.7.0
 docker-compose==1.29.2
 docker==5.0.0
 h5py>=2.10.0


### PR DESCRIPTION
### Description of work

* Start using confluent_kafka library in system tests.
* wait_until_kafka_ready method in conftest, now uses producer to send message to kafka and waits until the message delivery was acknowledged (as it is done in forwarder library's system tests) and then only declares that kafka is ready. Old way of successfully creating consumer and declaring kafka is ready **seems to create spurious and random errors while running system-tests locally**.  

NOTE: This PR does not fix assertion error in `test_filewriter_static_data.py` . That will be a different ticket.