### PR TITLE
Fix redaction of sensitive settings inadvertently modifies the setting

### DIFF
--- a/src/Kafka/ConfigureKafka.cpp
+++ b/src/Kafka/ConfigureKafka.cpp
@@ -20,8 +20,6 @@ void configureKafka(RdKafka::Conf *RdKafkaConfiguration,
       R"(ssl_key|.+password|.+secret|.+key\.pem)");
 
   for (const auto &[Key, Value] : Settings.KafkaConfiguration) {
-    const std::string &Key{ConfigurationItem.first};
-    const std::string &Value{ConfigurationItem.second};
     const bool IsSensitive = std::regex_match(Key, RegexSensitiveKey);
 
     LOG_DEBUG("Set config: {} = {}", Key, IsSensitive ? "<REDACTED>" : Value);


### PR DESCRIPTION
### Issue

ECDC-3152

### Description of work

Fixes bug introduced in PR https://github.com/ess-dmsc/kafka-to-nexus/pull/670.
Sensitive configuration settings were not only redacted in logs, but the redacted value was also used to configure the application.



