### PR TITLE
removing non-job pool mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Part of the ESS data streaming pipeline.
   --version                   Print application version and exit
   --command-status-uri URI REQUIRED
                               <host[:port][/topic]> Kafka broker/topic to listen for commands and to push status updates to.
-  --job-pool-uri URI          <host[:port][/topic]> Kafka broker/topic to listen for jobs
+  --job-pool-uri URI REQUIRED 
+  			      <host[:port][/topic]> Kafka broker/topic to listen for jobs
   --graylog-logger-address URI
                               <host:port> Log to Graylog via graylog_logger library
   --grafana-carbon-address URI

--- a/changes.md
+++ b/changes.md
@@ -1,5 +1,9 @@
 # Changes
 
+## Next version
+
+- The filewriter will now only run in the job pool mode. This means that the user is required to supply a job pool topic in the filewriter .ini configuration flag using the --job-pool-uri option.
+
 ## Version 4.1.0: Quality of life
 
 - Each ev42 writer module instance will now publish the number of events written to file.

--- a/src/CLIOptions.cpp
+++ b/src/CLIOptions.cpp
@@ -136,7 +136,7 @@ void setCLIOptions(CLI::App &App, MainOpt &MainOptions) {
 
   addUriOption(App, "--job-pool-uri", MainOptions.JobPoolURI,
                "<host[:port][/topic]> Kafka broker/topic to listen for jobs")
-  ->required();
+      ->required();
 
   addUriOption(App, "--graylog-logger-address",
                MainOptions.GraylogLoggerAddress,

--- a/src/CLIOptions.cpp
+++ b/src/CLIOptions.cpp
@@ -135,7 +135,8 @@ void setCLIOptions(CLI::App &App, MainOpt &MainOptions) {
       ->required();
 
   addUriOption(App, "--job-pool-uri", MainOptions.JobPoolURI,
-               "<host[:port][/topic]> Kafka broker/topic to listen for jobs");
+               "<host[:port][/topic]> Kafka broker/topic to listen for jobs")
+  ->required();
 
   addUriOption(App, "--graylog-logger-address",
                MainOptions.GraylogLoggerAddress,

--- a/src/CommandSystem/Handler.cpp
+++ b/src/CommandSystem/Handler.cpp
@@ -30,11 +30,11 @@ Handler::Handler(std::string const &ServiceIdentifier,
 void Handler::loopFunction() {
   auto JobMsg = JobPool->pollForJob();
   if (JobMsg.first == Kafka::PollStatus::Message) {
-    handleCommand(std::move(JobMsg.second));
+    handleCommand(std::move(JobMsg.second), true);
   }
   auto CommandMsg = CommandSource->pollForCommand();
   if (CommandMsg.first == Kafka::PollStatus::Message) {
-    handleCommand(std::move(CommandMsg.second));
+    handleCommand(std::move(CommandMsg.second), false);
   }
 }
 
@@ -82,9 +82,9 @@ void Handler::sendErrorEncounteredMessage(std::string FileName,
   PollForJob = true;
 }
 
-void Handler::handleCommand(FileWriter::Msg CommandMsg) {
+void Handler::handleCommand(FileWriter::Msg CommandMsg, bool IsJobPoolCommand) {
   if (Parser::isStartCommand(CommandMsg)) {
-    handleStartCommand(std::move(CommandMsg));
+    handleStartCommand(std::move(CommandMsg), IsJobPoolCommand);
   } else if (Parser::isStopCommand(CommandMsg)) {
     handleStopCommand(std::move(CommandMsg));
   } else {
@@ -132,7 +132,8 @@ bool isMsgTimeStampValid(time_point MsgTime) {
   return false;
 }
 
-void Handler::handleStartCommand(FileWriter::Msg CommandMsg) {
+void Handler::handleStartCommand(FileWriter::Msg CommandMsg,
+                                 bool IsJobPoolCommand) {
   try {
     time_point StopTime{0ms};
     std::string ExceptionMessage;
@@ -152,7 +153,9 @@ void Handler::handleStartCommand(FileWriter::Msg CommandMsg) {
           0}});
 
     CommandSteps.push_back(
-        {[&]() { return StartJob.ServiceID != ServiceId; },
+        {[&]() {
+           return not(IsJobPoolCommand xor (StartJob.ServiceID != ServiceId));
+         },
          {LogLevel::Debug, false,
           [&]() {
             return fmt::format(
@@ -190,17 +193,21 @@ void Handler::handleStartCommand(FileWriter::Msg CommandMsg) {
     CommandSteps.push_back(
         {[&]() {
            if (not StartJob.ControlTopic.empty()) {
-             LOG_INFO("Connecting to an alternative command topic: \"{}\"",
-                      StartJob.ControlTopic);
-             CommandSource = std::make_unique<CommandListener>(
-                 uri::URI{CommandTopicAddress, StartJob.ControlTopic},
-                 KafkaSettings);
-             AltCommandResponse = std::make_unique<FeedbackProducer>(
-                 ServiceId,
-                 uri::URI{CommandTopicAddress, StartJob.ControlTopic},
-                 KafkaSettings);
-             std::swap(CommandResponse, AltCommandResponse);
-             UsingAltTopic = true;
+             if (IsJobPoolCommand) {
+               LOG_INFO("Connecting to an alternative command topic: \"{}\"",
+                        StartJob.ControlTopic);
+               CommandSource = std::make_unique<CommandListener>(
+                   uri::URI{CommandTopicAddress, StartJob.ControlTopic},
+                   KafkaSettings);
+               AltCommandResponse = std::make_unique<FeedbackProducer>(
+                   ServiceId,
+                   uri::URI{CommandTopicAddress, StartJob.ControlTopic},
+                   KafkaSettings);
+               std::swap(CommandResponse, AltCommandResponse);
+               UsingAltTopic = true;
+             } else {
+               return false;
+             }
            }
            return true;
          },

--- a/src/CommandSystem/Handler.cpp
+++ b/src/CommandSystem/Handler.cpp
@@ -30,7 +30,7 @@ Handler::Handler(std::string const &ServiceIdentifier,
 void Handler::loopFunction() {
   auto JobMsg = JobPool->pollForJob();
   if (JobMsg.first == Kafka::PollStatus::Message) {
-      handleCommand(std::move(JobMsg.second));
+    handleCommand(std::move(JobMsg.second));
   }
   auto CommandMsg = CommandSource->pollForCommand();
   if (CommandMsg.first == Kafka::PollStatus::Message) {
@@ -152,9 +152,7 @@ void Handler::handleStartCommand(FileWriter::Msg CommandMsg) {
           0}});
 
     CommandSteps.push_back(
-        {[&]() {
-           return StartJob.ServiceID != ServiceId;
-         },
+        {[&]() { return StartJob.ServiceID != ServiceId; },
          {LogLevel::Debug, false,
           [&]() {
             return fmt::format(

--- a/src/CommandSystem/Handler.h
+++ b/src/CommandSystem/Handler.h
@@ -68,8 +68,8 @@ public:
   void loopFunction() override;
 
 private:
-  void handleCommand(FileWriter::Msg CommandMsg, bool IsJobPoolCommand);
-  void handleStartCommand(FileWriter::Msg CommandMsg, bool IsJobPoolCommand);
+  void handleCommand(FileWriter::Msg CommandMsg);
+  void handleStartCommand(FileWriter::Msg CommandMsg);
   void handleStopCommand(FileWriter::Msg CommandMsg);
   std::string const ServiceId;
   std::string JobId;

--- a/src/CommandSystem/Handler.h
+++ b/src/CommandSystem/Handler.h
@@ -68,8 +68,8 @@ public:
   void loopFunction() override;
 
 private:
-  void handleCommand(FileWriter::Msg CommandMsg);
-  void handleStartCommand(FileWriter::Msg CommandMsg);
+  void handleCommand(FileWriter::Msg CommandMsg, bool IsJobPoolCommand);
+  void handleStartCommand(FileWriter::Msg CommandMsg, bool IsJobPoolCommand);
   void handleStopCommand(FileWriter::Msg CommandMsg);
   std::string const ServiceId;
   std::string JobId;

--- a/src/MainOpt.h
+++ b/src/MainOpt.h
@@ -57,7 +57,7 @@ struct MainOpt {
   uri::URI CommandBrokerURI{"localhost:9092/kafka-to-nexus.command"};
 
   /// Kafka broker and topic where file writer jobs are published.
-  uri::URI JobPoolURI{""};
+  uri::URI JobPoolURI{"localhost:9092/kafka-to-nexus.jobpool"};
 
   /// \brief Path for HDF output.
   ///

--- a/src/kafka-to-nexus.cpp
+++ b/src/kafka-to-nexus.cpp
@@ -61,7 +61,8 @@ bool tryToFindTopics(std::string PoolTopic, std::string CommandTopic,
     if (ListOfTopics.find(PoolTopic) == ListOfTopics.end()) {
       auto MsgString = fmt::format(
           "Unable to find job pool topic with name \"{}\".", PoolTopic);
-      LOG_WARN(MsgString);
+      LOG_ERROR(MsgString);
+      throw std::runtime_error(MsgString);
     }
     if (ListOfTopics.find(CommandTopic) == ListOfTopics.end()) {
       auto MsgString = fmt::format(

--- a/system-tests/conftest.py
+++ b/system-tests/conftest.py
@@ -9,7 +9,7 @@ import pytest
 from compose.cli.main import TopLevelCommand, project_from_options
 from confluent_kafka import Producer
 from confluent_kafka.admin import AdminClient
-from file_writer_control import WorkerJobPool, WorkerCommandChannel
+from file_writer_control import WorkerJobPool
 
 from helpers.writer import stop_all_jobs
 
@@ -226,23 +226,6 @@ def start_file_writer(request):
         request.config.getoption(LOCAL_BUILD),
         request.config.getoption(WAIT_FOR_DEBUGGER_ATTACH),
     )
-
-
-@pytest.fixture(scope="function", autouse=True)
-def writer_channel(request) -> WorkerCommandChannel:
-    """
-    :type request: _pytest.python.FixtureRequest
-    """
-    kafka_host = "localhost:9093"
-    worker = WorkerCommandChannel(
-        command_topic_url=f"{kafka_host}/TEST_writer_commands"
-    )
-
-    def stop_current_jobs():
-        stop_all_jobs(worker)
-
-    request.addfinalizer(stop_current_jobs)
-    return worker
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/system-tests/helpers/writer.py
+++ b/system-tests/helpers/writer.py
@@ -10,9 +10,7 @@ import time
 SLEEP_TIME = 1.5
 
 
-def wait_writers_available(
-    worker_pool: WorkerJobPool, timeout: float, nr_of: int
-):
+def wait_writers_available(worker_pool: WorkerJobPool, timeout: float, nr_of: int):
     start_time = datetime.now()
     time.sleep(SLEEP_TIME)
     while True:

--- a/system-tests/test_epics_status.py
+++ b/system-tests/test_epics_status.py
@@ -15,8 +15,8 @@ from helpers.writer import (
 )
 
 
-def test_ep00(writer_channel, worker_pool, kafka_address):
-    wait_writers_available(writer_channel, nr_of=1, timeout=10)
+def test_ep00(worker_pool, kafka_address):
+    wait_writers_available(worker_pool, nr_of=1, timeout=10)
 
     producer = create_producer()
     topic = "TEST_epicsConnectionStatus"
@@ -42,7 +42,7 @@ def test_ep00(writer_channel, worker_pool, kafka_address):
     )
     wait_start_job(worker_pool, write_job, timeout=20)
 
-    wait_no_working_writers(writer_channel, timeout=30)
+    wait_no_working_writers(worker_pool, timeout=30)
 
     file_path = f"output-files/{file_name}"
     with OpenNexusFile(file_path) as file:

--- a/system-tests/test_f142_meta_data.py
+++ b/system-tests/test_f142_meta_data.py
@@ -18,8 +18,8 @@ from helpers.writer import (
 import numpy as np
 
 
-def test_f142_meta_data(writer_channel, worker_pool, kafka_address):
-    wait_writers_available(writer_channel, nr_of=1, timeout=10)
+def test_f142_meta_data(worker_pool, kafka_address):
+    wait_writers_available(worker_pool, nr_of=1, timeout=10)
     producer = create_producer()
 
     data_topic = "TEST_sampleEnv"
@@ -89,7 +89,7 @@ def test_f142_meta_data(writer_channel, worker_pool, kafka_address):
     )
     wait_start_job(worker_pool, write_job, timeout=20)
 
-    wait_no_working_writers(writer_channel, timeout=30)
+    wait_no_working_writers(worker_pool, timeout=30)
 
     # The command also includes a stream for topic TEST_emptyTopic which exists but has no data in it, the
     # file writer should recognise there is no data in that topic and close the corresponding streamer without problem.

--- a/system-tests/test_filewriter_ignores_commands.py
+++ b/system-tests/test_filewriter_ignores_commands.py
@@ -55,9 +55,7 @@ def test_ignores_commands_with_incorrect_id(
     assert Path(file_path).is_file()
 
 
-def test_ignores_commands_with_incorrect_job_id(
-    worker_pool, kafka_address
-):
+def test_ignores_commands_with_incorrect_job_id(worker_pool, kafka_address):
     wait_writers_available(worker_pool, nr_of=1, timeout=10)
     now = datetime.now()
     file_name = "output_file_job_id.nxs"

--- a/system-tests/test_filewriter_kafka_meta_data.py
+++ b/system-tests/test_filewriter_kafka_meta_data.py
@@ -12,8 +12,8 @@ from helpers.writer import (
 )
 
 
-def test_static_data_reaches_file(writer_channel, worker_pool, kafka_address):
-    wait_writers_available(writer_channel, nr_of=1, timeout=10)
+def test_static_data_reaches_file(worker_pool, kafka_address):
+    wait_writers_available(worker_pool, nr_of=1, timeout=10)
     now = datetime.now()
     start_time = now - timedelta(seconds=10)
     stop_time = now
@@ -29,8 +29,8 @@ def test_static_data_reaches_file(writer_channel, worker_pool, kafka_address):
     )
     wait_start_job(worker_pool, write_job, timeout=20)
 
-    wait_no_working_writers(writer_channel, timeout=30)
-    current_jobs = writer_channel.list_known_jobs()
+    wait_no_working_writers(worker_pool, timeout=30)
+    current_jobs = worker_pool.list_known_jobs()
     for c_job in current_jobs:
         if c_job.job_id == write_job.job_id:
             assert "extra" in c_job.metadata

--- a/system-tests/test_filewriter_links.py
+++ b/system-tests/test_filewriter_links.py
@@ -9,8 +9,8 @@ from helpers.writer import (
 )
 
 
-def test_static_data_reaches_file(writer_channel, worker_pool, kafka_address):
-    wait_writers_available(writer_channel, nr_of=1, timeout=10)
+def test_static_data_reaches_file(worker_pool, kafka_address):
+    wait_writers_available(worker_pool, nr_of=1, timeout=10)
     now = datetime.now()
     start_time = now - timedelta(seconds=10)
     stop_time = now
@@ -26,7 +26,7 @@ def test_static_data_reaches_file(writer_channel, worker_pool, kafka_address):
     )
     wait_start_job(worker_pool, write_job, timeout=20)
 
-    wait_no_working_writers(writer_channel, timeout=30)
+    wait_no_working_writers(worker_pool, timeout=30)
 
     file_path = f"output-files/{file_name}"
     with OpenNexusFile(file_path) as file:

--- a/system-tests/test_filewriter_static_data.py
+++ b/system-tests/test_filewriter_static_data.py
@@ -12,8 +12,8 @@ from helpers.writer import (
 )
 
 
-def test_static_data_reaches_file(writer_channel, worker_pool, kafka_address):
-    wait_writers_available(writer_channel, nr_of=1, timeout=10)
+def test_static_data_reaches_file(worker_pool, kafka_address):
+    wait_writers_available(worker_pool, nr_of=1, timeout=10)
     now = datetime.now()
     start_time = now - timedelta(seconds=10)
     stop_time = now
@@ -29,7 +29,7 @@ def test_static_data_reaches_file(writer_channel, worker_pool, kafka_address):
     )
     wait_start_job(worker_pool, write_job, timeout=20)
 
-    wait_no_working_writers(writer_channel, timeout=30)
+    wait_no_working_writers(worker_pool, timeout=30)
 
     file_path = f"output-files/{file_name}"
     with OpenNexusFile(file_path) as file:

--- a/system-tests/test_filewriter_stop_time.py
+++ b/system-tests/test_filewriter_stop_time.py
@@ -18,9 +18,9 @@ from helpers.writer import (
 
 
 def test_start_and_stop_time_are_in_the_past(
-    writer_channel, worker_pool, kafka_address
+    worker_pool, kafka_address
 ):
-    wait_writers_available(writer_channel, nr_of=1, timeout=10)
+    wait_writers_available(worker_pool, nr_of=1, timeout=10)
     producer = create_producer()
 
     data_topics = ["TEST_historicalData1", "TEST_historicalData2"]
@@ -71,7 +71,7 @@ def test_start_and_stop_time_are_in_the_past(
     )
     wait_start_job(worker_pool, write_job, timeout=20)
 
-    wait_no_working_writers(writer_channel, timeout=30)
+    wait_no_working_writers(worker_pool, timeout=30)
 
     # The command also includes a stream for topic TEST_emptyTopic which exists but has no data in it, the
     # file writer should recognise there is no data in that topic and close the corresponding streamer without problem.

--- a/system-tests/test_filewriter_stop_time.py
+++ b/system-tests/test_filewriter_stop_time.py
@@ -17,9 +17,7 @@ from helpers.writer import (
 )
 
 
-def test_start_and_stop_time_are_in_the_past(
-    worker_pool, kafka_address
-):
+def test_start_and_stop_time_are_in_the_past(worker_pool, kafka_address):
     wait_writers_available(worker_pool, nr_of=1, timeout=10)
     producer = create_producer()
 

--- a/system-tests/test_repeated_messages_logic.py
+++ b/system-tests/test_repeated_messages_logic.py
@@ -13,9 +13,7 @@ from helpers.writer import (
 import numpy as np
 
 
-def test_start_and_stop_time_are_in_the_past(
-    worker_pool, kafka_address
-):
+def test_start_and_stop_time_are_in_the_past(worker_pool, kafka_address):
     wait_writers_available(worker_pool, nr_of=1, timeout=10)
     producer = create_producer()
 

--- a/system-tests/test_repeated_messages_logic.py
+++ b/system-tests/test_repeated_messages_logic.py
@@ -14,9 +14,9 @@ import numpy as np
 
 
 def test_start_and_stop_time_are_in_the_past(
-    writer_channel, worker_pool, kafka_address
+    worker_pool, kafka_address
 ):
-    wait_writers_available(writer_channel, nr_of=1, timeout=10)
+    wait_writers_available(worker_pool, nr_of=1, timeout=10)
     producer = create_producer()
 
     data_topic = "TEST_repeatedMessages"
@@ -56,7 +56,7 @@ def test_start_and_stop_time_are_in_the_past(
     )
     wait_start_job(worker_pool, write_job, timeout=20)
 
-    wait_no_working_writers(writer_channel, timeout=30)
+    wait_no_working_writers(worker_pool, timeout=30)
 
     file_path = f"output-files/{file_name}"
     with OpenNexusFile(file_path) as file:

--- a/system-tests/test_same_id_multiple_modules.py
+++ b/system-tests/test_same_id_multiple_modules.py
@@ -15,9 +15,9 @@ from helpers.writer import (
 
 
 def test_two_different_writer_modules_with_same_flatbuffer_id(
-    writer_channel, worker_pool, kafka_address
+    worker_pool, kafka_address
 ):
-    wait_writers_available(writer_channel, nr_of=1, timeout=10)
+    wait_writers_available(worker_pool, nr_of=1, timeout=10)
     producer = create_producer()
     start_time = datetime.now() - timedelta(seconds=10)
     for i in range(10):
@@ -45,7 +45,7 @@ def test_two_different_writer_modules_with_same_flatbuffer_id(
         stop_time=datetime.now(),
     )
     wait_start_job(worker_pool, write_job, timeout=20)
-    wait_no_working_writers(writer_channel, timeout=30)
+    wait_no_working_writers(worker_pool, timeout=30)
 
     file_path = f"output-files/{file_name}"
     with OpenNexusFile(file_path) as file:


### PR DESCRIPTION
### Issue

ECDC-2619

### Description of work

Removing the non-job pool way to run file writer as we want to move away from having two separate ways to run the filewriter.
It should be possible to provide the same topic name for both the job pool and and command status
command-status-uri=localhost:9092/Loki_writerCommand
job-pool-uri=localhost:9092/Loki_writerCommand

System tests are updated to only use the job pool mode and nothing else.
There are also updates to the file-writer-control library found in this PR:
https://github.com/ess-dmsc/file-writer-control/pull/39
