### PR TITLE
Update BrokerSettings.h

### DIFF
--- a/src/Kafka/BrokerSettings.h
+++ b/src/Kafka/BrokerSettings.h
@@ -36,8 +36,7 @@ struct BrokerSettings {
   std::map<std::string, std::string> KafkaConfiguration = {
       {"socket.timeout.ms", "10000"},
       {"message.max.bytes", std::to_string(message_max_bytes)},
-      {"fetch.max.bytes",
-       std::to_string(fetch_max_bytes)},
+      {"fetch.max.bytes", std::to_string(fetch_max_bytes)},
       {"receive.message.max.bytes",
        std::to_string(
            receive_max_bytes)}, // must be at least fetch.max.bytes + 512

--- a/src/Kafka/BrokerSettings.h
+++ b/src/Kafka/BrokerSettings.h
@@ -37,8 +37,7 @@ struct BrokerSettings {
       {"socket.timeout.ms", "10000"},
       {"message.max.bytes", std::to_string(message_max_bytes)},
       {"fetch.max.bytes",
-       std::to_string(fetch_max_bytes)}, // this is the default value, here as
-                                         // documentation
+       std::to_string(fetch_max_bytes)},
       {"receive.message.max.bytes",
        std::to_string(
            receive_max_bytes)}, // must be at least fetch.max.bytes + 512


### PR DESCRIPTION
We are using 6 times the default, not the default for fetch.max.bytes.

## Issue

n/a

## Description of work

Update comment for Kafka configuration parameter.

## Checklist

- [ ] Changes have been documented in `changes.md`
