### PR TITLE
CI: Show cppcheck errors on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -219,7 +219,8 @@ def static_checks(builder, container) {
             """
             container.copyFrom("${builder.project}/${test_output}", builder.project)
             dir("${builder.project}") {
-              recordIssues sourceCodeEncoding: 'UTF-8', qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]], tools: [cppCheck(pattern: 'cppcheck.xml', reportEncoding: 'UTF-8')]
+              sh "cat ${test_output} || true"
+              recordIssues quiet: true, sourceCodeEncoding: 'UTF-8', qualityGates: [[threshold: 1, type: 'TOTAL', unstable: true]], tools: [cppCheck(pattern: 'cppcheck.xml', reportEncoding: 'UTF-8')]
             }
         }  // stage
 


### PR DESCRIPTION
### Issue

Builds do not show cppcheck errors

### Description of work

We output the errors file in the step previous to failure.

### Nominate for Group Code Review

- [ ] Nominate for code review 

