### PR TITLE
ECDC-3142 Ignore broker addresses sent in JobStart message

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -2,6 +2,8 @@
 
 ## Next version
 
+- Breaking: Ignore Kafka IP addresses sent in `StartJob` messages, experiment
+  data is now fetched from the broker configured in `job-pool-uri`.
 - Increased kafka message buffer sizes and added integration tests for this.
 - Improved help text formatting.
 - Added code for running Kafka tests. This code is disabled by default.

--- a/src/CommandSystem/Commands.h
+++ b/src/CommandSystem/Commands.h
@@ -22,7 +22,6 @@ struct StartInfo {
   std::string Filename;
   std::string NexusStructure;
   std::string Metadata;
-  uri::URI BrokerInfo{"localhost:9092"};
   time_point StartTime{0ms};
   time_point StopTime{time_point::max()};
   std::string ControlTopic;

--- a/src/CommandSystem/Parser.cpp
+++ b/src/CommandSystem/Parser.cpp
@@ -39,17 +39,6 @@ void checkRequiredFieldsArePresent(const RunStart *RunStartData) {
     Errors << "Filename missing, this field is required\n";
   }
 
-  if (RunStartData->broker() == nullptr ||
-      RunStartData->broker()->size() == 0) {
-    Errors << "Broker missing, this field is required\n";
-  } else {
-    try {
-      uri::URI(RunStartData->broker()->str());
-    } catch (const std::runtime_error &URIError) {
-      Errors << "Unable to parse broker address\n";
-    }
-  }
-
   std::string const ErrorsString = Errors.str();
   if (!ErrorsString.empty()) {
     throw std::runtime_error(fmt::format(

--- a/src/CommandSystem/Parser.cpp
+++ b/src/CommandSystem/Parser.cpp
@@ -84,7 +84,6 @@ Command::StartMessage extractStartMessage(Msg const &CommandMessage,
   if (RunStartData->service_id() != nullptr) {
     Result.ServiceID = RunStartData->service_id()->str();
   }
-  Result.BrokerInfo = uri::URI(RunStartData->broker()->str());
   Result.Filename = RunStartData->filename()->str();
   if (RunStartData->metadata() != nullptr) {
     Result.Metadata = RunStartData->metadata()->str();

--- a/src/JobCreator.cpp
+++ b/src/JobCreator.cpp
@@ -165,8 +165,10 @@ createFileWritingJob(Command::StartInfo const &StartInfo, MainOpt &Settings,
 
   Settings.StreamerConfiguration.StartTimestamp = StartInfo.StartTime;
   Settings.StreamerConfiguration.StopTimestamp = StartInfo.StopTime;
+  // Ignore broker addresses sent in StartInfo message and use known broker
+  // instead. Temporarily we reuse the broker from JobPoolURI. See ECDC-3118.
   Settings.StreamerConfiguration.BrokerSettings.Address =
-      StartInfo.BrokerInfo.HostPort;
+      Settings.JobPoolURI.HostPort;
 
   LOG_INFO("Write file with job_id: {}", Task->jobID());
   return std::make_unique<StreamController>(

--- a/src/tests/CommandSystem/CommandParserTests.cpp
+++ b/src/tests/CommandSystem/CommandParserTests.cpp
@@ -52,11 +52,6 @@ TEST_F(CommandParserHappyStartTests, IfFilenamePresentThenExtractedCorrectly) {
   ASSERT_EQ(FilenameInput, StartInfo.Filename);
 }
 
-TEST_F(CommandParserHappyStartTests, IfBrokerPresentThenExtractedCorrectly) {
-  ASSERT_EQ(BrokerInput, StartInfo.BrokerInfo.HostPort);
-  ASSERT_EQ(1234u, StartInfo.BrokerInfo.Port);
-}
-
 TEST_F(CommandParserHappyStartTests,
        IfNexusStructurePresentThenExtractedCorrectly) {
   ASSERT_EQ(NexusStructureInput, StartInfo.NexusStructure);

--- a/src/tests/CommandSystem/CommandParserTests.cpp
+++ b/src/tests/CommandSystem/CommandParserTests.cpp
@@ -25,7 +25,6 @@ std::string const NexusStructureInput = "{}";
 std::string const JobIDInput = "qw3rty";
 std::string const CommandIDInput = "some command id";
 std::optional<std::string> const ServiceIDInput = "filewriter1";
-std::string const BrokerInput = "somehost:1234";
 std::string const FilenameInput = "a-dummy-name-01.h5";
 uint64_t const StartTimeInput = 123456789000;
 uint64_t const StopTimeInput = 123456790000;
@@ -37,8 +36,7 @@ public:
   void SetUp() override {
     auto MessageBuffer = buildRunStartMessage(
         InstrumentNameInput, RunNameInput, NexusStructureInput, JobIDInput,
-        ServiceIDInput, BrokerInput, FilenameInput, StartTimeInput,
-        StopTimeInput);
+        ServiceIDInput, FilenameInput, StartTimeInput, StopTimeInput);
 
     StartInfo = Command::Parser::extractStartMessage(MessageBuffer);
   }
@@ -75,8 +73,7 @@ TEST(CommandParserSadStartTests, ThrowsIfNoJobID) {
   std::string const EmptyJobID;
   auto MessageBuffer = buildRunStartMessage(
       InstrumentNameInput, RunNameInput, NexusStructureInput, EmptyJobID,
-      ServiceIDInput, BrokerInput, FilenameInput, StartTimeInput,
-      StopTimeInput);
+      ServiceIDInput, FilenameInput, StartTimeInput, StopTimeInput);
 
   ASSERT_THROW(Command::Parser::extractStartMessage(MessageBuffer),
                std::runtime_error);
@@ -86,8 +83,7 @@ TEST(CommandParserSadStartTests, ThrowsIfNoFilename) {
   std::string const EmptyFilename;
   auto MessageBuffer = buildRunStartMessage(
       InstrumentNameInput, RunNameInput, NexusStructureInput, JobIDInput,
-      ServiceIDInput, BrokerInput, EmptyFilename, StartTimeInput,
-      StopTimeInput);
+      ServiceIDInput, EmptyFilename, StartTimeInput, StopTimeInput);
 
   ASSERT_THROW(Command::Parser::extractStartMessage(MessageBuffer),
                std::runtime_error);
@@ -97,30 +93,7 @@ TEST(CommandParserSadStartTests, ThrowsIfNoNexusStructure) {
   std::string const EmptyNexusStructure;
   auto MessageBuffer = buildRunStartMessage(
       InstrumentNameInput, RunNameInput, EmptyNexusStructure, JobIDInput,
-      ServiceIDInput, BrokerInput, FilenameInput, StartTimeInput,
-      StopTimeInput);
-
-  ASSERT_THROW(Command::Parser::extractStartMessage(MessageBuffer),
-               std::runtime_error);
-}
-
-TEST(CommandParserSadStartTests, IfNoBrokerThenThrows) {
-  std::string const EmptyBroker;
-  auto MessageBuffer = buildRunStartMessage(
-      InstrumentNameInput, RunNameInput, NexusStructureInput, JobIDInput,
-      ServiceIDInput, EmptyBroker, FilenameInput, StartTimeInput,
-      StopTimeInput);
-
-  ASSERT_THROW(Command::Parser::extractStartMessage(MessageBuffer),
-               std::runtime_error);
-}
-
-TEST(CommandParserSadStartTests, IfBrokerIsWrongFormThenThrows) {
-  std::string const BrokerInvalidFormat = "1234:somehost";
-  auto MessageBuffer = buildRunStartMessage(
-      InstrumentNameInput, RunNameInput, NexusStructureInput, JobIDInput,
-      ServiceIDInput, BrokerInvalidFormat, FilenameInput, StartTimeInput,
-      StopTimeInput);
+      ServiceIDInput, FilenameInput, StartTimeInput, StopTimeInput);
 
   ASSERT_THROW(Command::Parser::extractStartMessage(MessageBuffer),
                std::runtime_error);
@@ -131,7 +104,7 @@ TEST(CommandParserStartTests, IfNoStartTimeThenUsesSuppliedCurrentTime) {
   uint64_t const NoStartTime = 0;
   auto MessageBuffer = buildRunStartMessage(
       InstrumentNameInput, RunNameInput, NexusStructureInput, JobIDInput,
-      ServiceIDInput, BrokerInput, FilenameInput, NoStartTime, StopTimeInput);
+      ServiceIDInput, FilenameInput, NoStartTime, StopTimeInput);
 
   auto FakeCurrentTime = time_point{987654321ms};
 
@@ -145,8 +118,7 @@ TEST(CommandParserStartTests, IfBlankServiceIdThenIsBlank) {
   std::optional<std::string> const EmptyServiceID = "";
   auto MessageBuffer = buildRunStartMessage(
       InstrumentNameInput, RunNameInput, NexusStructureInput, JobIDInput,
-      EmptyServiceID, BrokerInput, FilenameInput, StartTimeInput,
-      StopTimeInput);
+      EmptyServiceID, FilenameInput, StartTimeInput, StopTimeInput);
 
   auto StartInfo = Command::Parser::extractStartMessage(MessageBuffer);
 
@@ -157,7 +129,7 @@ TEST(CommandParserStartTests, IfMissingServiceIdThenIsBlank) {
   std::optional<std::string> const NoServiceID = std::nullopt;
   auto MessageBuffer = buildRunStartMessage(
       InstrumentNameInput, RunNameInput, NexusStructureInput, JobIDInput,
-      NoServiceID, BrokerInput, FilenameInput, StartTimeInput, StopTimeInput);
+      NoServiceID, FilenameInput, StartTimeInput, StopTimeInput);
 
   auto StartInfo = Command::Parser::extractStartMessage(MessageBuffer);
 
@@ -253,8 +225,7 @@ TEST(CommandParserStartTests,
      DISABLED_MessageIsStartCommandIfValidRunStartFlatbuffer) {
   auto MessageBuffer = buildRunStartMessage(
       InstrumentNameInput, RunNameInput, NexusStructureInput, JobIDInput,
-      ServiceIDInput, BrokerInput, FilenameInput, StartTimeInput,
-      StopTimeInput);
+      ServiceIDInput, FilenameInput, StartTimeInput, StopTimeInput);
   FileWriter::Msg const TestMessage{MessageBuffer.data(), MessageBuffer.size()};
   ASSERT_TRUE(Command::Parser::isStartCommand(TestMessage));
 }

--- a/src/tests/MasterTests.cpp
+++ b/src/tests/MasterTests.cpp
@@ -91,7 +91,6 @@ public:
                               "file_name",
                               R"({"nexus_structure":5})",
                               R"({"meta_data":54})",
-                              uri::URI{"localhost:9092"},
                               StartTime,
                               StartTime + 50s,
                               "control_topic"};

--- a/src/tests/helpers/RunStartStopHelpers.cpp
+++ b/src/tests/helpers/RunStartStopHelpers.cpp
@@ -9,8 +9,8 @@ namespace RunStartStopHelpers {
 FileWriter::Msg buildRunStartMessage(
     std::string const &InstrumentName, std::string const &RunName,
     std::string const &NexusStructure, std::string const &JobID,
-    std::optional<std::string> const &ServiceID, std::string const &Broker,
-    std::string const &Filename, uint64_t StartTime, uint64_t StopTime) {
+    std::optional<std::string> const &ServiceID, std::string const &Filename,
+    uint64_t StartTime, uint64_t StopTime) {
   flatbuffers::FlatBufferBuilder Builder;
 
   const auto InstrumentNameOffset = Builder.CreateString(InstrumentName);
@@ -21,7 +21,6 @@ FileWriter::Msg buildRunStartMessage(
   if (ServiceID) {
     ServiceIDOffset = Builder.CreateString(*ServiceID);
   }
-  const auto BrokerOffset = Builder.CreateString(Broker);
   const auto FilenameOffset = Builder.CreateString(Filename);
 
   RunStartBuilder StartBuilder{Builder};
@@ -31,7 +30,6 @@ FileWriter::Msg buildRunStartMessage(
   StartBuilder.add_instrument_name(InstrumentNameOffset);
   StartBuilder.add_nexus_structure(NexusStructureOffset);
   StartBuilder.add_job_id(JobIDOffset);
-  StartBuilder.add_broker(BrokerOffset);
   if (ServiceID) {
     StartBuilder.add_service_id(ServiceIDOffset);
   }

--- a/src/tests/helpers/RunStartStopHelpers.h
+++ b/src/tests/helpers/RunStartStopHelpers.h
@@ -20,8 +20,8 @@ namespace RunStartStopHelpers {
 FileWriter::Msg buildRunStartMessage(
     std::string const &InstrumentName, std::string const &RunName,
     std::string const &NexusStructure, std::string const &JobID,
-    std::optional<std::string> const &ServiceID, std::string const &Broker,
-    std::string const &Filename, uint64_t StartTime, uint64_t StopTime);
+    std::optional<std::string> const &ServiceID, std::string const &Filename,
+    uint64_t StartTime, uint64_t StopTime);
 
 FileWriter::Msg
 buildRunStopMessage(uint64_t StopTime, std::string const &RunName,


### PR DESCRIPTION
### Issue

https://jira.esss.lu.se/browse/ECDC-3142


### Description of work

We want to decouple the Kafka addresses seen by Nicos and the Filewriter. In this commit we stop honouring the address sent by Nicos and use one of the addresses already known by the Filewriter.


Note that this is a temporary solution to mitigate the coupling with Nicos.
We want to refactor the Kafka configuration in the filewriter (see ECDC-3118), possibly resulting in a single "kafka-config" for all librdkafka settings.
The code in this commit should use such new configuration facility to set the broker address instead of using the address from JobPoolURI, which is quite arbitrary.

### Nominate for Group Code Review

- [ ] Nominate for code review 

### Reminder

*Changes should be documented in `changes.md`*
