### PR TITLE
Update build node and dependency versions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -337,17 +337,17 @@ def integration_test(builder, container) {
     }
 }
 
-String ubuntu_key = "ubuntu2004"
+String ubuntu_key = "ubuntu2204"
 String centos_key = "centos7"
 String release_key = "centos7-release"
 String integration_test_key = "integration-test"
 String static_checks_key = "static-checks"
 
 container_build_nodes = [
-  (centos_key): ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8'),
-  (release_key): ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8'),
-  (ubuntu_key): ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2004'),
-  (static_checks_key): ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2004')
+  (centos_key): ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11'),
+  (release_key): ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11'),
+  (ubuntu_key): ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2204'),
+  (static_checks_key): ContainerBuildNode.getDefaultContainerBuildNode('ubuntu2204')
 ]
 
 base_steps = [{b,c -> checkout(b, c)}, {b,c -> cpp_dependencies(b, c)}]

--- a/changes.md
+++ b/changes.md
@@ -6,6 +6,8 @@
 - Improved help text formatting.
 - Added code for running Kafka tests. This code is disabled by default.
 - It is now possible to set the Kafka poll timeout from the command line. This option should rarely (if ever) be used.
+- The following dependencies have been updated:
+  - graylog-logger ([#650](https://github.com/ess-dmsc/kafka-to-nexus/pull/650))
 
 ## Version 5.1.0: Attributes and dependencies
 

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -8,7 +8,7 @@ nlohmann_json/3.10.5
 streaming-data-types/3c24787
 cli11/2.2.0
 trompeloeil/42
-graylog-logger/2.1.3
+graylog-logger/2.1.4@ess-dmsc/stable
 date/3.0.1
 readerwriterqueue/1.0.6
 concurrentqueue/1.0.3

--- a/src/tests/helpers/RunStartStopHelpers.h
+++ b/src/tests/helpers/RunStartStopHelpers.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <optional>
+#include <string>
 
 namespace FileWriter {
 struct Msg;


### PR DESCRIPTION
### Issue

ECDC-3102

### Description of work

Update build node versions in Jenkinsfile. The CentOS 7 build now uses GCC 11, and the version of graylog-logger was updated in _conanfile.txt_.

### Nominate for Group Code Review

- [ ] Nominate for code review 

### Reminder

*Changes should be documented in `changes.md`*
