### PR TITLE
Change destination of cppcheck file in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -217,8 +217,10 @@ def static_checks(builder, container) {
               cd ${builder.project}
               cppcheck --xml --inline-suppr --suppress=unusedFunction --suppress=missingInclude --enable=all --inconclusive src/ 2> ${test_output}
             """
-            container.copyFrom("${builder.project}/${test_output}", '.')
-            recordIssues sourceCodeEncoding: 'UTF-8', qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]], tools: [cppCheck(pattern: 'cppcheck.xml', reportEncoding: 'UTF-8')]
+            container.copyFrom("${builder.project}/${test_output}", builder.project)
+            dir("${builder.project}") {
+              recordIssues sourceCodeEncoding: 'UTF-8', qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]], tools: [cppCheck(pattern: 'cppcheck.xml', reportEncoding: 'UTF-8')]
+            }
         }  // stage
 
         builder.stage("${container.key}: Doxygen") {

--- a/integration-tests/test_large_start_message.py
+++ b/integration-tests/test_large_start_message.py
@@ -29,9 +29,9 @@ def test_large_start_message(worker_pool, kafka_address, json_padding, file_nr):
         start_time=start_time,
         stop_time=stop_time,
     )
-    wait_start_job(worker_pool, write_job, timeout=60)
+    wait_start_job(worker_pool, write_job, timeout=80)
 
-    wait_no_working_writers(worker_pool, timeout=30)
+    wait_no_working_writers(worker_pool, timeout=40)
 
     with OpenNexusFile(file_path) as file:
         assert not file.swmr_mode


### PR DESCRIPTION
### Issue

ECDC-3378

### Description of work

Copy the cppcheck.xml file to the source directory in the Jenkins build before processing. This fixes the link to the file in the CppCheck warnings visualisation.

### Nominate for Group Code Review

- [ ] Nominate for code review 

### Reminder

*Changes should be documented in `changes.md`*
