### PR TITLE
ECDC-3001: Silencing spamming messages

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -10,6 +10,7 @@
   - graylog-logger ([#650](https://github.com/ess-dmsc/kafka-to-nexus/pull/650))
 - Enabled SSL and SASL in librdkafka to support Kafka authentication.
 - Fix to make all Kafka connections honour the provided librdkafka parameters.
+- Silencing x5f2 schema message and file writer not currently writing status message.
 
 ## Version 5.1.0: Attributes and dependencies
 

--- a/src/CommandSystem/Handler.cpp
+++ b/src/CommandSystem/Handler.cpp
@@ -103,7 +103,9 @@ void Handler::handleCommand(FileWriter::Msg CommandMsg, bool IsJobPoolCommand) {
   } else {
     std::string SchemaId(reinterpret_cast<char const *>(CommandMsg.data()) + 4,
                          4);
-    LOG_TRACE("Unable to handle (command) message of type: {}", SchemaId);
+    if (SchemaId != "x5f2") {
+      LOG_TRACE("Unable to handle (command) message of type: {}", SchemaId);
+    }
   }
 }
 

--- a/src/CommandSystem/Handler.cpp
+++ b/src/CommandSystem/Handler.cpp
@@ -95,7 +95,8 @@ void Handler::handleCommand(FileWriter::Msg CommandMsg, bool IsJobPoolCommand) {
     handleStopCommand(std::move(CommandMsg));
   } else if (Parser::isStatusMessage(CommandMsg) or
              Parser::isAnswerMessage(CommandMsg) or
-             Parser::isWritingDoneMessage(CommandMsg)) {
+             Parser::isWritingDoneMessage(CommandMsg) or
+             Parser::isFileWriterHeartbeatMessage(CommandMsg)) {
     // Do nothing
   } else if (CommandMsg.size() < 8) {
     LOG_TRACE("Unable to handle message as it was too short ({} bytes).",
@@ -103,9 +104,7 @@ void Handler::handleCommand(FileWriter::Msg CommandMsg, bool IsJobPoolCommand) {
   } else {
     std::string SchemaId(reinterpret_cast<char const *>(CommandMsg.data()) + 4,
                          4);
-    if (SchemaId != "x5f2") {
-      LOG_TRACE("Unable to handle (command) message of type: {}", SchemaId);
-    }
+    LOG_TRACE("Unable to handle (command) message of type: {}", SchemaId);
   }
 }
 

--- a/src/CommandSystem/Parser.cpp
+++ b/src/CommandSystem/Parser.cpp
@@ -156,4 +156,8 @@ bool isWritingDoneMessage(Msg const &CommandMessage) {
                                           FinishedWritingIdentifier());
 }
 
+bool isFileWriterHeartbeatMessage(Msg const &CommandMessage) {
+  std::string SchemaId(reinterpret_cast<char const *>(CommandMessage.data()) + 4, 4);
+  return SchemaId == "x5f2";
+}
 } // namespace Command::Parser

--- a/src/CommandSystem/Parser.cpp
+++ b/src/CommandSystem/Parser.cpp
@@ -157,7 +157,8 @@ bool isWritingDoneMessage(Msg const &CommandMessage) {
 }
 
 bool isFileWriterHeartbeatMessage(Msg const &CommandMessage) {
-  std::string SchemaId(reinterpret_cast<char const *>(CommandMessage.data()) + 4, 4);
+  std::string SchemaId(
+      reinterpret_cast<char const *>(CommandMessage.data()) + 4, 4);
   return SchemaId == "x5f2";
 }
 } // namespace Command::Parser

--- a/src/CommandSystem/Parser.h
+++ b/src/CommandSystem/Parser.h
@@ -53,6 +53,9 @@ bool isAnswerMessage(Msg const &CommandMessage);
 /// \brief Is the provided message a "writing is finished" broadcast?
 bool isWritingDoneMessage(Msg const &CommandMessage);
 
+/// \brief Is the provided message a file writer hearbeat message?
+bool isFileWriterHeartbeatMessage(Msg const &CommandMessage);
+
 /// \brief Extract the specified value.
 ///
 /// Throws if the key is not present

