### PR TITLE
ECDC-3107: honour broker settings

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -9,6 +9,7 @@
 - The following dependencies have been updated:
   - graylog-logger ([#650](https://github.com/ess-dmsc/kafka-to-nexus/pull/650))
 - Enabled SSL and SASL in librdkafka to support Kafka authentication.
+- Fix to make all Kafka connections honour the provided librdkafka parameters.
 
 ## Version 5.1.0: Attributes and dependencies
 

--- a/src/Kafka/MetaDataQuery.cpp
+++ b/src/Kafka/MetaDataQuery.cpp
@@ -29,8 +29,8 @@ std::vector<int> getPartitionsForTopic(std::string const &Broker,
       Broker, Topic, TimeOut, BrokerSettings);
 }
 
-std::set<std::string> getTopicList(std::string const &Broker,
-                                   duration TimeOut, BrokerSettings BrokerSettings) {
+std::set<std::string> getTopicList(std::string const &Broker, duration TimeOut,
+                                   BrokerSettings BrokerSettings) {
   return getTopicListImpl<RdKafka::Consumer>(Broker, TimeOut, BrokerSettings);
 }
 

--- a/src/Kafka/MetaDataQuery.cpp
+++ b/src/Kafka/MetaDataQuery.cpp
@@ -16,21 +16,22 @@ namespace Kafka {
 std::vector<std::pair<int, int64_t>>
 getOffsetForTime(std::string const &Broker, std::string const &Topic,
                  std::vector<int> const &Partitions, time_point Time,
-                 duration TimeOut) {
+                 duration TimeOut, BrokerSettings BrokerSettings) {
   return getOffsetForTimeImpl<RdKafka::Consumer>(Broker, Topic, Partitions,
-                                                 Time, TimeOut);
+                                                 Time, TimeOut, BrokerSettings);
 }
 
 std::vector<int> getPartitionsForTopic(std::string const &Broker,
                                        std::string const &Topic,
-                                       duration TimeOut) {
+                                       duration TimeOut,
+                                       BrokerSettings BrokerSettings) {
   return getPartitionsForTopicImpl<RdKafka::Consumer, RdKafka::Topic>(
-      Broker, Topic, TimeOut);
+      Broker, Topic, TimeOut, BrokerSettings);
 }
 
 std::set<std::string> getTopicList(std::string const &Broker,
-                                   duration TimeOut) {
-  return getTopicListImpl<RdKafka::Consumer>(Broker, TimeOut);
+                                   duration TimeOut, BrokerSettings BrokerSettings) {
+  return getTopicListImpl<RdKafka::Consumer>(Broker, TimeOut, BrokerSettings);
 }
 
 } // namespace Kafka

--- a/src/Kafka/MetaDataQuery.h
+++ b/src/Kafka/MetaDataQuery.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "Kafka/BrokerSettings.h"
 #include "TimeUtility.h"
 #include <chrono>
 #include <librdkafka/rdkafkacpp.h>
@@ -20,12 +21,14 @@ namespace Kafka {
 std::vector<std::pair<int, int64_t>>
 getOffsetForTime(std::string const &Broker, std::string const &Topic,
                  std::vector<int> const &Partitions, time_point Time,
-                 duration TimeOut);
+                 duration TimeOut, BrokerSettings BrokerSettings);
 
 std::vector<int> getPartitionsForTopic(std::string const &Broker,
                                        std::string const &Topic,
-                                       duration TimeOut);
+                                       duration TimeOut,
+                                       BrokerSettings BrokerSettings);
 
-std::set<std::string> getTopicList(std::string const &Broker, duration TimeOut);
+std::set<std::string> getTopicList(std::string const &Broker, duration TimeOut,
+                                   BrokerSettings BrokerSettings);
 
 } // namespace Kafka

--- a/src/Kafka/MetaDataQueryImpl.h
+++ b/src/Kafka/MetaDataQueryImpl.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "Kafka/BrokerSettings.h"
 #include "Kafka/MetadataException.h"
 #include "TimeUtility.h"
 #include <chrono>
@@ -25,10 +26,19 @@ findKafkaTopic(const std::string &Topic,
                const RdKafka::Metadata *KafkaMetadata);
 
 template <class KafkaHandle, class KafkaConf>
