### PR TITLE
integration tests: wait for delivery to be confirmed

### DIFF
--- a/integration-tests/helpers/kafkahelpers.py
+++ b/integration-tests/helpers/kafkahelpers.py
@@ -83,9 +83,16 @@ def datetime_to_ns(time: datetime):
 def publish_message(
     producer: Producer, data: bytes, topic: str, timestamp: datetime, flush: bool = True
 ):
-    producer.produce(topic=topic, value=data, timestamp=datetime_to_ms(timestamp))
-    if flush:
-        producer.flush()
+    delivered = False
+    def callback(err, msg):
+        if err is not None:
+            raise RuntimeError(f"Could not deliver message: {err}")
+        nonlocal delivered
+        delivered = True
+
+    producer.produce(topic=topic, value=data, timestamp=datetime_to_ms(timestamp), callback=callback)
+    while not delivered:
+        producer.poll(0.1)
 
 
 def publish_f142_message(

--- a/integration-tests/requirements.txt
+++ b/integration-tests/requirements.txt
@@ -1,5 +1,5 @@
 pytest>=6.2.2
-confluent_kafka == 1.7.0
+confluent_kafka == 1.9.2
 docker-compose==1.29.2
 docker==5.0.2
 h5py>=3.1.0

--- a/integration-tests/test_same_id_multiple_modules.py
+++ b/integration-tests/test_same_id_multiple_modules.py
@@ -23,7 +23,7 @@ def test_two_different_writer_modules_with_same_flatbuffer_id(
     now = datetime.now()
     start_time = now - timedelta(seconds=10)
     stop_time = now
-    for i in range(10):
+    for i in range(12):
         current_time = start_time + timedelta(seconds=1) * i
         publish_f142_message(
             producer,


### PR DESCRIPTION
Fixes issues seen when we upgrade to a newer version of Confluent Kafka Python