--- a/src/Master.cpp
+++ b/src/Master.cpp
@@ -110,7 +110,7 @@ void Master::setToIdle() {
         CurrentStreamController->errorMessage());
   } else {
     auto CurrentJSONStatus =
-        nlohmann::json::parse(Reporter->createJSONReport());
+        nlohmann::json::parse(Reporter->createJSONReport().dump());
     auto StaticMetaData = nlohmann::json::object();
     try {
       StaticMetaData = nlohmann::json::parse(CurrentMetadata);

--- a/src/Status/StatusReporterBase.cpp
+++ b/src/Status/StatusReporterBase.cpp
@@ -75,7 +75,7 @@ void StatusReporterBase::reportStatus() {
   try {
     auto const StatusJSONReport = createJSONReport();
     auto const StatusReportString = StatusJSONReport.dump();
-    if (StatusJSONReport["job_id"] != "not_currently_writing") {
+    if (StatusJSONReport["file_being_written"] != "") {
       LOG_DEBUG("status: {}", StatusReportString);
     }
 

--- a/src/Status/StatusReporterBase.cpp
+++ b/src/Status/StatusReporterBase.cpp
@@ -47,7 +47,7 @@ StatusReporterBase::createReport(std::string const &JSONReport) const {
 }
 
 // Create the JSON part of the status message
-std::string StatusReporterBase::createJSONReport() const {
+nlohmann::json StatusReporterBase::createJSONReport() const {
   std::shared_lock const lock(StatusMutex);
   auto Info = nlohmann::json::object();
   auto CurrentStatus = StatusGetter();
@@ -64,7 +64,7 @@ std::string StatusReporterBase::createJSONReport() const {
     JSONGenerator(TempObject);
   }
   Info["extra"] = TempObject;
-  return Info.dump();
+  return Info;
 }
 
 void StatusReporterBase::reportStatus() {
@@ -74,9 +74,12 @@ void StatusReporterBase::reportStatus() {
   }
   try {
     auto const StatusJSONReport = createJSONReport();
-    LOG_DEBUG("status: {}", StatusJSONReport);
+    auto const StatusReportString = StatusJSONReport.dump();
+    if (StatusJSONReport["job_id"] != "not_currently_writing") {
+      LOG_DEBUG("status: {}", StatusReportString);
+    }
 
-    StatusProducerTopic->produce(createReport(StatusJSONReport));
+    StatusProducerTopic->produce(createReport(StatusReportString));
     postReportStatusActions();
   } catch (std::runtime_error &E) {
     LOG_WARN("Unable to create a status report. The error was: {}", E.what());

--- a/src/Status/StatusReporterBase.h
+++ b/src/Status/StatusReporterBase.h
@@ -59,7 +59,7 @@ public:
   createReport(std::string const &JSONReport) const;
 
   /// Create the JSON part of the status report.
-  virtual std::string createJSONReport() const;
+  virtual nlohmann::json createJSONReport() const;
 
   virtual void
   setJSONMetaDataGenerator(JsonGeneratorFuncType GeneratorFunction) {

--- a/src/tests/MasterTests.cpp
+++ b/src/tests/MasterTests.cpp
@@ -46,7 +46,7 @@ public:
   MAKE_CONST_MOCK0(getStopTime, time_point(), override);
   MAKE_CONST_MOCK1(createReport,
                    flatbuffers::DetachedBuffer(std::string const &), override);
-  MAKE_CONST_MOCK0(createJSONReport, std::string(), override);
+  MAKE_CONST_MOCK0(createJSONReport, nlohmann::json(), override);
   MAKE_MOCK1(setJSONMetaDataGenerator, void(Status::JsonGeneratorFuncType),
              override);
 };

--- a/src/tests/StatusReporterTests.cpp
+++ b/src/tests/StatusReporterTests.cpp
@@ -58,7 +58,7 @@ public:
 TEST_F(StatusReporterTests, OnInitialisationValues) {
   ReporterPtr->setStatusGetter([=]() -> Status::JobStatusInfo { return {}; });
   ReporterPtr->setJSONMetaDataGenerator([](auto &) {});
-  auto JSONReport = ReporterPtr->createJSONReport();
+  auto JSONReport = ReporterPtr->createJSONReport().dump();
   auto Report = ReporterPtr->createReport(JSONReport);
   auto StatusMsg = deserialiseStatusMessage(Report);
 
@@ -74,7 +74,7 @@ TEST_F(StatusReporterTests, OnWritingInfoIsFilledOutCorrectly) {
   ReporterPtr->setStatusGetter([=]() { return Info; });
   ReporterPtr->setJSONMetaDataGenerator([](auto &) {});
 
-  auto JSONReport = ReporterPtr->createJSONReport();
+  auto JSONReport = ReporterPtr->createJSONReport().dump();
   auto Report = ReporterPtr->createReport(JSONReport);
   auto StatusMsg = deserialiseStatusMessage(Report);
 


### PR DESCRIPTION
### Issue

ECDC-3001

### Description of work

Silencing messages that are spamming terminal and graylog.
These messages are:
x5f2 schema output
file writer idle output.


### Reminder

*Changes should be documented in `changes.md`*