-std::unique_ptr<RdKafka::Handle> getKafkaHandle(std::string Broker) {
+std::unique_ptr<RdKafka::Handle> getKafkaHandle(std::string Broker, BrokerSettings BrokerSettings) {
   auto Conf =
       std::unique_ptr<KafkaConf>(KafkaConf::create(RdKafka::Conf::CONF_GLOBAL));
   std::string ErrorStr;
+  auto iter = BrokerSettings.KafkaConfiguration.begin();
+  while (iter != BrokerSettings.KafkaConfiguration.end()) {
+    if (Conf->set(iter->first, iter->second, ErrorStr) !=
+        RdKafka::Conf::CONF_OK) {
+      throw MetadataException(fmt::format(
+          R"(Got error when configuring metadata brokers "{}" setting: "{}")", iter->first, ErrorStr));
+    }
+    ++iter;
+  }
   if (Conf->set("metadata.broker.list", Broker, ErrorStr) !=
       RdKafka::Conf::CONF_OK) {
     throw MetadataException(fmt::format(
@@ -46,8 +56,8 @@ template <class KafkaHandle>
 std::vector<std::pair<int, int64_t>>
 getOffsetForTimeImpl(std::string const &Broker, std::string const &Topic,
                      std::vector<int> const &Partitions, time_point Time,
-                     duration TimeOut) {
-  auto Handle = getKafkaHandle<KafkaHandle, RdKafka::Conf>(Broker);
+                     duration TimeOut, BrokerSettings BrokerSettings) {
+  auto Handle = getKafkaHandle<KafkaHandle, RdKafka::Conf>(Broker, BrokerSettings);
   auto UsedTime = toMilliSeconds(Time);
   std::vector<std::unique_ptr<RdKafka::TopicPartition>> TopicPartitions;
   std::vector<RdKafka::TopicPartition *> TopicPartitionsRaw;
@@ -93,8 +103,9 @@ std::vector<int> extractPartitinIDs(MetaDataType TopicMetaData) {
 template <class KafkaHandle, class KafkaTopic>
 std::vector<int> getPartitionsForTopicImpl(std::string const &Broker,
                                            std::string const &Topic,
-                                           duration TimeOut) {
-  auto Handle = getKafkaHandle<KafkaHandle, RdKafka::Conf>(Broker);
+                                           duration TimeOut,
+                                           BrokerSettings BrokerSettings) {
+  auto Handle = getKafkaHandle<KafkaHandle, RdKafka::Conf>(Broker, BrokerSettings);
   std::string ErrorStr;
   auto TopicObj = std::unique_ptr<RdKafka::Topic>(
       KafkaTopic::create(Handle.get(), Topic, nullptr, ErrorStr));
@@ -116,8 +127,9 @@ std::vector<int> getPartitionsForTopicImpl(std::string const &Broker,
 
 template <class KafkaHandle>
 std::set<std::string> getTopicListImpl(std::string const &Broker,
-                                       duration TimeOut) {
-  auto Handle = getKafkaHandle<KafkaHandle, RdKafka::Conf>(Broker);
+                                       duration TimeOut,
+                                       BrokerSettings BrokerSettings) {
+  auto Handle = getKafkaHandle<KafkaHandle, RdKafka::Conf>(Broker, BrokerSettings);
   std::string ErrorStr;
   auto TimeOutInMs = toMilliSeconds(TimeOut);
   RdKafka::Metadata *MetadataPtr{nullptr};

--- a/src/Kafka/MetaDataQueryImpl.h
+++ b/src/Kafka/MetaDataQueryImpl.h
@@ -26,7 +26,8 @@ findKafkaTopic(const std::string &Topic,
                const RdKafka::Metadata *KafkaMetadata);
 
 template <class KafkaHandle, class KafkaConf>
-std::unique_ptr<RdKafka::Handle> getKafkaHandle(std::string Broker, BrokerSettings BrokerSettings) {
+std::unique_ptr<RdKafka::Handle> getKafkaHandle(std::string Broker,
+                                                BrokerSettings BrokerSettings) {
   auto Conf =
       std::unique_ptr<KafkaConf>(KafkaConf::create(RdKafka::Conf::CONF_GLOBAL));
   std::string ErrorStr;
@@ -35,7 +36,8 @@ std::unique_ptr<RdKafka::Handle> getKafkaHandle(std::string Broker, BrokerSettin
     if (Conf->set(iter->first, iter->second, ErrorStr) !=
         RdKafka::Conf::CONF_OK) {
       throw MetadataException(fmt::format(
-          R"(Got error when configuring metadata brokers "{}" setting: "{}")", iter->first, ErrorStr));
+          R"(Got error when configuring metadata brokers "{}" setting: "{}")",
+          iter->first, ErrorStr));
     }
     ++iter;
   }
@@ -57,7 +59,8 @@ std::vector<std::pair<int, int64_t>>
 getOffsetForTimeImpl(std::string const &Broker, std::string const &Topic,
                      std::vector<int> const &Partitions, time_point Time,
                      duration TimeOut, BrokerSettings BrokerSettings) {
-  auto Handle = getKafkaHandle<KafkaHandle, RdKafka::Conf>(Broker, BrokerSettings);
+  auto Handle =
+      getKafkaHandle<KafkaHandle, RdKafka::Conf>(Broker, BrokerSettings);
   auto UsedTime = toMilliSeconds(Time);
   std::vector<std::unique_ptr<RdKafka::TopicPartition>> TopicPartitions;
   std::vector<RdKafka::TopicPartition *> TopicPartitionsRaw;
@@ -101,11 +104,11 @@ std::vector<int> extractPartitinIDs(MetaDataType TopicMetaData) {
 }
 
 template <class KafkaHandle, class KafkaTopic>
-std::vector<int> getPartitionsForTopicImpl(std::string const &Broker,
-                                           std::string const &Topic,
-                                           duration TimeOut,
-                                           BrokerSettings BrokerSettings) {
-  auto Handle = getKafkaHandle<KafkaHandle, RdKafka::Conf>(Broker, BrokerSettings);
+std::vector<int>
+getPartitionsForTopicImpl(std::string const &Broker, std::string const &Topic,
+                          duration TimeOut, BrokerSettings BrokerSettings) {
+  auto Handle =
+      getKafkaHandle<KafkaHandle, RdKafka::Conf>(Broker, BrokerSettings);
   std::string ErrorStr;
   auto TopicObj = std::unique_ptr<RdKafka::Topic>(
       KafkaTopic::create(Handle.get(), Topic, nullptr, ErrorStr));
@@ -129,7 +132,8 @@ template <class KafkaHandle>
 std::set<std::string> getTopicListImpl(std::string const &Broker,
                                        duration TimeOut,
                                        BrokerSettings BrokerSettings) {
-  auto Handle = getKafkaHandle<KafkaHandle, RdKafka::Conf>(Broker, BrokerSettings);
+  auto Handle =
+      getKafkaHandle<KafkaHandle, RdKafka::Conf>(Broker, BrokerSettings);
   std::string ErrorStr;
   auto TimeOutInMs = toMilliSeconds(TimeOut);
   RdKafka::Metadata *MetadataPtr{nullptr};

--- a/src/Stream/Topic.cpp
+++ b/src/Stream/Topic.cpp
@@ -100,19 +100,17 @@ void Topic::setErrorState(const std::string &Msg) {
   return;
 }
 
-std::vector<std::pair<int, int64_t>>
-Topic::getOffsetForTimeInternal(std::string const &Broker,
-                                std::string const &Topic,
-                                std::vector<int> const &Partitions,
-                                time_point Time, duration TimeOut,
-                                Kafka::BrokerSettings BrokerSettings) const {
-  return Kafka::getOffsetForTime(Broker, Topic, Partitions, Time, TimeOut, BrokerSettings);
+std::vector<std::pair<int, int64_t>> Topic::getOffsetForTimeInternal(
+    std::string const &Broker, std::string const &Topic,
+    std::vector<int> const &Partitions, time_point Time, duration TimeOut,
+    Kafka::BrokerSettings BrokerSettings) const {
+  return Kafka::getOffsetForTime(Broker, Topic, Partitions, Time, TimeOut,
+                                 BrokerSettings);
 }
 
-std::vector<int> Topic::getPartitionsForTopicInternal(std::string const &Broker,
-                                                      std::string const &Topic,
-                                                      duration TimeOut,
-                                                      Kafka::BrokerSettings BrokerSettings) const {
+std::vector<int> Topic::getPartitionsForTopicInternal(
+    std::string const &Broker, std::string const &Topic, duration TimeOut,
+    Kafka::BrokerSettings BrokerSettings) const {
   return Kafka::getPartitionsForTopic(Broker, Topic, TimeOut, BrokerSettings);
 }
 

--- a/src/Stream/Topic.cpp
+++ b/src/Stream/Topic.cpp
@@ -8,6 +8,7 @@
 // Screaming Udder!                              https://esss.se
 
 #include "Topic.h"
+#include "Kafka/BrokerSettings.h"
 #include "Kafka/ConsumerFactory.h"
 #include "Kafka/MetaDataQuery.h"
 #include "logger.h"
@@ -60,7 +61,7 @@ void Topic::getPartitionsForTopic(Kafka::BrokerSettings const &Settings,
                                   std::string const &Topic) {
   try {
     auto FoundPartitions = getPartitionsForTopicInternal(
-        Settings.Address, Topic, CurrentMetadataTimeOut);
+        Settings.Address, Topic, CurrentMetadataTimeOut, Settings);
     Executor.sendWork([=]() {
       CurrentMetadataTimeOut = Settings.MinMetadataTimeout;
       getOffsetsForPartitions(Settings, Topic, FoundPartitions);
@@ -103,14 +104,16 @@ std::vector<std::pair<int, int64_t>>
 Topic::getOffsetForTimeInternal(std::string const &Broker,
                                 std::string const &Topic,
                                 std::vector<int> const &Partitions,
-                                time_point Time, duration TimeOut) const {
-  return Kafka::getOffsetForTime(Broker, Topic, Partitions, Time, TimeOut);
+                                time_point Time, duration TimeOut,
+                                Kafka::BrokerSettings BrokerSettings) const {
+  return Kafka::getOffsetForTime(Broker, Topic, Partitions, Time, TimeOut, BrokerSettings);
 }
 
 std::vector<int> Topic::getPartitionsForTopicInternal(std::string const &Broker,
                                                       std::string const &Topic,
-                                                      duration TimeOut) const {
-  return Kafka::getPartitionsForTopic(Broker, Topic, TimeOut);
+                                                      duration TimeOut,
+                                                      Kafka::BrokerSettings BrokerSettings) const {
+  return Kafka::getPartitionsForTopic(Broker, Topic, TimeOut, BrokerSettings);
 }
 
 void Topic::getOffsetsForPartitions(Kafka::BrokerSettings const &Settings,
@@ -119,7 +122,7 @@ void Topic::getOffsetsForPartitions(Kafka::BrokerSettings const &Settings,
   try {
     auto PartitionOffsetList = getOffsetForTimeInternal(
         Settings.Address, Topic, Partitions, StartConsumeTime - StartLeeway,
-        CurrentMetadataTimeOut);
+        CurrentMetadataTimeOut, Settings);
     Executor.sendWork([=]() {
       CurrentMetadataTimeOut = Settings.MinMetadataTimeout;
       createStreams(Settings, Topic, PartitionOffsetList);

--- a/src/Stream/Topic.h
+++ b/src/Stream/Topic.h
@@ -90,12 +90,13 @@ protected:
   virtual std::vector<std::pair<int, int64_t>>
   getOffsetForTimeInternal(std::string const &Broker, std::string const &Topic,
                            std::vector<int> const &Partitions, time_point Time,
-                           duration TimeOut) const;
+                           duration TimeOut, Kafka::BrokerSettings BrokerSettings) const;
 
   virtual std::vector<int>
   getPartitionsForTopicInternal(std::string const &Broker,
                                 std::string const &Topic,
-                                duration TimeOut) const;
+                                duration TimeOut,
+                                Kafka::BrokerSettings BrokerSettings) const;
 
   void checkIfDone();
   virtual void checkIfDoneTask();

--- a/src/Stream/Topic.h
+++ b/src/Stream/Topic.h
@@ -90,12 +90,12 @@ protected:
   virtual std::vector<std::pair<int, int64_t>>
   getOffsetForTimeInternal(std::string const &Broker, std::string const &Topic,
                            std::vector<int> const &Partitions, time_point Time,
-                           duration TimeOut, Kafka::BrokerSettings BrokerSettings) const;
+                           duration TimeOut,
+                           Kafka::BrokerSettings BrokerSettings) const;
 
   virtual std::vector<int>
   getPartitionsForTopicInternal(std::string const &Broker,
-                                std::string const &Topic,
-                                duration TimeOut,
+                                std::string const &Topic, duration TimeOut,
                                 Kafka::BrokerSettings BrokerSettings) const;
 
   void checkIfDone();

--- a/src/StreamController.cpp
+++ b/src/StreamController.cpp
@@ -71,7 +71,8 @@ std::string StreamController::getJobId() const { return WriterTask->jobID(); }
 void StreamController::getTopicNames() {
   try {
     auto TopicNames = Kafka::getTopicList(KafkaSettings.BrokerSettings.Address,
-                                          CurrentMetadataTimeOut);
+                                          CurrentMetadataTimeOut,
+                                          KafkaSettings.BrokerSettings);
     Executor.sendLowPriorityWork([=]() { initStreams(TopicNames); });
   } catch (MetadataException &E) {
     CurrentMetadataTimeOut *= 2;

--- a/src/kafka-to-nexus.cpp
+++ b/src/kafka-to-nexus.cpp
@@ -67,7 +67,8 @@ std::unique_ptr<Status::StatusReporter>
 createStatusReporter(MainOpt const &MainConfig,
                      std::string const &ApplicationName,
                      std::string const &ApplicationVersion) {
-  Kafka::BrokerSettings BrokerSettings = MainConfig.StreamerConfiguration.BrokerSettings;
+  Kafka::BrokerSettings BrokerSettings =
+      MainConfig.StreamerConfiguration.BrokerSettings;
   BrokerSettings.Address = MainConfig.CommandBrokerURI.HostPort;
   auto const StatusInformation =
       Status::ApplicationStatusInfo{MainConfig.StatusMasterInterval,

--- a/src/kafka-to-nexus.cpp
+++ b/src/kafka-to-nexus.cpp
@@ -67,7 +67,7 @@ std::unique_ptr<Status::StatusReporter>
 createStatusReporter(MainOpt const &MainConfig,
                      std::string const &ApplicationName,
                      std::string const &ApplicationVersion) {
-  Kafka::BrokerSettings BrokerSettings;
+  Kafka::BrokerSettings BrokerSettings = MainConfig.StreamerConfiguration.BrokerSettings;
   BrokerSettings.Address = MainConfig.CommandBrokerURI.HostPort;
   auto const StatusInformation =
       Status::ApplicationStatusInfo{MainConfig.StatusMasterInterval,
@@ -82,9 +82,10 @@ createStatusReporter(MainOpt const &MainConfig,
 }
 
 bool tryToFindTopics(std::string PoolTopic, std::string CommandTopic,
-                     std::string Broker, duration TimeOut) {
+                     std::string Broker, duration TimeOut,
+                     Kafka::BrokerSettings BrokerSettings) {
   try {
-    auto ListOfTopics = Kafka::getTopicList(Broker, TimeOut);
+    auto ListOfTopics = Kafka::getTopicList(Broker, TimeOut, BrokerSettings);
     if (ListOfTopics.find(PoolTopic) == ListOfTopics.end()) {
       auto MsgString = fmt::format(
           R"(Unable to find job pool topic with name "{}".)", PoolTopic);
@@ -218,7 +219,8 @@ int main(int argc, char **argv) {
       if (FindTopicMode) {
         if (tryToFindTopics(PoolTopic, CommandTopic,
                             Options->CommandBrokerURI.HostPort,
-                            CMetaDataTimeout)) {
+                            CMetaDataTimeout,
+                            Options->StreamerConfiguration.BrokerSettings)) {
           LOG_DEBUG("Command and status topics found, starting master.");
           MasterPtr = GenerateMaster();
           FindTopicMode = false;

--- a/src/tests/MetaDataQueryTests.cpp
+++ b/src/tests/MetaDataQueryTests.cpp
@@ -49,14 +49,16 @@ class CreateKafkaHandleTest : public ::testing::Test {
 
 TEST_F(CreateKafkaHandleTest, OnSuccess) {
   Kafka::BrokerSettings BrokerSettings = {};
-  auto Result =
-      Kafka::getKafkaHandle<RdKafka::Consumer, RdKafka::Conf>("some_broker", BrokerSettings);
+  auto Result = Kafka::getKafkaHandle<RdKafka::Consumer, RdKafka::Conf>(
+      "some_broker", BrokerSettings);
   EXPECT_FALSE(Result == nullptr);
 }
 
 TEST_F(CreateKafkaHandleTest, FailureToCreateHandleThrows) {
-  auto testFunc = [](auto Adr, auto BrokerSettings) { // Work around for GTest limitation
-    return Kafka::getKafkaHandle<UsedProducerMock, RdKafka::Conf>(Adr, BrokerSettings);
+  auto testFunc = [](auto Adr,
+                     auto BrokerSettings) { // Work around for GTest limitation
+    return Kafka::getKafkaHandle<UsedProducerMock, RdKafka::Conf>(
+        Adr, BrokerSettings);
   };
   Kafka::BrokerSettings BrokerSettings = {};
   EXPECT_THROW(testFunc("some_broker", BrokerSettings), MetadataException);
@@ -64,8 +66,10 @@ TEST_F(CreateKafkaHandleTest, FailureToCreateHandleThrows) {
 }
 
 TEST_F(CreateKafkaHandleTest, FailureToSetBrokerThrows) {
-  auto testFunc = [](auto Adr, auto BrokerSettings) { // Work around for GTest limitation
-    return Kafka::getKafkaHandle<UsedProducerMock, UsedConfMock>(Adr, BrokerSettings);
+  auto testFunc = [](auto Adr,
+                     auto BrokerSettings) { // Work around for GTest limitation
+    return Kafka::getKafkaHandle<UsedProducerMock, UsedConfMock>(
+        Adr, BrokerSettings);
   };
   Kafka::BrokerSettings BrokerSettings = {};
   EXPECT_THROW(testFunc("some_broker", BrokerSettings), MetadataException);
@@ -201,17 +205,15 @@ TEST_F(GetTopicNamesTest, OnSuccess) {
   UsedProducerMockAlt::ReturnErrorCode = RdKafka::ErrorCode::ERR_NO_ERROR;
   auto ExpectedTopics = std::set<std::string>{"some_topic", "some_other_topic"};
   Kafka::BrokerSettings BrokerSettings;
-  auto ReceivedTopics =
-      Kafka::getTopicListImpl<UsedProducerMockAlt>("Some_broker", 10ms,
-        BrokerSettings);
+  auto ReceivedTopics = Kafka::getTopicListImpl<UsedProducerMockAlt>(
+      "Some_broker", 10ms, BrokerSettings);
   EXPECT_EQ(ReceivedTopics, ExpectedTopics);
 }
 
 TEST_F(GetTopicNamesTest, MetadataFailure) {
   UsedProducerMockAlt::ReturnErrorCode = RdKafka::ErrorCode::ERR__TIMED_OUT;
   Kafka::BrokerSettings BrokerSettings;
-  EXPECT_THROW(
-      Kafka::getTopicListImpl<UsedProducerMockAlt>("Some_broker", 10ms,
-        BrokerSettings),
-      MetadataException);
+  EXPECT_THROW(Kafka::getTopicListImpl<UsedProducerMockAlt>("Some_broker", 10ms,
+                                                            BrokerSettings),
+               MetadataException);
 }

--- a/src/tests/Stream/TopicTests.cpp
+++ b/src/tests/Stream/TopicTests.cpp
@@ -7,6 +7,7 @@
 //
 // Screaming Udder!                              https://esss.se
 
+#include "Kafka/BrokerSettings.h"
 #include "Kafka/Consumer.h"
 #include "Kafka/MetadataException.h"
 #include "Metrics/Registrar.h"
@@ -41,13 +42,14 @@ public:
   using Topic::CurrentMetadataTimeOut;
   using Topic::Executor;
   using offset_list = std::vector<std::pair<int, int64_t>>;
-  MAKE_CONST_MOCK5(getOffsetForTimeInternal,
+  MAKE_CONST_MOCK6(getOffsetForTimeInternal,
                    offset_list(std::string const &, std::string const &,
-                               std::vector<int> const &, time_point, duration),
+                               std::vector<int> const &, time_point, duration,
+                               Kafka::BrokerSettings BrokerSettings),
                    override);
-  MAKE_CONST_MOCK3(getPartitionsForTopicInternal,
+  MAKE_CONST_MOCK4(getPartitionsForTopicInternal,
                    std::vector<int>(std::string const &, std::string const &,
-                                    duration),
+                                    duration, Kafka::BrokerSettings BrokerSettings),
                    override);
   MAKE_MOCK2(getPartitionsForTopic,
              void(Kafka::BrokerSettings const &, std::string const &),
@@ -133,7 +135,7 @@ TEST_F(TopicTest, IfGetPartitionsForTopicExceptionThenReExecute) {
   // unsuccessful
   REQUIRE_CALL(*UnderTest, shouldGiveUp()).TIMES(1).RETURN(false);
   REQUIRE_CALL(*UnderTest, getPartitionsForTopic(_, UsedTopicName)).TIMES(1);
-  REQUIRE_CALL(*UnderTest, getPartitionsForTopicInternal(_, UsedTopicName, _))
+  REQUIRE_CALL(*UnderTest, getPartitionsForTopicInternal(_, UsedTopicName, _, _))
       .TIMES(1)
       .THROW(MetadataException("Test"));
   UnderTest->getPartitionsForTopicBase(KafkaSettings, UsedTopicName);
@@ -148,7 +150,7 @@ TEST_F(TopicTest, GetPartitionsForTopicTimeOut) {
   // unsuccessful
   FORBID_CALL(*UnderTest, getPartitionsForTopic(_, _));
   REQUIRE_CALL(*UnderTest, shouldGiveUp()).TIMES(1).RETURN(true);
-  REQUIRE_CALL(*UnderTest, getPartitionsForTopicInternal(_, UsedTopicName, _))
+  REQUIRE_CALL(*UnderTest, getPartitionsForTopicInternal(_, UsedTopicName, _, _))
       .TIMES(1)
       .THROW(MetadataException("Test"));
   UnderTest->getPartitionsForTopicBase(KafkaSettings, UsedTopicName);
@@ -161,7 +163,7 @@ TEST_F(TopicTest, IfGetPartitionsForTopicSuccessThenNotReExecuted) {
   std::vector<int> ReturnPartitions{2, 3};
 
   FORBID_CALL(*UnderTest, getPartitionsForTopic(_, _));
-  REQUIRE_CALL(*UnderTest, getPartitionsForTopicInternal(_, UsedTopicName, _))
+    REQUIRE_CALL(*UnderTest, getPartitionsForTopicInternal(_, UsedTopicName, _, _))
       .TIMES(1)
       .RETURN(ReturnPartitions);
   REQUIRE_CALL(*UnderTest,
@@ -183,7 +185,7 @@ TEST_F(TopicTest, IfGetOffsetsForPartitionsExceptionThenReExecute) {
                getOffsetsForPartitions(_, UsedTopicName, Partitions))
       .TIMES(1);
   REQUIRE_CALL(*UnderTest,
-               getOffsetForTimeInternal(_, UsedTopicName, Partitions, _, _))
+               getOffsetForTimeInternal(_, UsedTopicName, Partitions, _, _, _))
       .TIMES(1)
       .THROW(MetadataException("Test"));
   UnderTest->getOffsetsForPartitionsBase(KafkaSettings, UsedTopicName,
@@ -201,7 +203,7 @@ TEST_F(TopicTest, GetOffsetsForPartitionsTimeOut) {
   FORBID_CALL(*UnderTest, getOffsetsForPartitions(_, _, _));
   REQUIRE_CALL(*UnderTest, shouldGiveUp()).TIMES(1).RETURN(true);
   REQUIRE_CALL(*UnderTest,
-               getOffsetForTimeInternal(_, UsedTopicName, Partitions, _, _))
+               getOffsetForTimeInternal(_, UsedTopicName, Partitions, _, _, _))
       .TIMES(1)
       .THROW(MetadataException("Test"));
   UnderTest->getOffsetsForPartitionsBase(KafkaSettings, UsedTopicName,
@@ -217,7 +219,7 @@ TEST_F(TopicTest, IfGetOffsetsForPartitionsSuccessThenNotReExecuted) {
 
   FORBID_CALL(*UnderTest, getOffsetsForPartitions(_, _, _));
   REQUIRE_CALL(*UnderTest,
-               getOffsetForTimeInternal(_, UsedTopicName, Partitions, _, _))
+               getOffsetForTimeInternal(_, UsedTopicName, Partitions, _, _, _))
       .TIMES(1)
       .RETURN(ReturnOffsets);
   REQUIRE_CALL(*UnderTest, createStreams(_, UsedTopicName, ReturnOffsets))

--- a/src/tests/Stream/TopicTests.cpp
+++ b/src/tests/Stream/TopicTests.cpp
@@ -49,7 +49,8 @@ public:
                    override);
   MAKE_CONST_MOCK4(getPartitionsForTopicInternal,
                    std::vector<int>(std::string const &, std::string const &,
-                                    duration, Kafka::BrokerSettings BrokerSettings),
+                                    duration,
+                                    Kafka::BrokerSettings BrokerSettings),
                    override);
   MAKE_MOCK2(getPartitionsForTopic,
              void(Kafka::BrokerSettings const &, std::string const &),
@@ -135,7 +136,8 @@ TEST_F(TopicTest, IfGetPartitionsForTopicExceptionThenReExecute) {
   // unsuccessful
   REQUIRE_CALL(*UnderTest, shouldGiveUp()).TIMES(1).RETURN(false);
   REQUIRE_CALL(*UnderTest, getPartitionsForTopic(_, UsedTopicName)).TIMES(1);
-  REQUIRE_CALL(*UnderTest, getPartitionsForTopicInternal(_, UsedTopicName, _, _))
+  REQUIRE_CALL(*UnderTest,
+               getPartitionsForTopicInternal(_, UsedTopicName, _, _))
       .TIMES(1)
       .THROW(MetadataException("Test"));
   UnderTest->getPartitionsForTopicBase(KafkaSettings, UsedTopicName);
@@ -150,7 +152,8 @@ TEST_F(TopicTest, GetPartitionsForTopicTimeOut) {
   // unsuccessful
   FORBID_CALL(*UnderTest, getPartitionsForTopic(_, _));
   REQUIRE_CALL(*UnderTest, shouldGiveUp()).TIMES(1).RETURN(true);
-  REQUIRE_CALL(*UnderTest, getPartitionsForTopicInternal(_, UsedTopicName, _, _))
+  REQUIRE_CALL(*UnderTest,
+               getPartitionsForTopicInternal(_, UsedTopicName, _, _))
       .TIMES(1)
       .THROW(MetadataException("Test"));
   UnderTest->getPartitionsForTopicBase(KafkaSettings, UsedTopicName);
@@ -163,7 +166,8 @@ TEST_F(TopicTest, IfGetPartitionsForTopicSuccessThenNotReExecuted) {
   std::vector<int> ReturnPartitions{2, 3};
 
   FORBID_CALL(*UnderTest, getPartitionsForTopic(_, _));
-    REQUIRE_CALL(*UnderTest, getPartitionsForTopicInternal(_, UsedTopicName, _, _))
+  REQUIRE_CALL(*UnderTest,
+               getPartitionsForTopicInternal(_, UsedTopicName, _, _))
       .TIMES(1)
       .RETURN(ReturnPartitions);
   REQUIRE_CALL(*UnderTest,


### PR DESCRIPTION
### Issue

https://jira.esss.lu.se/browse/ECDC-3107

### Description of work

kafka-to-nexus performs a number of Kafka operations assuming that a broker address is enough to establish a connection. This is however not true for SSL or SASL connections, where librdkafka parameters read from `-X` flags must be used when creating the Kafka Handle.

This PR passes around the BrokerSettings (the ones created by parsed from command line parameters) to all parts of the code that create Kafka connections.


### Nominate for Group Code Review

- [ ] Nominate for code review 

