### PR TITLE
CI: Enable SSL and SASL in librdkafka via conanfile.txt

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -361,7 +361,7 @@ container_build_node_steps = [
 ]
 
 if ( env.CHANGE_ID ) {
-  container_build_nodes[integration_test_key] = ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc8')
+  container_build_nodes[integration_test_key] = ContainerBuildNode.getDefaultContainerBuildNode('centos7-gcc11')
 }
 
 pipeline_builder = new PipelineBuilder(this, container_build_nodes)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -413,6 +413,7 @@ def get_macos_pipeline() {
           try {
           // temporary conan remove until all projects move to new package version
           sh "conan remove -f FlatBuffers/*"
+          sh "conan remove -f OpenSSL/*"
           sh "conan remove -f cli11/*"
             checkout scm
           } catch (e) {

--- a/changes.md
+++ b/changes.md
@@ -8,6 +8,7 @@
 - It is now possible to set the Kafka poll timeout from the command line. This option should rarely (if ever) be used.
 - The following dependencies have been updated:
   - graylog-logger ([#650](https://github.com/ess-dmsc/kafka-to-nexus/pull/650))
+- Enabled SSL and SASL in librdkafka to support Kafka authentication.
 
 ## Version 5.1.0: Attributes and dependencies
 

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -26,6 +26,8 @@ gtest:shared=False
 hdf5:shared=True
 h5cpp:with_boost=False
 librdkafka:shared=True
+librdkafka:ssl=True
+librdkafka:sasl=True
 date:use_system_tz_db=True
 
 [imports]


### PR DESCRIPTION
### Issue

https://jira.esss.lu.se/browse/ECDC-2142

### Description of work

Authentication attempts against Kafka listeners with SASL/SCRAM seem to fail.

This PR enables SSL and SASL in librdkafka to leverage existing SASL/SCRAM support in the library.


### Nominate for Group Code Review

- [ ] Nominate for code review 

