### PR TITLE
ECDC-2967: Continue listening to inactive topic

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -11,6 +11,7 @@
 - Enabled SSL and SASL in librdkafka to support Kafka authentication.
 - Fix to make all Kafka connections honour the provided librdkafka parameters.
 - Silencing x5f2 schema message and file writer not currently writing status message.
+- The case when messages are not received from a specific Kafka topic does not make the file writer unsubscribe from the topic anymore. Instead a warning is provided in the file writer log.
 
 ## Version 5.1.0: Attributes and dependencies
 

--- a/src/Stream/Partition.cpp
+++ b/src/Stream/Partition.cpp
@@ -100,30 +100,41 @@ void Partition::addPollTask() {
   Executor.sendLowPriorityWork([=]() { pollForMessage(); });
 }
 
-bool Partition::shouldStopBasedOnPollStatus(Kafka::PollStatus CStatus) {
-  if (StopTester.shouldStopPartition(CStatus)) {
-    switch (StopTester.reasonForStopping()) {
-    case PartitionFilter::StopReason::ERROR:
-      LOG_ERROR("Stopping consumption of data from Kafka in partition {} of "
-                "topic {} due to poll error.",
-                PartitionID, Topic);
-      break;
-    case PartitionFilter::StopReason::TIMEOUT:
-      LOG_ERROR(
-          "Stopping consumption of data from Kafka in partition {} of "
-          "topic {} due to timeout ({:.1f}s passed) when polling for new data.",
+void Partition::checkAndLogPartitionTimeOut() {
+  if (StopTester.hasTopicTimedOut()) {
+      if (not PartitionTimeOutLogged) {
+      LOG_WARN(
+          "No new messages were received from Kafka in partition {} of "
+          "topic {} ({:.1f}s passed) when polling for new data.",
           PartitionID, Topic,
           double(std::chrono::duration_cast<std::chrono::milliseconds>(
                      system_clock::now() - StopTester.getErrorTime())
                      .count()) /
               1000.0);
+      PartitionTimeOutLogged = true;
+    }
+  }
+  else {
+    PartitionTimeOutLogged = false;
+  }
+}
+
+bool Partition::shouldStopBasedOnPollStatus(Kafka::PollStatus CStatus) {
+  checkAndLogPartitionTimeOut();
+  if (StopTester.shouldStopPartition(CStatus)) {
+    switch (StopTester.currentPartitionState()) {
+    case PartitionFilter::PartitionState::ERROR:
+      LOG_ERROR("Stopping consumption of data from Kafka in partition {} of "
+                "topic {} due to poll error.",
+                PartitionID, Topic);
       break;
-    case PartitionFilter::StopReason::END_OF_PARTITION:
+    case PartitionFilter::PartitionState::END_OF_PARTITION:
       LOG_INFO(
           R"(Done consuming data from partition {} of topic "{}" (reached the end of the partition).)",
           PartitionID, Topic);
       break;
-    case PartitionFilter::StopReason::NO_REASON:
+    case PartitionFilter::PartitionState::TIMEOUT:
+    case PartitionFilter::PartitionState::DEFAULT:
     default:
       LOG_INFO(R"(Done consuming data from partition {} of topic "{}".)",
                PartitionID, Topic);

--- a/src/Stream/Partition.cpp
+++ b/src/Stream/Partition.cpp
@@ -108,7 +108,7 @@ void Partition::checkAndLogPartitionTimeOut() {
           "topic {} ({:.1f}s passed) when polling for new data.",
           PartitionID, Topic,
           double(std::chrono::duration_cast<std::chrono::milliseconds>(
-                     system_clock::now() - StopTester.getErrorTime())
+                     system_clock::now() - StopTester.getStatusOccurrenceTime())
                      .count()) /
               1000.0);
       PartitionTimeOutLogged = true;

--- a/src/Stream/Partition.h
+++ b/src/Stream/Partition.h
@@ -57,6 +57,9 @@ public:
   /// Non blocking. Will tell the consumer thread to stop as soon as possible.
   /// There are no guarantees for when the consumer is actually stopped.
   void stop();
+  
+  /// \brief Checks for occurrence for time out and logs it once for each time out occurence.
+  void checkAndLogPartitionTimeOut();
 
   void setStopTime(time_point Stop);
 
@@ -111,6 +114,7 @@ protected:
   virtual void processMessage(FileWriter::Msg const &Message);
   std::unique_ptr<Kafka::ConsumerInterface> ConsumerPtr;
   int PartitionID{-1};
+  bool PartitionTimeOutLogged{false};
   std::string Topic{"not_initialized"};
   std::atomic_bool HasFinished{false};
   std::int64_t CurrentOffset{0};

--- a/src/Stream/PartitionFilter.h
+++ b/src/Stream/PartitionFilter.h
@@ -30,7 +30,7 @@ public:
   enum class PartitionState { DEFAULT, END_OF_PARTITION, ERROR, TIMEOUT};
   PartitionFilter() = default;
   PartitionFilter(time_point StopAtTime, duration StopTimeLeeway,
-                  duration ErrorTimeOut);
+                  duration TimeLimit);
 
   /// \brief Update the stop time.
   void setStopTime(time_point Stop) { StopTime = Stop; }
@@ -51,24 +51,24 @@ public:
     return State == PartitionState::ERROR;
   }
   
-  /// \brief Check if error time out has been exceeded.
-  bool hasExceededErrorTimeOut();
+  /// \brief Check if time limit has been exceeded.
+  bool hasExceededTimeLimit();
   
   /// \brief Check if topic has timed out.
   bool hasTopicTimedOut();
   
-  /// \brief Update error time.
-  void updateErrorTime(PartitionState ComparisonState);
+  /// \brief Update status occurence time.
+  void updateStatusOccurrenceTime(PartitionState ComparisonState);
 
-  time_point getErrorTime() const { return ErrorTime; }
+  time_point getStatusOccurrenceTime() const { return StatusOccurrenceTime; }
 
 protected:
   bool ForceStop{false};
   PartitionState State{PartitionState::DEFAULT};
-  time_point ErrorTime;
+  time_point StatusOccurrenceTime;
   time_point StopTime{time_point::max()};
   duration StopLeeway{10s};
-  duration ErrorTimeOut{10s};
+  duration TimeLimit{10s};
 };
 
 } // namespace Stream

--- a/src/tests/Stream/PartitionFilterTest.cpp
+++ b/src/tests/Stream/PartitionFilterTest.cpp
@@ -50,7 +50,7 @@ TEST_F(PartitionFilterTest, ErrorStateNoStopAlt) {
 
 TEST_F(PartitionFilterTest, OnTimeoutHasErrorState) {
   EXPECT_FALSE(UnderTest.shouldStopPartition(Kafka::PollStatus::TimedOut));
-  EXPECT_TRUE(UnderTest.hasErrorState());
+  EXPECT_FALSE(UnderTest.hasErrorState());
 }
 
 TEST_F(PartitionFilterTest, AfterErrorRecoversOnValidMessage) {
@@ -82,15 +82,15 @@ TEST_F(PartitionFilterTest, AfterErrorRecoversOnEOPWithDelay) {
 }
 
 TEST_F(PartitionFilterTest, AfterErrorStateNoRecoveryOnTimeOut) {
-  EXPECT_FALSE(UnderTest.shouldStopPartition(Kafka::PollStatus::Error));
   EXPECT_FALSE(UnderTest.shouldStopPartition(Kafka::PollStatus::TimedOut));
+  EXPECT_FALSE(UnderTest.shouldStopPartition(Kafka::PollStatus::Error));
   EXPECT_TRUE(UnderTest.hasErrorState());
 }
 
 TEST_F(PartitionFilterTest, AfterErrorStateRecoverOnTimeOutWithDelay) {
-  EXPECT_FALSE(UnderTest.shouldStopPartition(Kafka::PollStatus::Error));
-  std::this_thread::sleep_for(40ms);
   EXPECT_FALSE(UnderTest.shouldStopPartition(Kafka::PollStatus::TimedOut));
+  std::this_thread::sleep_for(40ms);
+  EXPECT_FALSE(UnderTest.shouldStopPartition(Kafka::PollStatus::Error));
   EXPECT_TRUE(UnderTest.hasErrorState());
 }
 


### PR DESCRIPTION
### Issue

https://jira.esss.lu.se/browse/ECDC-2967

### Description of work

The file writer does not unsubscribe from the Kafka topic anymore when messages are not receieved
after a certain configurable time (default 30s). Instead a warning message is logged (only once per occurrence).

### Nominate for Group Code Review

Jenny Walker