### PR TITLE
Fix: Constructor with 1 argument that is not explicit

### DIFF
--- a/src/Status/StatusService.h
+++ b/src/Status/StatusService.h
@@ -29,7 +29,7 @@ class StatusService {
 public:
   /// \brief Service constructor.
   /// \param TcpPort Desired tcp port for accepting connections(default 8888)
-  StatusService(int TcpPort);
+  explicit StatusService(int TcpPort);
 
   /// \brief launches run() in a thread.
   void startThread();


### PR DESCRIPTION
### Issue

Jenkins builds started to fail `cppcheck` ever since https://github.com/ess-dmsc/kafka-to-nexus/pull/679

Build example: https://jenkins.esss.dk/dm/blue/organizations/jenkins/ess-dmsc%2Fkafka-to-nexus/detail/main/108/pipeline/172

It may be related to cppcheck errors like below (note that Jenkins is NOT showing these errors, but simply fails the build)
```
<?xml version="1.0" encoding="UTF-8"?>
<results version="2">
    <cppcheck version="2.7"/>
    <errors>
        <error id="noExplicitConstructor" severity="style" msg="Class &apos;StatusService&apos; has a constructor with 1 argument that is not explicit." verbose="Class &apos;StatusService&apos; has a constructor with 1 argument that is not explicit. Such constructors should in general be explicit for type safety reasons. Using the explicit keyword in the constructor means some mistakes when using the class can be avoided." cwe="398" file0="src/kafka-to-nexus.cpp">
            <location file="src/Status/StatusService.h" line="32" column="3"/>
            <symbol>StatusService</symbol>
        </error>
    </errors>
</results>

```


### Description of work

Set constructor as explicit as no implicit conversions are desired here.

### Nominate for Group Code Review

- [ ] Nominate for code review 

