### PR TITLE
ECDC-3109: Allow dynamic path

### DIFF
--- a/src/FileWriterTask.cpp
+++ b/src/FileWriterTask.cpp
@@ -35,7 +35,7 @@ json hdf_parse(std::string const &Structure) {
 std::vector<Source> &FileWriterTask::sources() { return SourceToModuleMap; }
 
 void FileWriterTask::setFullFilePath(std::string const &Prefix,
-                                 std::string const &Name) {
+                                     std::string const &Name) {
   FullFilePath = Prefix;
   FullFilePath.append(Name);
 }
@@ -51,7 +51,8 @@ void FileWriterTask::InitialiseHdf(std::string const &NexusStructure,
 
   if (std::filesystem::exists(FullFilePath)) {
     ErrorString = fmt::format(
-        R"(Failed to initialize HDF file "{}". Error was: "{}".)", FullFilePath.string(),
+        R"(Failed to initialize HDF file "{}". Error was: "{}".)",
+        FullFilePath.string(),
         "a file with that filename already exists in that directory. Delete "
         "the existing file or provide another filename");
     std::throw_with_nested(std::runtime_error(ErrorString));
@@ -63,7 +64,8 @@ void FileWriterTask::InitialiseHdf(std::string const &NexusStructure,
   } else if (FullFilePath.has_parent_path() and
              not std::filesystem::exists(FullFilePath.parent_path())) {
     ErrorString = fmt::format(
-        R"(Failed to initialize HDF file "{}". Error was: The parent directory does not exist.)", FullFilePath.string());
+        R"(Failed to initialize HDF file "{}". Error was: The parent directory does not exist.)",
+        FullFilePath.string());
     std::throw_with_nested(std::runtime_error(ErrorString));
   }
 

--- a/src/FileWriterTask.cpp
+++ b/src/FileWriterTask.cpp
@@ -34,13 +34,10 @@ json hdf_parse(std::string const &Structure) {
 
 std::vector<Source> &FileWriterTask::sources() { return SourceToModuleMap; }
 
-void FileWriterTask::setFilename(std::string const &Prefix,
+void FileWriterTask::setFullFilePath(std::string const &Prefix,
                                  std::string const &Name) {
-  if (Prefix.empty()) {
-    Filename = Name;
-  } else {
-    Filename = Prefix + "/" + Name;
-  }
+  FullFilePath = Prefix;
+  FullFilePath.append(Name);
 }
 
 void FileWriterTask::addSource(Source &&Source) {
@@ -51,35 +48,33 @@ void FileWriterTask::InitialiseHdf(std::string const &NexusStructure,
                                    std::vector<ModuleHDFInfo> &HdfInfo) {
   auto NexusStructureJson = hdf_parse(NexusStructure);
   std::string ErrorString;
-  std::filesystem::path FilePath(Filename);
 
-  if (std::filesystem::exists(Filename)) {
+  if (std::filesystem::exists(FullFilePath)) {
     ErrorString = fmt::format(
-        R"(Failed to initialize HDF file "{}". Error was: "{}".)", Filename,
+        R"(Failed to initialize HDF file "{}". Error was: "{}".)", FullFilePath.string(),
         "a file with that filename already exists in that directory. Delete "
         "the existing file or provide another filename");
     std::throw_with_nested(std::runtime_error(ErrorString));
-  } else if (not FilePath.has_filename()) {
+  } else if (not FullFilePath.has_filename()) {
     ErrorString =
         fmt::format(R"(Failed to initialize HDF file "{}". Error was: "{}".)",
-                    Filename, "filename is empty");
+                    FullFilePath.string(), "filename is empty");
     std::throw_with_nested(std::runtime_error(ErrorString));
-  } else if (FilePath.has_parent_path() and
-             not std::filesystem::exists(FilePath.parent_path())) {
+  } else if (FullFilePath.has_parent_path() and
+             not std::filesystem::exists(FullFilePath.parent_path())) {
     ErrorString = fmt::format(
-        R"(Failed to initialize HDF file "{}". Error was: The parent directory does not exist.)",
-        Filename);
+        R"(Failed to initialize HDF file "{}". Error was: The parent directory does not exist.)", FullFilePath.string());
     std::throw_with_nested(std::runtime_error(ErrorString));
   }
 
   try {
-    LOG_INFO("Creating HDF file {}", Filename);
-    File = std::make_unique<HDFFile>(Filename, NexusStructureJson, HdfInfo,
+    LOG_INFO("Creating HDF file {}", FullFilePath.string());
+    File = std::make_unique<HDFFile>(FullFilePath, NexusStructureJson, HdfInfo,
                                      MetaDataTracker);
   } catch (std::exception const &E) {
     ErrorString =
         fmt::format(R"(Failed to initialize HDF file "{}". Error was: {})",
-                    Filename, E.what());
+                    FullFilePath.string(), E.what());
     LOG_ERROR(ErrorString);
     std::throw_with_nested(std::runtime_error(ErrorString));
   }
@@ -99,7 +94,7 @@ bool FileWriterTask::isInWriteMode() { return File->isSWMRMode(); }
 
 void FileWriterTask::setJobId(std::string const &Id) { JobId = Id; }
 
-std::string FileWriterTask::filename() const { return Filename; }
+std::string FileWriterTask::filename() const { return FullFilePath.string(); }
 
 void FileWriterTask::writeLinks(
     const std::vector<ModuleSettings> &LinkSettingsList) {
@@ -116,11 +111,11 @@ void FileWriterTask::flushDataToFile() {
 
 void FileWriterTask::updateApproximateFileSize() {
   std::error_code ErrorCode;
-  auto size = std::filesystem::file_size(Filename, ErrorCode);
+  auto size = std::filesystem::file_size(FullFilePath, ErrorCode);
   if (ErrorCode) {
     LOG_ERROR(
         R"(Unable to determine file size of the file "{}". The error was: {})",
-        Filename, ErrorCode.message());
+        FullFilePath.string(), ErrorCode.message());
     return;
   }
   auto SizeValue = int(std::ceil(size / 10'000'000.0) * 10);

--- a/src/FileWriterTask.h
+++ b/src/FileWriterTask.h
@@ -68,7 +68,7 @@ public:
   ///
   /// \param Prefix The path prefix.
   /// \param Name The filename (can include path).
-  void setFilename(std::string const &Prefix, std::string const &Name);
+  void setFullFilePath(std::string const &Prefix, std::string const &Name);
 
   /// \brief Get the list of demuxers.
   ///
@@ -106,7 +106,7 @@ public:
   void updateApproximateFileSize();
 
 private:
-  std::string Filename;
+  std::filesystem::path FullFilePath;
   MetaData::TrackerPtr MetaDataTracker;
   MetaData::Value<uint32_t> FileSizeMB;
   Metrics::Metric FileSizeMBMetric{"approx_file_size_mb",

--- a/src/HDFFile.cpp
+++ b/src/HDFFile.cpp
@@ -135,7 +135,8 @@ void HDFFileBase::flush() {
 }
 
 void HDFFile::openFileInRegularMode() {
-  LOG_DEBUG(R"(Opening file "{}" in regular (non SWMR) mode.)", H5FileName.string());
+  LOG_DEBUG(R"(Opening file "{}" in regular (non SWMR) mode.)",
+            H5FileName.string());
   hdfFile() = hdf5::file::open(H5FileName, hdf5::file::AccessFlags::ReadWrite,
                                FileAccessList);
 }

--- a/src/HDFFile.cpp
+++ b/src/HDFFile.cpp
@@ -19,7 +19,7 @@ using HDFOperations::createHDFStructures;
 using HDFOperations::writeAttributesIfPresent;
 using HDFOperations::writeHDFISO8601AttributeCurrentTime;
 
-HDFFile::HDFFile(std::string const &FileName,
+HDFFile::HDFFile(std::filesystem::path const &FileName,
                  nlohmann::json const &NexusStructure,
                  std::vector<ModuleHDFInfo> &ModuleHDFInfo,
                  MetaData::TrackerPtr &TrackerPtr)
@@ -114,7 +114,7 @@ void HDFFile::closeFile() {
 }
 
 void HDFFile::openFileInSWMRMode() {
-  LOG_DEBUG(R"(Opening file "{}" in SWMR mode.)", H5FileName);
+  LOG_DEBUG(R"(Opening file "{}" in SWMR mode.)", H5FileName.string());
   hdfFile() = hdf5::file::open(H5FileName,
                                hdf5::file::AccessFlags::ReadWrite |
                                    hdf5::file::AccessFlags::SWMRWrite,
@@ -135,7 +135,7 @@ void HDFFileBase::flush() {
 }
 
 void HDFFile::openFileInRegularMode() {
-  LOG_DEBUG(R"(Opening file "{}" in regular (non SWMR) mode.)", H5FileName);
+  LOG_DEBUG(R"(Opening file "{}" in regular (non SWMR) mode.)", H5FileName.string());
   hdfFile() = hdf5::file::open(H5FileName, hdf5::file::AccessFlags::ReadWrite,
                                FileAccessList);
 }
@@ -146,7 +146,7 @@ void HDFFile::addLinks(std::vector<ModuleSettings> const &LinkSettingsList) {
     HDFOperations::addLinks(hdfGroup(), LinkSettingsList);
   } catch (std::exception const &E) {
     LOG_ERROR(R"(Unable to finish file "{}". Error message was: {})",
-              H5FileName, E.what());
+              H5FileName.string(), E.what());
   }
 }
 
@@ -158,7 +158,7 @@ void HDFFile::addMetaData() {
     }
   } catch (std::exception const &E) {
     LOG_ERROR(R"(Unable to finish file "{}". Error message was: {})",
-              H5FileName, E.what());
+              H5FileName.string(), E.what());
   }
 }
 

--- a/src/HDFFile.h
+++ b/src/HDFFile.h
@@ -45,7 +45,8 @@ private:
 
 class HDFFile : public HDFFileBase {
 public:
-  HDFFile(std::filesystem::path const &FileName, nlohmann::json const &NexusStructure,
+  HDFFile(std::filesystem::path const &FileName,
+          nlohmann::json const &NexusStructure,
           std::vector<ModuleHDFInfo> &ModuleHDFInfo,
           MetaData::TrackerPtr &TrackerPtr);
   void addLinks(std::vector<ModuleSettings> const &LinkSettingsList);

--- a/src/HDFFile.h
+++ b/src/HDFFile.h
@@ -45,7 +45,7 @@ private:
 
 class HDFFile : public HDFFileBase {
 public:
-  HDFFile(std::string const &FileName, nlohmann::json const &NexusStructure,
+  HDFFile(std::filesystem::path const &FileName, nlohmann::json const &NexusStructure,
           std::vector<ModuleHDFInfo> &ModuleHDFInfo,
           MetaData::TrackerPtr &TrackerPtr);
   void addLinks(std::vector<ModuleSettings> const &LinkSettingsList);
@@ -66,7 +66,7 @@ private:
   hdf5::property::FileAccessList FileAccessList;
   hdf5::property::FileCreationList FileCreationList;
 
-  std::string H5FileName;
+  std::filesystem::path H5FileName;
   nlohmann::json StoredNexusStructure;
   MetaData::TrackerPtr const MetaDataTracker;
 };

--- a/src/JobCreator.cpp
+++ b/src/JobCreator.cpp
@@ -107,7 +107,7 @@ createFileWritingJob(Command::StartInfo const &StartInfo, MainOpt &Settings,
                      MetaData::TrackerPtr const &Tracker) {
   auto Task = std::make_unique<FileWriterTask>(Registrar, Tracker);
   Task->setJobId(StartInfo.JobID);
-  Task->setFilename(Settings.HDFOutputPrefix, StartInfo.Filename);
+  Task->setFullFilePath(Settings.HDFOutputPrefix, StartInfo.Filename);
 
   std::vector<ModuleHDFInfo> ModuleHDFInfoList =
       initializeHDF(*Task, StartInfo.NexusStructure);

--- a/src/MainOpt.h
+++ b/src/MainOpt.h
@@ -61,7 +61,7 @@ struct MainOpt {
   ///
   /// This gets prepended to the HDF output filename given in the write
   /// commands.
-  std::string HDFOutputPrefix;
+  std::string HDFOutputPrefix{""};
 
   /// Used for command line argument.
   bool ListWriterModules = false;

--- a/src/MainOpt.h
+++ b/src/MainOpt.h
@@ -61,7 +61,7 @@ struct MainOpt {
   ///
   /// This gets prepended to the HDF output filename given in the write
   /// commands.
-  std::string HDFOutputPrefix{""};
+  std::string HDFOutputPrefix{std::filesystem::current_path().root_path()};
 
   /// Used for command line argument.
   bool ListWriterModules = false;

--- a/src/tests/FileWriterTaskTests.cpp
+++ b/src/tests/FileWriterTaskTests.cpp
@@ -25,7 +25,7 @@ TEST_F(FileWriterTask, WithPrefixFullFileNameIsCorrect) {
   FileWriter::FileWriterTask Task(TestRegistrar,
                                   std::make_shared<MetaData::Tracker>());
 
-  Task.setFilename("SomePrefix", "File.hdf");
+  Task.setFullFilePath("SomePrefix", "File.hdf");
 
   ASSERT_EQ("SomePrefix/File.hdf", Task.filename());
 }
@@ -34,9 +34,9 @@ TEST_F(FileWriterTask, WithoutPrefixFileNameIsCorrect) {
   FileWriter::FileWriterTask Task(TestRegistrar,
                                   std::make_shared<MetaData::Tracker>());
 
-  Task.setFilename("", "File.hdf");
+  Task.setFullFilePath("/", "File.hdf");
 
-  ASSERT_EQ("File.hdf", Task.filename());
+  ASSERT_EQ("/File.hdf", Task.filename());
 }
 
 TEST_F(FileWriterTask, AddingSourceAddsToDemuxers) {

--- a/src/tests/HDFFileTest.cpp
+++ b/src/tests/HDFFileTest.cpp
@@ -19,7 +19,7 @@ public:
     }
     ModuleHDFInfoList.clear();
   }
-  std::string FileName{"someFileName.hdf"};
+  std::filesystem::path FileName{"someFileName.hdf"};
   nlohmann::json NexusStructure{};
   std::vector<ModuleHDFInfo> ModuleHDFInfoList;
   MetaData::TrackerPtr Tracker{};

--- a/src/tests/MasterTests.cpp
+++ b/src/tests/MasterTests.cpp
@@ -87,8 +87,9 @@ public:
   StatusReporterStandIn *StatusReporter;
   std::unique_ptr<FileWriter::Master> UnderTest;
   time_point StartTime{system_clock::now()};
+  std::filesystem::path FilePath = std::filesystem::current_path().append("file_name");
   Command::StartInfo StartCmd{"job_id",
-                              "file_name",
+                              FilePath,
                               R"({"nexus_structure":5})",
                               R"({"meta_data":54})",
                               StartTime,

--- a/src/tests/MasterTests.cpp
+++ b/src/tests/MasterTests.cpp
@@ -87,7 +87,8 @@ public:
   StatusReporterStandIn *StatusReporter;
   std::unique_ptr<FileWriter::Master> UnderTest;
   time_point StartTime{system_clock::now()};
-  std::filesystem::path FilePath = std::filesystem::current_path().append("file_name");
+  std::filesystem::path FilePath =
+      std::filesystem::current_path().append("file_name");
   Command::StartInfo StartCmd{"job_id",
                               FilePath,
                               R"({"nexus_structure":5})",


### PR DESCRIPTION
### Issue

Closes https://jira.esss.lu.se/browse/ECDC-3109

### Description of work

Making changes to how the HDF5 file path is handled both internally and as input in the
config .ini file to the file writer. By requirements, if the hdf-output-prefix is not provided in the .ini file,
the default should be the root directory (the rest of the path might come from NICOS for example).

### Reminder

*Changes should be documented in `changes.md`*
