### PR TITLE
Redact Kafka SASL credentials in logs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,11 @@ if (UNIX AND NOT APPLE)
   endif()
 endif()
 
+if (APPLE)
+  message(STATUS "Temporary suppressing deprecated warning (asio)")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated")
+endif()
+
 set(CONAN_PROFILE "default" CACHE STRING "Name of conan profile to use, uses default by default")
 set(CONAN_FILE "conanfile.txt" CACHE STRING "Name of the conanfile to use, must be placed in the project's conan directory")
 set(CONAN "AUTO" CACHE STRING "conan options AUTO (conan must be in path), MANUAL (expects conanbuildinfo.cmake in build directory) or DISABLE")

--- a/changes.md
+++ b/changes.md
@@ -2,6 +2,8 @@
 
 ## Next version
 
+- Redact Kafka SASL password in logs.
+- Ignore deprecated warnings on macOS (can be removed when https://github.com/chriskohlhoff/asio/issues/1183 is addressed.
 - Breaking: Ignore Kafka IP addresses sent in `StartJob` messages, experiment
   data is now fetched from the broker configured in `job-pool-uri`.
 - The case when messages are not received from a specific Kafka topic does not make the file writer unsubscribe from the topic anymore. Instead a warning is provided in the file writer log.

--- a/src/Kafka/ConfigureKafka.cpp
+++ b/src/Kafka/ConfigureKafka.cpp
@@ -15,13 +15,18 @@ void configureKafka(RdKafka::Conf *RdKafkaConfiguration,
                     Kafka::BrokerSettings Settings) {
   std::string ErrorString;
   for (const auto &ConfigurationItem : Settings.KafkaConfiguration) {
-    LOG_DEBUG("set config: {} = {}", ConfigurationItem.first,
-              ConfigurationItem.second);
+    std::string Key{ConfigurationItem.first};
+    std::string Value{ConfigurationItem.second};
+
+    // Don't log sensitive data
+    if (Key == "sasl.password") {
+      Value = "<REDACTED>";
+    }
+
+    LOG_DEBUG("set config: {} = {}", Key, Value);
     if (RdKafka::Conf::ConfResult::CONF_OK !=
-        RdKafkaConfiguration->set(ConfigurationItem.first,
-                                  ConfigurationItem.second, ErrorString)) {
-      LOG_WARN("Failure setting config: {} = {}", ConfigurationItem.first,
-               ConfigurationItem.second);
+        RdKafkaConfiguration->set(Key, Value, ErrorString)) {
+      LOG_WARN("Failure setting config: {} = {}", Key, Value);
     }
   }
 }


### PR DESCRIPTION
### Issue

ECDC-3152.

### Description of work

Redact Kafka SASL password in logs. Also add CMake configuration for macOS build workaround due to warning/error generated by asio code.

### Nominate for Group Code Review

- [ ] Nominate for code review 

### Reminder

*Changes should be documented in `changes.md`*
